### PR TITLE
Add new Jubileo tab with placeholder screens

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -49,16 +49,24 @@ export default function TabsLayout() {
             headerShown: false // Cantoral uses its own StackNavigator header
           }} 
         />
-        <Tabs.Screen 
-          name="calendario" 
+        <Tabs.Screen
+          name="calendario"
           options={{
             title: 'Calendario',
             tabBarIcon: ({color, size}) => <MaterialIcons name="calendar-today" color={color} size={size}/>,
             headerStyle: { backgroundColor: '#A3BD31' } // Éxito / Confirmación color
-          }} 
+          }}
         />
-        <Tabs.Screen 
-          name="fotos" 
+        <Tabs.Screen
+          name="jubileo"
+          options={{
+            title: 'Jubileo',
+            tabBarIcon: ({color, size}) => <MaterialIcons name="celebration" color={color} size={size}/>,
+            headerShown: false
+          }}
+        />
+        <Tabs.Screen
+          name="fotos"
           options={{
             title: 'Fotos',
             tabBarIcon: ({color, size}) => <MaterialIcons name="photo-library" color={color} size={size}/>,

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -1,0 +1,41 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import JubileoHomeScreen from '../screens/JubileoHomeScreen';
+import HorarioScreen from '../screens/HorarioScreen';
+import MaterialesScreen from '../screens/MaterialesScreen';
+import VisitasScreen from '../screens/VisitasScreen';
+import ProfundizaScreen from '../screens/ProfundizaScreen';
+import GruposScreen from '../screens/GruposScreen';
+
+export type JubileoStackParamList = {
+  Home: undefined;
+  Horario: undefined;
+  Materiales: undefined;
+  Visitas: undefined;
+  Profundiza: undefined;
+  Grupos: undefined;
+};
+
+const Stack = createNativeStackNavigator<JubileoStackParamList>();
+
+export default function JubileoTab() {
+  return (
+    <Stack.Navigator
+      initialRouteName="Home"
+      screenOptions={{
+        headerBackTitle: 'Atrás',
+        headerStyle: { backgroundColor: '#9D1E74' },
+        headerTintColor: '#fff',
+        headerTitleStyle: { fontWeight: 'bold' },
+        headerTitleAlign: 'center',
+      }}
+    >
+      <Stack.Screen name="Home" component={JubileoHomeScreen} options={{ title: 'Jubileo' }} />
+      <Stack.Screen name="Horario" component={HorarioScreen} options={{ title: 'Horario' }} />
+      <Stack.Screen name="Materiales" component={MaterialesScreen} options={{ title: 'Materiales' }} />
+      <Stack.Screen name="Visitas" component={VisitasScreen} options={{ title: 'Visitas' }} />
+      <Stack.Screen name="Profundiza" component={ProfundizaScreen} options={{ title: 'Profundiza' }} />
+      <Stack.Screen name="Grupos" component={GruposScreen} options={{ title: 'Grupos' }} />
+    </Stack.Navigator>
+  );
+}

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function GruposScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function HorarioScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { View, StyleSheet, Dimensions, Text, TouchableOpacity, ViewStyle, TextStyle } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Card } from 'react-native-paper';
+
+import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import typography from '@/constants/typography';
+import { JubileoStackParamList } from '../(tabs)/jubileo';
+
+interface NavigationItem {
+  label: string;
+  icon: string;
+  target: keyof JubileoStackParamList;
+  backgroundColor: string;
+  color: string;
+}
+
+const navigationItems: NavigationItem[] = [
+  { label: 'Horario', icon: '⏰', target: 'Horario', backgroundColor: '#FF8A65', color: colors.black },
+  { label: 'Materiales', icon: '📦', target: 'Materiales', backgroundColor: '#4FC3F7', color: colors.black },
+  { label: 'Visitas', icon: '🚌', target: 'Visitas', backgroundColor: '#81C784', color: colors.black },
+  { label: 'Profundiza', icon: '📖', target: 'Profundiza', backgroundColor: '#BA68C8', color: colors.black },
+  { label: 'Grupos', icon: '👥', target: 'Grupos', backgroundColor: '#FFD54F', color: colors.black },
+];
+
+const { width } = Dimensions.get('window');
+const gap = spacing.lg;
+const itemPerRow = width > 700 ? 3 : 2;
+const totalGapSize = (itemPerRow - 1) * gap;
+const windowWidth = width - spacing.lg * 2;
+const maxRectSize = 180;
+const rectDimension = Math.min((windowWidth - totalGapSize) / itemPerRow, maxRectSize);
+
+export default function JubileoHomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
+  return (
+    <View style={styles.container}>
+      <View style={styles.gridContainer}>
+        {navigationItems.map((item, index) => (
+          <TouchableOpacity
+            key={index}
+            onPress={() => navigation.navigate(item.target)}
+            style={styles.linkWrapper}
+          >
+            <Card style={[styles.rectangle, { backgroundColor: item.backgroundColor }]} elevation={2}>
+              <Card.Content style={styles.cardContent}>
+                <Text style={[styles.iconPlaceholder, { color: item.color }]}>{item.icon}</Text>
+                <Text style={[styles.rectangleLabel, { color: item.color }]}>{item.label}</Text>
+              </Card.Content>
+            </Card>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+interface Styles {
+  container: ViewStyle;
+  gridContainer: ViewStyle;
+  rectangle: ViewStyle;
+  cardContent: ViewStyle;
+  linkWrapper: ViewStyle;
+  iconPlaceholder: TextStyle;
+  rectangleLabel: TextStyle;
+}
+
+const styles = StyleSheet.create<Styles>({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: spacing.lg,
+  },
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    gap: gap,
+  },
+  rectangle: {
+    width: rectDimension,
+    height: rectDimension,
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  cardContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
+  },
+  linkWrapper: {
+    width: rectDimension,
+    height: rectDimension,
+  },
+  iconPlaceholder: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+    textShadowColor: 'rgba(0,0,0,0.08)',
+    textShadowOffset: { width: 1, height: 2 },
+    textShadowRadius: 2,
+  },
+  rectangleLabel: {
+    ...(typography.button as TextStyle),
+    fontWeight: 'bold',
+    textAlign: 'center',
+    fontSize: 18,
+    letterSpacing: 0.5,
+    marginTop: 2,
+  },
+});

--- a/mcm-app/app/screens/MaterialesScreen.tsx
+++ b/mcm-app/app/screens/MaterialesScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function MaterialesScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function ProfundizaScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/mcm-app/app/screens/VisitasScreen.tsx
+++ b/mcm-app/app/screens/VisitasScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function VisitasScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});


### PR DESCRIPTION
## Summary
- add Jubileo stack navigator and screens
- register new Jubileo tab in layout
- create empty placeholder screens
- design visual grid for Jubileo home

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8881e7f08326b7413f10085dacb6