### PR TITLE
Fix album image URLs

### DIFF
--- a/mcm-app/assets/albums.json
+++ b/mcm-app/assets/albums.json
@@ -4,7 +4,7 @@
     "title": "Pascua Joven 2025",
     "location": "Córdoba",
     "date": "Abril 2025",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/25%20Pascua%20Joven.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/25%20Pascua%20Joven.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/wXEcRR9yH655rU8UA"
   },
   {
@@ -12,7 +12,7 @@
     "title": "Congreso M+C 2025",
     "location": "Benicàssim",
     "date": "7-9 marzo",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/25%20Congreso%20MC.jpeg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/25%20Congreso%20MC.jpeg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/vmDd3U7UCfPxBPnJ7"
   },
   {
@@ -20,7 +20,7 @@
     "title": "X Congreso MCM",
     "location": "Tortosa",
     "date": "1-3 febrero 2024",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/24%20Congreso.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/24%20Congreso.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/zkYfRN7tbxzcAywY6"
   },
   {
@@ -28,7 +28,7 @@
     "title": "Campamento COM 2024",
     "location": "Albaida",
     "date": "15-19 julio",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/24%20Pascua%20Encuentro.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/24%20Pascua%20Encuentro.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/2k9GBUe7Byis8bPZA"
   },
   {
@@ -36,7 +36,7 @@
     "title": "Pascua Joven 2024",
     "location": "Córdoba",
     "date": "Marzo 2024",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/24%20Pascua%20Joven.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/24%20Pascua%20Joven.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/T42uNZfgLFBig87x5"
   },
   {
@@ -44,7 +44,7 @@
     "title": "Post MAT24",
     "location": "Tortosa",
     "date": "Diciembre 2024",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/24%20Post%20MAT.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/24%20Post%20MAT.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/MmrpJ8VehN56Z5Mb6"
   },
   {
@@ -52,7 +52,7 @@
     "title": "MAT24",
     "location": "Godelleta",
     "date": "Agosto 2024",
-    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/24%20MAT.jpg?raw=true",
+    "imageUrl": "https://github.com/mcmespana/mcmapp/blob/main/portadas-albumes/24%20MAT.jpg?raw=true",
     "albumUrl": "https://photos.app.goo.gl/54DYB5XaTbWcS31NA"
   }
 ]


### PR DESCRIPTION
## Summary
- fix the album cover URLs so they reference `portadas-albumes`

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f842d11048326991995a07888605a