### PR TITLE
Rediseño con animaciones para la pantalla de inicio

### DIFF
--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet, Dimensions, ViewStyle, TextStyle, Text } from 'react-native';
 import { Link, LinkProps } from 'expo-router';
 import { Card } from 'react-native-paper';
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, { useSharedValue, withTiming, withDelay, useAnimatedStyle } from 'react-native-reanimated';
+import { HelloWave } from '@/components/HelloWave';
 
 import colors from '@/constants/colors';
 import typography from '@/constants/typography';
@@ -69,12 +72,30 @@ const rectDimension = Math.min(
   maxRectSize
 );
 
+function AnimatedCard({ children, index }: { children: React.ReactNode; index: number }) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withDelay(index * 100, withTiming(1, { duration: 500 }));
+  }, [index, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: progress.value }],
+    opacity: progress.value,
+  }));
+
+  return <Animated.View style={animatedStyle}>{children}</Animated.View>;
+}
+
 export default function Home() {
   return (
-    <View style={styles.container}>
+    <LinearGradient colors={[colors.primary, colors.accent]} style={styles.container}>
+      <View style={styles.header}>
+        <HelloWave />
+      </View>
       <View style={styles.gridContainer}>
         {navigationItems.map((item, index) => {
-          const content = (
+          const card = (
             <Card
               key={index}
               style={[
@@ -93,6 +114,8 @@ export default function Home() {
             </Card>
           );
 
+          const wrapped = <AnimatedCard index={index}>{card}</AnimatedCard>;
+
           if (item.href) {
             return (
               <Link
@@ -100,22 +123,21 @@ export default function Home() {
                 href={item.href}
                 asChild
               >
-                <View style={styles.linkWrapper}>
-                  {content}
-                </View>
+                <View style={styles.linkWrapper}>{wrapped}</View>
               </Link>
             );
           }
 
-          return content;
+          return wrapped;
         })}
       </View>
-    </View>
+    </LinearGradient>
   );
 }
 
 interface Styles {
   container: ViewStyle;
+  header: ViewStyle;
   gridContainer: ViewStyle;
   rectangle: ViewStyle;
   cardContent: ViewStyle;
@@ -129,8 +151,11 @@ interface Styles {
 const styles = StyleSheet.create<Styles>({
   container: {
     flex: 1,
-    backgroundColor: colors.background,
     padding: spacing.lg,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: spacing.lg,
   },
   gridContainer: {
     flexDirection: 'row',

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -25,6 +25,7 @@
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.1.7",
+        "expo-linear-gradient": "^14.1.4",
         "expo-linking": "~7.1.5",
         "expo-notifications": "~0.31.2",
         "expo-router": "~5.0.6",
@@ -7694,6 +7695,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.1.4.tgz",
+      "integrity": "sha512-bImj2qqIjnl+VHYGnIwan9LxmGvb8e4hFqHpxsPzUiK7Ady7uERrXPhJcyTKTxRf4RL2sQRDpoOKzBYNdQDmuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -28,6 +28,7 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.1.7",
+    "expo-linear-gradient": "^14.1.4",
     "expo-linking": "~7.1.5",
     "expo-notifications": "~0.31.2",
     "expo-router": "~5.0.6",


### PR DESCRIPTION
## Summary
- add expo-linear-gradient for gradient backgrounds
- redesign home screen with a gradient header and animated cards

## Testing
- `npm run lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f86fa04008326bee3b5b562c521bf