### PR TITLE
Add calendar view with ICS support

### DIFF
--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -1,6 +1,6 @@
 // app/(tabs)/calendario.tsx
 import React, { useState, useMemo } from 'react';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet, ScrollView, ViewStyle, TextStyle } from 'react-native';
 import { Calendar, CalendarProps } from 'react-native-calendars';
 import { Checkbox, Text } from 'react-native-paper';
 import colors from '@/constants/colors';
@@ -14,7 +14,11 @@ const calendarConfigs: CalendarConfig[] = [
     url: 'https://calendar.google.com/calendar/ical/consolacion.org_11dp4qj27sgud37d7fjanghfck%40group.calendar.google.com/public/basic.ics',
     color: '#A3BD31',
   },
-  // Agrega más calendarios aquí si es necesario
+  {
+    name: 'MCM Local',
+    url: 'https://calendar.google.com/calendar/ical/33j7mpbn86b2jj9sl8rds2e9m8%40group.calendar.google.com/public/basic.ics',
+    color: '#31AADF',
+  },
 ];
 
 export default function Calendario() {
@@ -90,19 +94,19 @@ export default function Calendario() {
 }
 
 interface Styles {
-  container: any;
-  calendar: any;
-  checkboxContainer: any;
-  checkboxItem: any;
-  checkboxLabel: any;
-  eventList: any;
-  eventListTitle: any;
-  eventItem: any;
-  eventTitle: any;
-  eventLocation: any;
-  dot: any;
-  eventTextContainer: any;
-  noEvents: any;
+  container: ViewStyle;
+  calendar: ViewStyle;
+  checkboxContainer: ViewStyle;
+  checkboxItem: ViewStyle;
+  checkboxLabel: TextStyle;
+  eventList: ViewStyle;
+  eventListTitle: TextStyle;
+  eventItem: ViewStyle;
+  eventTitle: TextStyle;
+  eventLocation: TextStyle;
+  dot: ViewStyle;
+  eventTextContainer: ViewStyle;
+  noEvents: TextStyle;
 }
 
 const styles = StyleSheet.create<Styles>({

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -1,34 +1,170 @@
 // app/(tabs)/calendario.tsx
-import React from 'react';
-import { View, Text, StyleSheet, ViewStyle, TextStyle } from 'react-native';
+import React, { useState, useMemo } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Calendar, CalendarProps } from 'react-native-calendars';
+import { Checkbox, Text } from 'react-native-paper';
 import colors from '@/constants/colors';
-import typography from '@/constants/typography';
 import spacing from '@/constants/spacing';
+import typography from '@/constants/typography';
+import useCalendarEvents, { CalendarConfig, CalendarEvent } from '@/hooks/useCalendarEvents';
 
-interface Styles {
-  container: ViewStyle;
-  title: TextStyle;
-}
+const calendarConfigs: CalendarConfig[] = [
+  {
+    name: 'MCM Europa',
+    url: 'https://calendar.google.com/calendar/ical/consolacion.org_11dp4qj27sgud37d7fjanghfck%40group.calendar.google.com/public/basic.ics',
+    color: '#A3BD31',
+  },
+  // Agrega más calendarios aquí si es necesario
+];
 
 export default function Calendario() {
+  const [visibleCalendars, setVisibleCalendars] = useState<boolean[]>(calendarConfigs.map(() => true));
+  const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const { eventsByDate } = useCalendarEvents(calendarConfigs);
+
+  const filteredByDate = useMemo(() => {
+    const map: Record<string, CalendarEvent[]> = {};
+    Object.keys(eventsByDate).forEach((date) => {
+      const events = eventsByDate[date].filter(ev => visibleCalendars[ev.calendarIndex]);
+      if (events.length) map[date] = events;
+    });
+    return map;
+  }, [eventsByDate, visibleCalendars]);
+
+  const markedDates = useMemo<CalendarProps['markedDates']>(() => {
+    const marks: { [date: string]: any } = {};
+    Object.keys(filteredByDate).forEach((date) => {
+      const dots = filteredByDate[date].map(ev => ({
+        key: `${ev.calendarIndex}-${ev.title}`,
+        color: calendarConfigs[ev.calendarIndex].color,
+      }));
+      marks[date] = { marked: true, dots };
+    });
+    marks[selectedDate] = { ...(marks[selectedDate] || {}), selected: true, selectedColor: colors.primary };
+    return marks;
+  }, [filteredByDate, selectedDate]);
+
+  const eventsForSelected = filteredByDate[selectedDate] || [];
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Aquí va el Calendario 🎶</Text>
-    </View>
+    <ScrollView style={styles.container}>
+      <Calendar
+        onDayPress={(day) => setSelectedDate(day.dateString)}
+        markedDates={markedDates}
+        markingType="multi-dot"
+        style={styles.calendar}
+      />
+      <View style={styles.checkboxContainer}>
+        {calendarConfigs.map((cal, idx) => (
+          <View key={idx} style={styles.checkboxItem}>
+            <Checkbox
+              status={visibleCalendars[idx] ? 'checked' : 'unchecked'}
+              onPress={() => {
+                const copy = [...visibleCalendars];
+                copy[idx] = !copy[idx];
+                setVisibleCalendars(copy);
+              }}
+              color={cal.color}
+            />
+            <Text style={styles.checkboxLabel}>{cal.name}</Text>
+          </View>
+        ))}
+      </View>
+      <View style={styles.eventList}>
+        <Text style={styles.eventListTitle}>Eventos para {selectedDate}</Text>
+        {eventsForSelected.map((ev, i) => (
+          <View key={i} style={styles.eventItem}>
+            <View style={[styles.dot, { backgroundColor: calendarConfigs[ev.calendarIndex].color }]} />
+            <View style={styles.eventTextContainer}>
+              <Text style={styles.eventTitle}>{ev.title}</Text>
+              {ev.location ? <Text style={styles.eventLocation}>{ev.location}</Text> : null}
+            </View>
+          </View>
+        ))}
+        {eventsForSelected.length === 0 && (
+          <Text style={styles.noEvents}>No hay eventos para este día.</Text>
+        )}
+      </View>
+    </ScrollView>
   );
+}
+
+interface Styles {
+  container: any;
+  calendar: any;
+  checkboxContainer: any;
+  checkboxItem: any;
+  checkboxLabel: any;
+  eventList: any;
+  eventListTitle: any;
+  eventItem: any;
+  eventTitle: any;
+  eventLocation: any;
+  dot: any;
+  eventTextContainer: any;
+  noEvents: any;
 }
 
 const styles = StyleSheet.create<Styles>({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.md,
   },
-  title: {
-    ...typography.h1,
-    fontWeight: 'bold', // or use a valid value like '700'
+  calendar: {
+    marginBottom: spacing.md,
+  },
+  checkboxContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.md,
+  },
+  checkboxItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  checkboxLabel: {
+    ...typography.body,
     color: colors.text,
+  },
+  eventList: {
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  eventListTitle: {
+    ...typography.h2,
+    color: colors.text,
+    marginBottom: spacing.sm,
+    fontWeight: 'bold',
+  },
+  eventItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.xs,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: spacing.sm,
+  },
+  eventTextContainer: {
+    flexDirection: 'column',
+  },
+  eventTitle: {
+    ...typography.body,
+    color: colors.text,
+  },
+  eventLocation: {
+    ...typography.body,
+    color: colors.secondary,
+  },
+  noEvents: {
+    ...typography.body,
+    color: colors.text,
+    fontStyle: 'italic',
   },
 });

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect } from 'react';
+
+export interface CalendarConfig {
+  url: string;
+  color: string;
+  name: string;
+}
+
+export interface CalendarEvent {
+  date: string; // YYYY-MM-DD
+  title: string;
+  description?: string;
+  location?: string;
+  calendarIndex: number;
+}
+
+function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
+  const events: Omit<CalendarEvent, 'calendarIndex'>[] = [];
+  const lines = text.split(/\r?\n/);
+  let current: Partial<Omit<CalendarEvent, 'calendarIndex'>> = {};
+  for (const line of lines) {
+    if (line.startsWith('BEGIN:VEVENT')) {
+      current = {};
+    } else if (line.startsWith('END:VEVENT')) {
+      if (current.date && current.title) {
+        events.push(current as Omit<CalendarEvent, 'calendarIndex'>);
+      }
+      current = {};
+    } else if (line.startsWith('SUMMARY:')) {
+      current.title = line.slice('SUMMARY:'.length).trim();
+    } else if (line.startsWith('DESCRIPTION:')) {
+      current.description = line
+        .slice('DESCRIPTION:'.length)
+        .replace(/\\n/g, ' ')
+        .trim();
+    } else if (line.startsWith('LOCATION:')) {
+      current.location = line.slice('LOCATION:'.length).trim();
+    } else if (line.startsWith('DTSTART')) {
+      const parts = line.split(':');
+      const value = parts[1];
+      if (value) {
+        const datePart = value.trim().substring(0, 8); // YYYYMMDD
+        const year = datePart.substring(0, 4);
+        const month = datePart.substring(4, 6);
+        const day = datePart.substring(6, 8);
+        current.date = `${year}-${month}-${day}`;
+      }
+    }
+  }
+  return events;
+}
+
+export default function useCalendarEvents(calendars: CalendarConfig[]) {
+  const [eventsByDate, setEventsByDate] = useState<Record<string, CalendarEvent[]>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    async function fetchCalendars() {
+      setLoading(true);
+      const map: Record<string, CalendarEvent[]> = {};
+      for (let i = 0; i < calendars.length; i++) {
+        const cfg = calendars[i];
+        try {
+          const res = await fetch(cfg.url);
+          const text = await res.text();
+          const events = parseICS(text);
+          events.forEach((ev) => {
+            const withCal: CalendarEvent = { ...ev, calendarIndex: i };
+            if (!map[ev.date]) map[ev.date] = [];
+            map[ev.date].push(withCal);
+          });
+        } catch (e) {
+          console.error('Error fetching calendar', cfg.url, e);
+        }
+      }
+      if (mounted) {
+        setEventsByDate(map);
+        setLoading(false);
+      }
+    }
+    fetchCalendars();
+    return () => {
+      mounted = false;
+    };
+  }, [calendars]);
+
+  return { eventsByDate, loading };
+}

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -38,6 +38,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
+        "react-native-calendars": "^1.1312.1",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-onesignal": "^5.2.11",
         "react-native-paper": "^5.14.4",
@@ -10162,6 +10163,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10961,6 +10968,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -11987,7 +12004,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11999,7 +12015,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -12245,6 +12260,38 @@
         }
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1312.1",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1312.1.tgz",
+      "integrity": "sha512-295577LyDmLF53wURndNFly6SFQRpKR4d+fzGiIUs1FzdT1JK7uydtCUqm4++eKDuwhsz2mXJkszmTi6etsTdw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -12383,6 +12430,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
+    },
     "node_modules/react-native-web": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
@@ -12501,6 +12554,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14291,6 +14359,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -15181,6 +15255,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -41,6 +41,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
+    "react-native-calendars": "^1.1312.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-onesignal": "^5.2.11",
     "react-native-paper": "^5.14.4",


### PR DESCRIPTION
## Summary
- install `react-native-calendars`
- create `useCalendarEvents` hook to fetch and parse iCal feeds
- build new Calendario screen with month view, calendar toggles and event list

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f867ae77083268ecbac44585de828