### PR TITLE
Fix settings persistence

### DIFF
--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -78,6 +78,17 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     saveSettings();
   }, [settings, isLoadingSettings]);
 
+  // Ensure latest settings are persisted if the provider unmounts before
+  // the save effect above runs (e.g. user quickly leaves the screen)
+  useEffect(() => {
+    return () => {
+      if (isLoadingSettings) return;
+      AsyncStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings)).catch(error => {
+        console.error('Failed to save settings to AsyncStorage on unmount:', error);
+      });
+    };
+  }, [settings, isLoadingSettings]);
+
   const handleSetSettings = (newValues: Partial<SongSettings>) => {
     setAppSettings(prevSettings => ({
       ...prevSettings,


### PR DESCRIPTION
## Summary
- save song settings on context unmount to ensure latest changes persist

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f83aff1248326b40d0e636a1726a9