### PR TITLE
Refactor: Arreglando el empastre de SongDetailScreen y SongListScreen

### DIFF
--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from 'react';
-import { ScrollView, Text, StyleSheet, useWindowDimensions, ActivityIndicator, View, TouchableOpacity, Modal, Button, TouchableWithoutFeedback } from 'react-native';
-import { WebView } from 'react-native-webview';
+// Unused imports (TouchableOpacity, Modal, Button, TouchableWithoutFeedback) removed
+import { ScrollView, Text, StyleSheet, useWindowDimensions, View } from 'react-native';
 import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
 import { Ionicons } from '@expo/vector-icons';
 import { AppColors } from '../styles/theme';
-import { ChordProParser, HtmlDivFormatter } from 'chordsheetjs';
-import { SongFilename } from '../../assets/songs'; // Re-added
-import { songAssets } from '../../assets/songs/index'; // Re-added
+// ChordProParser and HtmlDivFormatter removed as they are now in the hook
+import { SongFilename } from '../../assets/songs';
+import { songAssets } from '../../assets/songs/index';
+import SongDisplay from '../../components/SongDisplay';
+import { useSongProcessor } from '../../hooks/useSongProcessor';
+import SongControls from '../../components/SongControls'; // Added import
 import { RouteProp } from '@react-navigation/native';
 import { RootStackParamList } from '../(tabs)/cancionero';
 
@@ -26,8 +29,8 @@ interface SongDetailScreenProps {
 export default function SongDetailScreen({ route }: SongDetailScreenProps) {
   // title from params is for the navigation screen header, actual song title rendered by WebView
   const { filename, title: navScreenTitle, author, key, capo } = route.params;
-  const [songHtml, setSongHtml] = useState<string>('Cargando…');
-  const [isLoading, setIsLoading] = useState(true);
+  // songHtml state is now managed by useSongProcessor
+  const [isFileLoading, setIsFileLoading] = useState(true); // Renamed from isLoading
 
   const { width } = useWindowDimensions();
 
@@ -35,481 +38,108 @@ export default function SongDetailScreen({ route }: SongDetailScreenProps) {
   const [originalChordPro, setOriginalChordPro] = useState<string | null>(null);
   const [chordsVisible, setChordsVisible] = useState(true);
   const [currentTranspose, setCurrentTranspose] = useState(0); // Semitones: 0 is original, positive up, negative down
-  const [showActionButtons, setShowActionButtons] = useState(false);
-  const [showTransposeModal, setShowTransposeModal] = useState(false);
+  // showActionButtons, showTransposeModal, showFontSizeModal, showFontFamilyModal states removed
   const [isNotationFabActive, setIsNotationFabActive] = useState(false);
   const [currentFontSizeEm, setCurrentFontSizeEm] = useState(1.0); // Base font size is 1em
-  const [showFontSizeModal, setShowFontSizeModal] = useState(false);
   const [currentFontFamily, setCurrentFontFamily] = useState(availableFonts[0].cssValue); // Default to mono, availableFonts is now at top
-  const [showFontFamilyModal, setShowFontFamilyModal] = useState(false);
 
-  // Function to parse and display the song
-  const displaySong = async (chordProContent: string, transposeSteps: number, showChords: boolean, fontSize: number, fontFamily: string) => {
-    setIsLoading(true);
-    try {
-      let processedChordPro = chordProContent;
+  // Call the hook to process the song
+  const { songHtml, isLoadingSong: isSongProcessing } = useSongProcessor({
+    originalChordPro,
+    currentTranspose,
+    chordsVisible,
+    currentFontSizeEm,
+    currentFontFamily,
+    author, // Pass author from route.params
+    key,    // Pass key from route.params
+    capo,   // Pass capo from route.params
+  });
 
-      // Normalize ChordPro section tags (e.g., {soc} to {start_of_chorus})
-      processedChordPro = processedChordPro.replace(/\{sov\}/gi, '{start_of_verse}')
-                                     .replace(/\{eov\}/gi, '{end_of_verse}')
-                                     .replace(/\{soc\}/gi, '{start_of_chorus}')
-                                     .replace(/\{eoc\}/gi, '{end_of_chorus}')
-                                     .replace(/\{sob\}/gi, '{start_of_bridge}')
-                                     .replace(/\{eob\}/gi, '{end_of_bridge}');
-
-      // Remove existing transpose directive if any, to apply a new one cleanly
-      processedChordPro = processedChordPro.replace(/\{transpose:.*\}\n?/gi, '');
-
-      if (transposeSteps !== 0) {
-        const chordProValueForDirective = transposeSteps < 0 ? transposeSteps + 12 : transposeSteps;
-        if (chordProValueForDirective !== 0) {
-          processedChordPro = `{transpose: ${chordProValueForDirective}}\n${processedChordPro}`;
-        }
-      }
-
-      // Apply font size adjustments
-      // Ensure base font size for lyrics and chords is 1em in the main style block
-      // The title (h1) and meta info should not be affected by this specific adjustment
-      const fontSizeCss = `
-        .chord-sheet .lyrics, .chord-sheet .chord {
-          font-size: ${fontSize}em !important;
-        }
-      `;
-
-      const parser = new ChordProParser();
-      const song = parser.parse(processedChordPro);
-      const formatter = new HtmlDivFormatter();
-      let formattedSong = formatter.format(song);
-
-      // Build meta HTML for author, key, capo (title comes from formattedSong)
-      let metaInsert = '';
-      if (author) {
-        metaInsert += `<div class="song-meta-author">${author}</div>`;
-      }
-      let finalKeyCapoString = '';
-      if (key) {
-        finalKeyCapoString += `<strong>${key.toUpperCase()}</strong>`;
-      }
-
-      if (capo !== undefined && capo > 0) {
-        if (finalKeyCapoString) finalKeyCapoString += ' - ';
-        finalKeyCapoString += `Cejilla ${capo}`;
-      }
-
-      if (currentTranspose !== 0) {
-        if (finalKeyCapoString) finalKeyCapoString += ' / ';
-        const transposeDisplay = currentTranspose > 0 ? `+${currentTranspose}` : `${currentTranspose}`;
-        finalKeyCapoString += `<strong>Semitonos: ${transposeDisplay}</strong>`;
-      }
-
-      if (finalKeyCapoString) {
-        metaInsert += `<div class="song-meta-keycapo">${finalKeyCapoString}</div>`;
-      }
-
-      // Inject metaInsert after the main title in formattedSong
-      let finalSongContentWithMeta = formattedSong;
-      if (metaInsert) {
-        const titleEndTag = '</h1>'; // Assuming chordsheetjs uses <h1> for title
-        const titleEndIndex = formattedSong.indexOf(titleEndTag);
-        if (titleEndIndex !== -1) {
-          const insertionPoint = titleEndIndex + titleEndTag.length;
-          finalSongContentWithMeta =
-            formattedSong.substring(0, insertionPoint) +
-            metaInsert +
-            formattedSong.substring(insertionPoint);
-        } else {
-          // Fallback: if no <h1>, prepend meta to the whole song (less ideal)
-          finalSongContentWithMeta = metaInsert + formattedSong;
-        }
-      }
-
-      const chordsCss = showChords ? '' : '<style>.chord { display: none !important; }</style>';
-
-      const finalHtml = `
-        <html>
-        <head>
-          <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-          <style>
-            body {
-              font-family: ${fontFamily};
-              margin: 10px;
-              background-color: #ffffff; /* UPDATED: White background */
-              color: ${AppColors.textDark};
-              font-size: 100%; /* Base for em units */
-            }
-            h1 {
-              color: #333;
-              margin-bottom: 0.2em;
-              font-size: 1.6em; /* Fixed size relative to body */
-              text-align: center; /* ADDED: Centered title */
-            }
-            .song-meta-author {
-              color: #777; /* UPDATED: Lighter grey */
-              font-size: 0.9em; /* Relative to body */
-              margin-bottom: 5px; /* Adjusted margin */
-              font-style: italic; /* ADDED: Italic author */
-              text-align: center; /* ADDED: Centered author */
-            }
-            .song-meta-keycapo {
-              color: #555; /* Original color for non-bold parts */
-              font-size: 0.9em; /* Relative to body */
-              margin-bottom: 10px;
-              text-align: center; /* ADDED: Centered key/capo info */
-            }
-            .song-meta-keycapo strong {
-              font-weight: bold; /* Ensures parts wrapped in <strong> are bold */
-            }
-            .chord-sheet {
-              margin-top: 1em;
-              text-align: left; /* Ensure song content itself is left-aligned */
-            }
-            .row {
-              display: flex;
-              flex-wrap: wrap;
-              margin-bottom: 0.2em;
-            }
-            .column {
-              padding-right: 0; /* Ajustado para evitar espacios extra dentro de las palabras */
-            }
-            .chord-sheet .chord {
-              color: ${AppColors.primary};
-              font-weight: bold;
-              white-space: pre;
-              display: block;
-              min-height: 1.2em;
-            }
-            .chord-sheet .lyrics {
-              white-space: pre;
-              display: block;
-              min-height: 1.2em;
-            }
-            .comment, .c {
-              color: ${AppColors.secondaryText};
-              font-style: italic;
-              white-space: pre;
-              display: block;
-              margin-top: 0.5em;
-              margin-bottom: 0.5em;
-            }
-            /* Styles for song sections (verse, chorus, bridge) */
-            .paragraph {
-              margin-top: 1.75em; /* Aumentado para mayor separación entre estrofas (0.7em * 2.5) */
-              margin-bottom: 1.75em; /* Aumentado para mayor separación entre estrofas (0.7em * 2.5) */
-            }
-            .paragraph.chorus {
-              font-weight: bold;
-              margin-top: 1.2em; /* More spacing for choruses */
-              margin-bottom: 1.2em;
-            }
-            /* Verses and bridges will use .paragraph styling by default */
-            /* Add specific styles for .paragraph.verse or .paragraph.bridge if needed */
-
-            ${fontSizeCss} /* Injects: .chord-sheet .lyrics, .chord-sheet .chord { font-size: ${fontSize}em !important; } */
-          </style>
-          ${chordsCss}
-        </head>
-        <body>
-          ${finalSongContentWithMeta} 
-        </body>
-        </html>
-      `;
-      setSongHtml(finalHtml);
-    } catch (err) {
-      console.error('Error procesando canción en SongDetailScreen:', err);
-      setSongHtml('❌ Error cargando canción disculpas 🥺');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
+  // Effect for loading the ChordPro file content
   useEffect(() => {
     (async () => {
       if (!filename) {
-        setSongHtml('Error: Nombre de archivo no proporcionado.');
-        setIsLoading(false);
+        // setSongHtml('Error: Nombre de archivo no proporcionado.'); // This will be handled by the hook if originalChordPro is null
+        setIsFileLoading(false);
         return;
       }
       try {
-        setIsLoading(true);
+        setIsFileLoading(true);
         const asset = Asset.fromModule(songAssets[filename as SongFilename]);
         await asset.downloadAsync();
         if (asset.localUri) {
           const fileContent = await FileSystem.readAsStringAsync(asset.localUri);
           setOriginalChordPro(fileContent); // Store original content
-          // Initial display:
-          displaySong(fileContent, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily);
+          // displaySong is now handled by the useSongProcessor hook via useEffect when originalChordPro changes
         } else {
           throw new Error('No se pudo obtener la URI local del archivo.');
         }
       } catch (err: any) {
         console.error('Error cargando la canción:', err);
-        setSongHtml(`Error al cargar la canción: ${err.message}`);
+        // setSongHtml(`Error al cargar la canción: ${err.message}`); // Hook will display its own error
+        setOriginalChordPro(null); // Ensure originalChordPro is null on error so hook can show error state
       } finally {
-        setIsLoading(false);
+        setIsFileLoading(false);
       }
     })();
   }, [filename]);
 
-  useEffect(() => {
-    if (originalChordPro) {
-      displaySong(originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily);
+  // displaySong function and its useEffect have been removed, logic is in useSongProcessor.
+
+  // Handlers for actual state changes (passed to SongControls)
+  const handleToggleChords = () => setChordsVisible(!chordsVisible);
+
+  const handleChangeNotation = () => {
+    setIsNotationFabActive(!isNotationFabActive);
+    alert('Notación (Próximamente)');
+  };
+
+  const handleSetTranspose = (semitones: number) => {
+    let newTranspose = semitones;
+    if (newTranspose >= 12 || newTranspose <= -12) {
+      newTranspose = newTranspose % 12;
     }
-  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily]);
+    setCurrentTranspose(newTranspose);
+    // setShowTransposeModal(false); // Modal state is now in SongControls
+  };
 
-const handleToggleChords = () => setChordsVisible(!chordsVisible);
-const handleOpenTransposeModal = () => setShowTransposeModal(true);
-const handleChangeNotation = () => {
-  setIsNotationFabActive(!isNotationFabActive);
-  alert('Notación (Próximamente)');
-};
-const handleOpenFontSizeModal = () => setShowFontSizeModal(true);
-const handleChangeFontFamily = () => setShowFontFamilyModal(true);
-const handleSetTranspose = (semitones: number) => {
-  let newTranspose = semitones;
-  // Wrap around at +12 and -12 to 0
-  if (newTranspose >= 12 || newTranspose <= -12) {
-    newTranspose = newTranspose % 12;
-  }
-  setCurrentTranspose(newTranspose);
-  setShowTransposeModal(false);
-};
+  const handleSetFontSize = (newSizeEm: number) => {
+    setCurrentFontSizeEm(newSizeEm);
+    // setShowFontSizeModal(false); // Modal state is now in SongControls
+  };
 
-const handleSetFontSize = (newSizeEm: number) => {
-  // Optional: Add min/max font size limits if desired
-  // Example: if (newSizeEm < 0.5) newSizeEm = 0.5;
-  //          if (newSizeEm > 2.0) newSizeEm = 2.0;
-  setCurrentFontSizeEm(newSizeEm);
-  // setShowFontSizeModal(false); // Keep modal open to see changes
-};
+  const handleSetFontFamily = (newFontFamily: string) => {
+    setCurrentFontFamily(newFontFamily);
+    // setShowFontFamilyModal(false); // Modal state is now in SongControls
+  };
 
-const handleSetFontFamily = (newFontFamily: string) => {
-  setCurrentFontFamily(newFontFamily);
-  setShowFontFamilyModal(false);
-};
+  // Removed handleOpenTransposeModal, handleOpenFontSizeModal, handleOpenFontFamilyModal
 
-return (
-  <View style={styles.container}>
-    {/* The screen title for React Navigation is set in cancionero.tsx options */}
-    {/* The song's main title, author, key, capo are now rendered inside the WebView below */}
-    {/* <Text style={styles.title}>{navScreenTitle}</Text> */}
-    <View style={styles.webViewContainer}>
-      {isLoading ? (
-        <ActivityIndicator size="large" color="#0000ff" />
-      ) : (
-        <WebView
-          originWhitelist={['*']}
-          source={{ html: songHtml }}
-          style={styles.webView}
-        />
-      )}
+  return (
+    <View style={styles.container}>
+      <SongDisplay songHtml={songHtml} isLoading={isFileLoading || isSongProcessing} />
+      <SongControls
+        chordsVisible={chordsVisible}
+        currentTranspose={currentTranspose}
+        currentFontSizeEm={currentFontSizeEm}
+        currentFontFamily={currentFontFamily}
+        isNotationFabActive={isNotationFabActive}
+        availableFonts={availableFonts}
+        onToggleChords={handleToggleChords}
+        onSetTranspose={handleSetTranspose}
+        onSetFontSize={handleSetFontSize}
+        onSetFontFamily={handleSetFontFamily}
+        onChangeNotation={handleChangeNotation}
+      />
     </View>
-
-    {/* FABs */}
-    <View style={styles.fabContainer}>
-      {showActionButtons && (
-        <View style={styles.fabActionsContainer}>
-          <TouchableOpacity style={[styles.fabAction, !chordsVisible && styles.fabActionActive]} onPress={handleToggleChords}>
-            <Text style={[styles.fabActionText, !chordsVisible && styles.fabActionTextActive]}>Acordes {chordsVisible ? 'ON' : 'OFF'}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.fabAction, currentTranspose !== 0 && styles.fabActionActive]} onPress={handleOpenTransposeModal}>
-            <Text style={[styles.fabActionText, currentTranspose !== 0 && styles.fabActionTextActive]}>Cambiar tono</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.fabAction, isNotationFabActive && styles.fabActionActive]} onPress={handleChangeNotation}>
-            <Text style={[styles.fabActionText, isNotationFabActive && styles.fabActionTextActive]}>Notación</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.fabAction, currentFontSizeEm !== 1.0 && styles.fabActionActive]} onPress={handleOpenFontSizeModal}>
-            <Text style={[styles.fabActionText, currentFontSizeEm !== 1.0 && styles.fabActionTextActive]}>Tamaño Letra</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={[styles.fabAction, currentFontFamily !== availableFonts[0].cssValue && styles.fabActionActive]} onPress={handleChangeFontFamily}>
-            <Text style={[styles.fabActionText, currentFontFamily !== availableFonts[0].cssValue && styles.fabActionTextActive]}>Tipo de Letra</Text>
-          </TouchableOpacity>
-        </View>
-      )}
-      <TouchableOpacity style={styles.fabMain} onPress={() => setShowActionButtons(!showActionButtons)}>
-        <Text style={styles.fabMainText}>{showActionButtons ? '✕' : '🛠️'}</Text>
-      </TouchableOpacity>
-    </View>
-
-    {/* Font Size Modal */}
-    <Modal
-      transparent={true}
-      visible={showFontSizeModal}
-      onRequestClose={() => setShowFontSizeModal(false)}
-      animationType="fade"
-    >
-      <TouchableWithoutFeedback onPress={() => setShowFontSizeModal(false)}>
-        <View style={styles.modalOverlay}>
-          <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-            <View style={styles.modalContent}>
-              <Text style={styles.modalTitle}>Ajustar Tamaño Letra</Text>
-              <View style={styles.fontSizeButtonRow}>
-                <Button title="A+" onPress={() => handleSetFontSize(currentFontSizeEm + 0.1)} />
-                <Button title="A-" onPress={() => handleSetFontSize(Math.max(0.5, currentFontSizeEm - 0.1))} />
-              </View>
-              <Button title={`Original (${(currentFontSizeEm * 100).toFixed(0)}%)`} onPress={() => handleSetFontSize(1.0)} />
-              <Button title="Cerrar" onPress={() => setShowFontSizeModal(false)} color="#888"/>
-            </View>
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
-    </Modal>
-
-    {/* Font Family Modal */}
-    <Modal
-      transparent={true}
-      visible={showFontFamilyModal}
-      onRequestClose={() => setShowFontFamilyModal(false)}
-      animationType="fade"
-    >
-      <TouchableWithoutFeedback onPress={() => setShowFontFamilyModal(false)}>
-        <View style={styles.modalOverlay}>
-          <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-            <View style={styles.modalContent}>
-              <Text style={styles.modalTitle}>Seleccionar Tipo de Letra</Text>
-              {availableFonts.map((font) => (
-                <TouchableOpacity
-                  key={font.cssValue}
-                  style={styles.fontFamilyOptionButton}
-                  onPress={() => handleSetFontFamily(font.cssValue)}
-                >
-                  <Text style={[styles.fontFamilyOptionText, { fontFamily: font.cssValue }]}>{font.name}</Text>
-                </TouchableOpacity>
-              ))}
-              <Button title="Cerrar" onPress={() => setShowFontFamilyModal(false)} color="#888"/>
-            </View>
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
-    </Modal>
-
-    {/* Transpose Modal */}
-    <Modal
-      transparent={true}
-      visible={showTransposeModal}
-      onRequestClose={() => setShowTransposeModal(false)}
-      animationType="fade"
-    >
-      <TouchableWithoutFeedback onPress={() => setShowTransposeModal(false)}>
-        <View style={styles.modalOverlay}>
-          <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-            <View style={styles.modalContent}>
-              <Text style={styles.modalTitle}>Cambio tono</Text>
-              <View style={styles.transposeButtonRow}>
-                <Button title="+1/2 tono" onPress={() => handleSetTranspose(currentTranspose + 1)} />
-                <Button title="+1 tono" onPress={() => handleSetTranspose(currentTranspose + 2)} />
-              </View>
-              <View style={styles.transposeButtonRow}>
-                <Button title="-1/2 tono" onPress={() => handleSetTranspose(currentTranspose - 1)} />
-                <Button title="-1 tono" onPress={() => handleSetTranspose(currentTranspose - 2)} />
-              </View>
-              <Button title="Tono Original 🔄" onPress={() => handleSetTranspose(0)} />
-              <Button title="Volver" onPress={() => setShowTransposeModal(false)} color="#888"/>
-            </View>
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
-    </Modal>
-  </View>
-);
-
+  );
 }
 
 const styles = StyleSheet.create({
-  fabContainer: {
-    position: 'absolute',
-    bottom: 20,
-    right: 20,
-    alignItems: 'flex-end',
-  },
-  fabActionsContainer: {
-    marginBottom: 10,
-    alignItems: 'flex-end',
-  },
-  fabAction: { 
-    backgroundColor: AppColors.backgroundLight, 
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    borderRadius: 20,
-    marginBottom: 8,
-    elevation: 2,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.22,
-    shadowRadius: 2.22,
-    borderWidth: 1.5,
-    borderColor: AppColors.primary, 
-  },
-  fabActionActive: { 
-    backgroundColor: AppColors.primary, 
-    borderColor: AppColors.primaryDark, 
-  },
-  fabActionText: { 
-    color: AppColors.primary, 
-    fontWeight: 'bold',
-  },
-  fabActionTextActive: { 
-    color: AppColors.textLight, 
-  },
-  fabMain: { 
-    backgroundColor: AppColors.accentYellow,
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    justifyContent: 'center',
-    alignItems: 'center',
-    elevation: 8, 
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-  },
-  fabMainText: {
-    color: AppColors.textLight,
-    fontSize: 28,
-    fontWeight: 'bold',
-  },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: AppColors.modalOverlay,
-  },
-  modalContent: {
-    backgroundColor: 'white',
-    padding: 20,
-    borderRadius: 10,
-    width: '80%',
-    alignItems: 'center',
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 15,
-  },
-  fontFamilyOptionButton: {
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    backgroundColor: '#e9ecef', // Using a light gray as AppColors.lightGray is not defined in theme
-    marginBottom: 10,
-    alignItems: 'center',
-  },
-  fontFamilyOptionText: {
-    fontSize: 16,
-    color: AppColors.textDark,
-  },
-  transposeButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    marginBottom: 15,
-    width: '100%',
-  },
-  fontSizeButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    width: '100%',
-    marginBottom: 10,
-  },
+  // Removed styles: fabContainer, fabActionsContainer, fabAction, fabActionActive,
+  // fabActionText, fabActionTextActive, fabMain, fabMainText, modalOverlay,
+  // modalContent, modalTitle, fontFamilyOptionButton, fontFamilyOptionText,
+  // transposeButtonRow, fontSizeButtonRow
   container: { flex: 1, padding: 10 },
   title: { fontSize: 24, fontWeight: 'bold', marginBottom: 10, textAlign: 'center' },
   messageContainer: {
@@ -517,14 +147,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  webViewContainer: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: '#ddd',
-  },
-  content: { fontSize: 16, fontFamily: 'monospace' }, // Cambiado a monospace para mejor visualización de acordes si se usara Text
-  webView: {
-    flex: 1,
-  }
+  content: { fontSize: 16, fontFamily: 'monospace' },
 });
 

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -1,16 +1,17 @@
 import { useState, useEffect } from 'react';
-import { FlatList, TouchableOpacity, Text, View, StyleSheet } from 'react-native';
+import { FlatList, Text, View, StyleSheet } from 'react-native'; // TouchableOpacity removed
 import rawSongsData from '../../assets/songs.json';
 import SongSearch from '../../components/SongSearch';
+import SongListItem from '../../components/SongListItem'; // Added import
 
 // Type for song data
 interface Song {
   title: string;
   filename: string;
-  author: string;
-  key: string; 
-  capo: number;
-  info: string;
+  author?: string; // Optional
+  key?: string; // Optional
+  capo?: number; // Optional
+  info?: string; // Optional
 }
 
 // Ensure the data is in the correct format
@@ -172,31 +173,9 @@ export default function SongsListScreen({ route, navigation }: {
       <FlatList
         data={filteredSongs}
         keyExtractor={(item) => item.filename}
-        renderItem={({ item }) => {
-          return (
-            <TouchableOpacity
-              onPress={() => handleSongPress(item)}
-              style={styles.songItem}
-            >
-              <View style={styles.songInfoContainer}>
-                <Text style={styles.songTitle}>
-                  {item.title.replace(/^\d+\.\s*/, '')} {/* Remove leading numbers */}
-                </Text>
-                {item.author ? (
-                  <Text style={styles.songAuthor}>{item.author}</Text>
-                ) : null}
-              </View>
-              <View style={styles.keyCapoContainer}>
-                {item.key ? (
-                  <Text style={styles.songKey}>{item.key.toUpperCase()}</Text>
-                ) : null}
-                {item.capo > 0 ? (
-                  <Text style={styles.songCapo}>{`C/${item.capo}`}</Text>
-                ) : null}
-              </View>
-            </TouchableOpacity>
-          );
-        }}
+        renderItem={({ item }) => (
+          <SongListItem song={item} onPress={handleSongPress} />
+        )}
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
             <Text>No se encontraron canciones que coincidan con la búsqueda</Text>
@@ -218,28 +197,6 @@ const styles = StyleSheet.create({
     padding: 16,
     backgroundColor: '#f5f5f5',
     color: '#333',
-  },
-  songItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 16,
-    borderBottomWidth: 1,
-    borderColor: '#eee',
-  },
-  songTitle: {
-    fontSize: 16,
-    color: '#333',
-  },
-  songInfoContainer: {
-    flex: 1, // Allows title/author to take up space and push key/capo to the right
-    marginRight: 8, // Adds a small gap
-  },
-  songAuthor: {
-    fontSize: 14,
-    color: '#666',
-    marginTop: 4,
-    fontStyle: 'italic',
   },
   loadingText: {
     fontSize: 16,
@@ -278,19 +235,5 @@ const styles = StyleSheet.create({
     color: '#888',
     fontStyle: 'italic',
     textAlign: 'center',
-  },
-  keyCapoContainer: {
-    flexDirection: 'column', // Stack key and capo vertically if both present
-    alignItems: 'flex-end', // Align to the right
-  },
-  songKey: {
-    fontSize: 16, // Slightly larger
-    fontWeight: 'bold',
-    color: '#000000', // Black
-  },
-  songCapo: {
-    fontSize: 13, // Slightly smaller
-    color: '#888', // Keep color
-    fontWeight: 'normal', // Normal weight
   },
 });

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -1,0 +1,284 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, Modal, Button, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import { AppColors } from '../app/styles/theme'; // Adjust path as necessary
+
+// Define availableFonts structure if not already globally defined
+interface FontOption {
+  name: string;
+  cssValue: string;
+}
+
+interface SongControlsProps {
+  chordsVisible: boolean;
+  currentTranspose: number;
+  currentFontSizeEm: number;
+  currentFontFamily: string;
+  isNotationFabActive: boolean;
+  availableFonts: FontOption[];
+  onToggleChords: () => void;
+  onSetTranspose: (semitones: number) => void;
+  onSetFontSize: (sizeEm: number) => void;
+  onSetFontFamily: (fontFamily: string) => void;
+  onChangeNotation: () => void; // For "Notación (Próximamente)"
+}
+
+const SongControls: React.FC<SongControlsProps> = ({
+  chordsVisible,
+  currentTranspose,
+  currentFontSizeEm,
+  currentFontFamily,
+  isNotationFabActive,
+  availableFonts,
+  onToggleChords,
+  onSetTranspose,
+  onSetFontSize,
+  onSetFontFamily,
+  onChangeNotation,
+}) => {
+  const [showActionButtons, setShowActionButtons] = useState(false);
+  const [showTransposeModal, setShowTransposeModal] = useState(false);
+  const [showFontSizeModal, setShowFontSizeModal] = useState(false);
+  const [showFontFamilyModal, setShowFontFamilyModal] = useState(false);
+
+  const handleOpenTransposeModal = () => setShowTransposeModal(true);
+  const handleOpenFontSizeModal = () => setShowFontSizeModal(true);
+  const handleOpenFontFamilyModal = () => setShowFontFamilyModal(true);
+
+  // Wrapper for onSetTranspose to also close the modal
+  const handleSetTransposeAndClose = (semitones: number) => {
+    onSetTranspose(semitones);
+    //setShowTransposeModal(false); // Keep modal open to see changes, or close if preferred
+  };
+  
+  // Wrapper for onSetFontSize, modal can be kept open
+  const handleSetFontSizeAndClose = (size: number) => {
+    onSetFontSize(size);
+    // setShowFontSizeModal(false); // Keep modal open
+  }
+
+  // Wrapper for onSetFontFamily to also close the modal
+  const handleSetFontFamilyAndClose = (fontFamily: string) => {
+    onSetFontFamily(fontFamily);
+    setShowFontFamilyModal(false);
+  };
+
+  return (
+    <>
+      {/* FABs */}
+      <View style={styles.fabContainer}>
+        {showActionButtons && (
+          <View style={styles.fabActionsContainer}>
+            <TouchableOpacity style={[styles.fabAction, !chordsVisible && styles.fabActionActive]} onPress={onToggleChords}>
+              <Text style={[styles.fabActionText, !chordsVisible && styles.fabActionTextActive]}>Acordes {chordsVisible ? 'ON' : 'OFF'}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, currentTranspose !== 0 && styles.fabActionActive]} onPress={handleOpenTransposeModal}>
+              <Text style={[styles.fabActionText, currentTranspose !== 0 && styles.fabActionTextActive]}>Cambiar tono</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, isNotationFabActive && styles.fabActionActive]} onPress={onChangeNotation}>
+              <Text style={[styles.fabActionText, isNotationFabActive && styles.fabActionTextActive]}>Notación</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, currentFontSizeEm !== 1.0 && styles.fabActionActive]} onPress={handleOpenFontSizeModal}>
+              <Text style={[styles.fabActionText, currentFontSizeEm !== 1.0 && styles.fabActionTextActive]}>Tamaño Letra</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionActive]} onPress={handleOpenFontFamilyModal}>
+              <Text style={[styles.fabActionText, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionTextActive]}>Tipo de Letra</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+        <TouchableOpacity style={styles.fabMain} onPress={() => setShowActionButtons(!showActionButtons)}>
+          <Text style={styles.fabMainText}>{showActionButtons ? '✕' : '🛠️'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Font Size Modal */}
+      <Modal
+        transparent={true}
+        visible={showFontSizeModal}
+        onRequestClose={() => setShowFontSizeModal(false)}
+        animationType="fade"
+      >
+        <TouchableWithoutFeedback onPress={() => setShowFontSizeModal(false)}>
+          <View style={styles.modalOverlay}>
+            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
+              <View style={styles.modalContent}>
+                <Text style={styles.modalTitle}>Ajustar Tamaño Letra</Text>
+                <View style={styles.fontSizeButtonRow}>
+                  <Button title="A+" onPress={() => handleSetFontSizeAndClose(currentFontSizeEm + 0.1)} />
+                  <Button title="A-" onPress={() => handleSetFontSizeAndClose(Math.max(0.5, currentFontSizeEm - 0.1))} />
+                </View>
+                <Button title={`Original (${(currentFontSizeEm * 100).toFixed(0)}%)`} onPress={() => handleSetFontSizeAndClose(1.0)} />
+                <Button title="Cerrar" onPress={() => setShowFontSizeModal(false)} color="#888"/>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Font Family Modal */}
+      <Modal
+        transparent={true}
+        visible={showFontFamilyModal}
+        onRequestClose={() => setShowFontFamilyModal(false)}
+        animationType="fade"
+      >
+        <TouchableWithoutFeedback onPress={() => setShowFontFamilyModal(false)}>
+          <View style={styles.modalOverlay}>
+            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
+              <View style={styles.modalContent}>
+                <Text style={styles.modalTitle}>Seleccionar Tipo de Letra</Text>
+                {availableFonts.map((font) => (
+                  <TouchableOpacity
+                    key={font.cssValue}
+                    style={styles.fontFamilyOptionButton}
+                    onPress={() => handleSetFontFamilyAndClose(font.cssValue)}
+                  >
+                    <Text style={[styles.fontFamilyOptionText, { fontFamily: font.cssValue }]}>{font.name}</Text>
+                  </TouchableOpacity>
+                ))}
+                <Button title="Cerrar" onPress={() => setShowFontFamilyModal(false)} color="#888"/>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Transpose Modal */}
+      <Modal
+        transparent={true}
+        visible={showTransposeModal}
+        onRequestClose={() => setShowTransposeModal(false)}
+        animationType="fade"
+      >
+        <TouchableWithoutFeedback onPress={() => setShowTransposeModal(false)}>
+          <View style={styles.modalOverlay}>
+            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
+              <View style={styles.modalContent}>
+                <Text style={styles.modalTitle}>Cambio tono</Text>
+                <View style={styles.transposeButtonRow}>
+                  <Button title="+1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 1)} />
+                  <Button title="+1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 2)} />
+                </View>
+                <View style={styles.transposeButtonRow}>
+                  <Button title="-1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 1)} />
+                  <Button title="-1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 2)} />
+                </View>
+                <Button title="Tono Original 🔄" onPress={() => handleSetTransposeAndClose(0)} />
+                <Button title="Volver" onPress={() => setShowTransposeModal(false)} color="#888"/>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </>
+  );
+};
+
+// Styles moved from SongDetailScreen.tsx
+const styles = StyleSheet.create({
+  fabContainer: {
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+    alignItems: 'flex-end',
+  },
+  fabActionsContainer: {
+    marginBottom: 10,
+    alignItems: 'flex-end',
+  },
+  fabAction: {
+    backgroundColor: AppColors.backgroundLight,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginBottom: 8,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.22,
+    shadowRadius: 2.22,
+    borderWidth: 1.5,
+    borderColor: AppColors.primary,
+  },
+  fabActionActive: {
+    backgroundColor: AppColors.primary,
+    borderColor: AppColors.primaryDark,
+  },
+  fabActionText: {
+    color: AppColors.primary,
+    fontWeight: 'bold',
+  },
+  fabActionTextActive: {
+    color: AppColors.textLight,
+  },
+  fabMain: {
+    backgroundColor: AppColors.accentYellow,
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+  },
+  fabMainText: {
+    color: AppColors.textLight,
+    fontSize: 28,
+    fontWeight: 'bold',
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: AppColors.modalOverlay,
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    padding: 20,
+    borderRadius: 10,
+    width: '80%',
+    alignItems: 'center',
+    // Add shadow for modals if desired, e.g.:
+    // shadowColor: '#000',
+    // shadowOffset: { width: 0, height: 2 },
+    // shadowOpacity: 0.25,
+    // shadowRadius: 3.84,
+    // elevation: 5,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 15,
+    color: AppColors.textDark, // Ensure text color is appropriate
+  },
+  fontFamilyOptionButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    backgroundColor: '#e9ecef',
+    marginBottom: 10,
+    alignItems: 'center',
+    width: '100%', // Make buttons take full width of modal content
+  },
+  fontFamilyOptionText: {
+    fontSize: 16,
+    color: AppColors.textDark,
+  },
+  transposeButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around', // Or 'space-between'
+    marginBottom: 15,
+    width: '100%',
+  },
+  fontSizeButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around', // Or 'space-between'
+    width: '100%',
+    marginBottom: 10,
+  },
+  // Ensure all necessary styles from SongDetailScreen related to FABs and Modals are here
+});
+
+export default SongControls;

--- a/mcm-app/components/SongDisplay.tsx
+++ b/mcm-app/components/SongDisplay.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { AppColors } from '../app/styles/theme'; // Assuming AppColors might be used for loading indicator or styles
+
+interface SongDisplayProps {
+  songHtml: string;
+  isLoading: boolean;
+}
+
+const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
+  if (isLoading) {
+    return (
+      <View style={[styles.webViewContainer, styles.loadingContainer]}>
+        <ActivityIndicator size="large" color={AppColors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.webViewContainer}>
+      <WebView
+        originWhitelist={['*']}
+        source={{ html: songHtml }}
+        style={styles.webView}
+        showsVerticalScrollIndicator={false}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  webViewContainer: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ddd', // From SongDetailScreen styles
+  },
+  loadingContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  webView: {
+    flex: 1,
+  },
+});
+
+export default SongDisplay;

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { TouchableOpacity, Text, View, StyleSheet } from 'react-native';
+
+// Type for song data (ensure this matches the one in SongListScreen.tsx or a shared types file)
+interface Song {
+  title: string;
+  filename: string;
+  author?: string; // Made optional to match usage
+  key?: string;
+  capo?: number; // Changed to number to match usage
+  info?: string; // Made optional
+}
+
+interface SongListItemProps {
+  song: Song;
+  onPress: (song: Song) => void;
+}
+
+const SongListItem: React.FC<SongListItemProps> = ({ song, onPress }) => {
+  return (
+    <TouchableOpacity
+      onPress={() => onPress(song)}
+      style={styles.songItem}
+    >
+      <View style={styles.songInfoContainer}>
+        <Text style={styles.songTitle}>
+          {song.title.replace(/^\d+\.\s*/, '')} {/* Remove leading numbers */}
+        </Text>
+        {song.author ? (
+          <Text style={styles.songAuthor}>{song.author}</Text>
+        ) : null}
+      </View>
+      <View style={styles.keyCapoContainer}>
+        {song.key ? (
+          <Text style={styles.songKey}>{song.key.toUpperCase()}</Text>
+        ) : null}
+        {song.capo && song.capo > 0 ? ( // Ensure capo is a number and greater than 0
+          <Text style={styles.songCapo}>{`C/${song.capo}`}</Text>
+        ) : null}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  songItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderColor: '#eee', // From SongListScreen styles
+  },
+  songInfoContainer: {
+    flex: 1,
+    marginRight: 8,
+  },
+  songTitle: {
+    fontSize: 16,
+    color: '#333', // From SongListScreen styles
+  },
+  songAuthor: {
+    fontSize: 14,
+    color: '#666', // From SongListScreen styles
+    marginTop: 4,
+    fontStyle: 'italic',
+  },
+  keyCapoContainer: {
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+  },
+  songKey: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#000000', // From SongListScreen styles
+  },
+  songCapo: {
+    fontSize: 13,
+    color: '#888', // From SongListScreen styles
+    fontWeight: 'normal',
+  },
+});
+
+export default SongListItem;

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import { ChordProParser, HtmlDivFormatter } from 'chordsheetjs';
+import { AppColors } from '../app/styles/theme'; // Ensure this path is correct relative to the hooks folder
+
+interface UseSongProcessorParams {
+  originalChordPro: string | null;
+  currentTranspose: number;
+  chordsVisible: boolean;
+  currentFontSizeEm: number;
+  currentFontFamily: string;
+  author?: string; // Added to pass author
+  key?: string; // Added to pass key
+  capo?: number; // Added to pass capo
+}
+
+export const useSongProcessor = ({
+  originalChordPro,
+  currentTranspose,
+  chordsVisible,
+  currentFontSizeEm,
+  currentFontFamily,
+  author,
+  key,
+  capo,
+}: UseSongProcessorParams) => {
+  const [songHtml, setSongHtml] = useState<string>('Cargando…');
+  const [isLoadingSong, setIsLoadingSong] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!originalChordPro) {
+      // setSongHtml('Esperando contenido de la canción...'); // Or some other placeholder
+      setIsLoadingSong(false); // Not necessarily loading if there's no content to process
+      return;
+    }
+
+    setIsLoadingSong(true);
+    try {
+      let processedChordPro = originalChordPro;
+
+      processedChordPro = processedChordPro.replace(/\{sov\}/gi, '{start_of_verse}')
+                                     .replace(/\{eov\}/gi, '{end_of_verse}')
+                                     .replace(/\{soc\}/gi, '{start_of_chorus}')
+                                     .replace(/\{eoc\}/gi, '{end_of_chorus}')
+                                     .replace(/\{sob\}/gi, '{start_of_bridge}')
+                                     .replace(/\{eob\}/gi, '{end_of_bridge}');
+      processedChordPro = processedChordPro.replace(/\{transpose:.*\}\n?/gi, '');
+
+      if (currentTranspose !== 0) {
+        const chordProValueForDirective = currentTranspose < 0 ? currentTranspose + 12 : currentTranspose;
+        if (chordProValueForDirective !== 0) {
+          processedChordPro = `{transpose: ${chordProValueForDirective}}\n${processedChordPro}`;
+        }
+      }
+
+      const fontSizeCss = `
+        .chord-sheet .lyrics, .chord-sheet .chord {
+          font-size: ${currentFontSizeEm}em !important;
+        }
+      `;
+
+      const parser = new ChordProParser();
+      const song = parser.parse(processedChordPro);
+      const formatter = new HtmlDivFormatter();
+      let formattedSong = formatter.format(song);
+
+      let metaInsert = '';
+      if (author) {
+        metaInsert += `<div class="song-meta-author">${author}</div>`;
+      }
+      let finalKeyCapoString = '';
+      if (key) {
+        finalKeyCapoString += `<strong>${key.toUpperCase()}</strong>`;
+      }
+
+      if (capo !== undefined && capo > 0) {
+        if (finalKeyCapoString) finalKeyCapoString += ' - ';
+        finalKeyCapoString += `Cejilla ${capo}`;
+      }
+
+      if (currentTranspose !== 0) {
+        if (finalKeyCapoString) finalKeyCapoString += ' / ';
+        const transposeDisplay = currentTranspose > 0 ? `+${currentTranspose}` : `${currentTranspose}`;
+        finalKeyCapoString += `<strong>Semitonos: ${transposeDisplay}</strong>`;
+      }
+
+      if (finalKeyCapoString) {
+        metaInsert += `<div class="song-meta-keycapo">${finalKeyCapoString}</div>`;
+      }
+
+      let finalSongContentWithMeta = formattedSong;
+      if (metaInsert) {
+        const titleEndTag = '</h1>';
+        const titleEndIndex = formattedSong.indexOf(titleEndTag);
+        if (titleEndIndex !== -1) {
+          const insertionPoint = titleEndIndex + titleEndTag.length;
+          finalSongContentWithMeta =
+            formattedSong.substring(0, insertionPoint) +
+            metaInsert +
+            formattedSong.substring(insertionPoint);
+        } else {
+          finalSongContentWithMeta = metaInsert + formattedSong;
+        }
+      }
+
+      const chordsCss = chordsVisible ? '' : '<style>.chord { display: none !important; }</style>';
+
+      const finalHtml = `
+        <html>
+        <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+          <style>
+            body {
+              font-family: ${currentFontFamily};
+              margin: 10px;
+              background-color: #ffffff;
+              color: ${AppColors.textDark};
+              font-size: 100%;
+            }
+            h1 {
+              color: #333;
+              margin-bottom: 0.2em;
+              font-size: 1.6em;
+              text-align: center;
+            }
+            .song-meta-author {
+              color: #777;
+              font-size: 0.9em;
+              margin-bottom: 5px;
+              font-style: italic;
+              text-align: center;
+            }
+            .song-meta-keycapo {
+              color: #555;
+              font-size: 0.9em;
+              margin-bottom: 10px;
+              text-align: center;
+            }
+            .song-meta-keycapo strong {
+              font-weight: bold;
+            }
+            .chord-sheet {
+              margin-top: 1em;
+              text-align: left;
+            }
+            .row {
+              display: flex;
+              flex-wrap: wrap;
+              margin-bottom: 0.2em;
+            }
+            .column {
+              padding-right: 0;
+            }
+            .chord-sheet .chord {
+              color: ${AppColors.primary};
+              font-weight: bold;
+              white-space: pre;
+              display: block;
+              min-height: 1.2em;
+            }
+            .chord-sheet .lyrics {
+              white-space: pre;
+              display: block;
+              min-height: 1.2em;
+            }
+            .comment, .c {
+              color: ${AppColors.secondaryText};
+              font-style: italic;
+              white-space: pre;
+              display: block;
+              margin-top: 0.5em;
+              margin-bottom: 0.5em;
+            }
+            .paragraph {
+              margin-top: 1.75em;
+              margin-bottom: 1.75em;
+            }
+            .paragraph.chorus {
+              font-weight: bold;
+              margin-top: 1.2em;
+              margin-bottom: 1.2em;
+            }
+            ${fontSizeCss}
+          </style>
+          ${chordsCss}
+        </head>
+        <body>
+          ${finalSongContentWithMeta}
+        </body>
+        </html>
+      `;
+      setSongHtml(finalHtml);
+    } catch (err) {
+      console.error('Error procesando canción en useSongProcessor:', err);
+      setSongHtml('❌ Error preparando la canción.');
+    } finally {
+      setIsLoadingSong(false);
+    }
+  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily, author, key, capo]);
+
+  return { songHtml, isLoadingSong };
+};


### PR DESCRIPTION
Refactor de `SongDetailScreen.tsx` y `SongListScreen.tsx` para mejorar que se entienda mejor 

Key changes include:

1.  **`SongListScreen.tsx` Refactoring:**
    *   Extracted `SongListItem.tsx`: A new component to render each individual song item in the list. `SongListScreen.tsx` now uses this component within its `FlatList`.
    *   Relevant styles were moved to `SongListItem.tsx`.

2.  **`SongDetailScreen.tsx` Refactoring:**
    *   Extracted `SongDisplay.tsx`: A new component responsible for rendering the song's HTML content within a `WebView`. It handles its own loading state display.
    *   Extracted `useSongProcessor.ts`: A custom hook that encapsulates all logic for parsing ChordPro content, applying formatting (transposition, font changes, chord visibility), and generating the final HTML for the `SongDisplay`. It manages the `songHtml` and processing state.
    *   Extracted `SongControls.tsx`: A new component that contains all user interface controls for the song detail view, including Floating Action Buttons (FABs) for actions like toggling chords, transposing, changing font size/family, and their associated Modals. This component manages its internal state for modal visibility.
    *   `SongDetailScreen.tsx` is now significantly leaner. Its primary roles are fetching initial song data, managing core song display settings (e.g., `currentTranspose`, `chordsVisible`), and coordinating the `SongDisplay`, `useSongProcessor`, and `SongControls`.
    *   Styles were moved to their respective new components (`SongDisplay.tsx`, `SongControls.tsx`).

This modularization makes each part of the songbook functionality easier to understand, and modify independently.