### PR TITLE
Simplify home screen UI with notification placeholder

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -25,13 +25,13 @@ export default function TabsLayout() {
           tabBarStyle: { backgroundColor: colors.background }, //
         }}
       >
-        <Tabs.Screen 
-          name="index" 
+        <Tabs.Screen
+          name="index"
           options={{
             title: 'Inicio',
             tabBarIcon: ({color, size}) => <MaterialIcons name="home" color={color} size={size}/>,
-            headerShown: false // No header for Inicio tab
-          }} 
+            headerShown: true
+          }}
         />
         <Tabs.Screen 
           name="comunica" 

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -1,265 +1,118 @@
-import React, { useEffect, ComponentProps } from 'react';
-import { View, Text, StyleSheet, Dimensions, ViewStyle, TextStyle, ScrollView } from 'react-native';
+import React, { useLayoutEffect, ComponentProps } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, ViewStyle, TextStyle } from 'react-native';
 import { Link, LinkProps } from 'expo-router';
-import { Card } from 'react-native-paper';
-import { LinearGradient } from 'expo-linear-gradient';
-import Animated, { useSharedValue, withTiming, withDelay, useAnimatedStyle } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { Badge } from 'react-native-paper';
 import colors from '@/constants/colors';
-import typography from '@/constants/typography';
 import spacing from '@/constants/spacing';
+import typography from '@/constants/typography';
 
-type NavigationItem = {
+interface NavigationItem {
   href?: LinkProps['href'];
   label: string;
   icon: ComponentProps<typeof MaterialIcons>['name'];
   backgroundColor: string;
   color: string;
-};
+}
 
 const navigationItems: NavigationItem[] = [
-  {
-    href: "/cancionero",
-    label: "Cantoral",
-    icon: "library-music",
-    backgroundColor: colors.warning,
-    color: colors.black,
-  },
-  {
-    href: "/fotos",
-    label: "Fotos",
-    icon: "photo-library",
-    backgroundColor: colors.accent,
-    color: colors.black,
-  },
-  {
-    href: "/calendario",
-    label: "Calendario",
-    icon: "event",
-    backgroundColor: colors.info,
-    color: colors.black,
-  },
-  {
-    href: "/comunica",
-    label: "Comunica",
-    icon: "chat",
-    backgroundColor: colors.success,
-    color: colors.black,
-  },
-  {
-    label: "Mas cosas...",
-    icon: "build",
-    backgroundColor: colors.warning,
-    color: colors.black,
-  },
-  {
-    label: "Y mas cosas....",
-    icon: "hourglass-empty",
-    backgroundColor: colors.danger,
-    color: colors.black,
-  },
+  { href: '/cancionero', label: 'Cantoral', icon: 'library-music', backgroundColor: colors.warning, color: colors.black },
+  { href: '/fotos', label: 'Fotos', icon: 'photo-library', backgroundColor: colors.accent, color: colors.black },
+  { href: '/calendario', label: 'Calendario', icon: 'event', backgroundColor: colors.info, color: colors.black },
+  { href: '/comunica', label: 'Comunica', icon: 'chat', backgroundColor: colors.success, color: colors.black },
+  { label: 'Mas cosas...', icon: 'build', backgroundColor: colors.warning, color: colors.black },
+  { label: 'Y mas cosas....', icon: 'hourglass-empty', backgroundColor: colors.danger, color: colors.black },
 ];
 
-// Global constants that don't depend on component state/props
-const GAP_SIZE = spacing.lg;
-const ITEMS_PER_ROW = 2;
-
-function AnimatedCard({ children, index, style }: { children: React.ReactNode; index: number; style?: ViewStyle; /* Removed ...rest and [key: string]: any */ }) {
-  const progress = useSharedValue(0);
-
-  useEffect(() => {
-    progress.value = withDelay(index * 100, withTiming(1, { duration: 500 }));
-  }, [index, progress]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: progress.value }],
-    opacity: progress.value,
-  }));
-
-  return <Animated.View style={[animatedStyle, style]}>{children}</Animated.View>; // Removed {...rest}
+function NotificationsButton() {
+  return (
+    <Link href="/notifications" asChild>
+      <TouchableOpacity style={{ marginRight: spacing.md }}>
+        <View>
+          <MaterialIcons name="notifications" size={24} color="#fff" />
+          <Badge style={styles.badge} />
+        </View>
+      </TouchableOpacity>
+    </Link>
+  );
 }
 
 export default function Home() {
-  const currentInsets = useSafeAreaInsets();
-  const { width: windowWidthDimen, height: windowHeightDimen } = Dimensions.get('window');
+  const navigation = useNavigation();
 
-  const baseRectSize = React.useMemo(() => {
-    const numNavigationItems = navigationItems.length;
-    const numberOfRows = Math.ceil(numNavigationItems / ITEMS_PER_ROW);
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => <NotificationsButton />,
+      title: 'Inicio',
+    });
+  }, [navigation]);
 
-    // Calculate size based on width
-    const horizontalPadding = spacing.lg * 2; // For scrollContentContainer
-    const availableWidthForGrid = windowWidthDimen - horizontalPadding;
-    const widthBasedSize = (availableWidthForGrid - (ITEMS_PER_ROW - 1) * GAP_SIZE) / ITEMS_PER_ROW;
-
-    // Calculate size based on height
-    // Height available for ScrollView's content (after LinearGradient's safe area padding)
-    const scrollViewContentAvailableHeight = windowHeightDimen - (currentInsets.top + currentInsets.bottom);
-    // Height available for grid items within ScrollView content (after scrollContentContainer's own padding)
-    const verticalPaddingForScrollContent = spacing.lg * 2;
-    const availableHeightForGridItems = scrollViewContentAvailableHeight - verticalPaddingForScrollContent;
-    const heightBasedSize = (availableHeightForGridItems - (numberOfRows - 1) * GAP_SIZE) / numberOfRows;
-    
-    // Use the smaller of the two, ensuring it's a positive number and has a minimum
-    const constrainedSize = Math.min(widthBasedSize, heightBasedSize > 0 ? heightBasedSize : widthBasedSize);
-    return Math.max(constrainedSize, 50); // Minimum item size 50x50
-  }, [windowWidthDimen, windowHeightDimen, currentInsets]);
-
-  const insets = currentInsets; // Keep using 'insets' variable name if preferred in LinearGradient
   return (
-    <LinearGradient
-      colors={[colors.primary, colors.secondary]}
-      style={[
-        styles.outerContainer, // Changed from styles.container
-        {
-          paddingTop: insets.top, // Only inset for top
-          paddingBottom: insets.bottom, // Only inset for bottom
-        },
-      ]}
-    >
-      <ScrollView 
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContentContainer}
-      >
-        <View style={styles.gridContainer}>
-        {navigationItems.map((item, index) => {
-          const itemKey = `${item.label.replace(/\s+/g, '-')}-${index}`; // Create a more robust key
-
-          const dynamicSizeStyle: ViewStyle = {
-            width: baseRectSize,
-            height: baseRectSize,
-          };
-
-          const dynamicCircleStyle: ViewStyle = {
-            width: baseRectSize * 0.6,
-            height: baseRectSize * 0.6,
-            borderRadius: baseRectSize * 0.3,
-            top: -baseRectSize * 0.2,
-            right: -baseRectSize * 0.2,
-          };
-
-          const card = (
-            <Card
-              // key prop will be on the wrapping AnimatedCard or Link
-              style={[
-                styles.rectangle, // Contains static styles like borderRadius
-                // dynamicSizeStyle is now applied to AnimatedCard, Card will flex into it.
-                { backgroundColor: item.backgroundColor },
-                !item.href && styles.disabledRectangle,
-                !item.href && styles.placeholder,
-              ]}
-              contentStyle={styles.cardContentInternal}
-              elevation={2}
-            >
-              <Card.Content style={styles.cardContentInternal}>
-                <View style={styles.circleDecoration} /> {/* Reverted: No dynamicCircleStyle */}
-                <MaterialIcons name={item.icon} style={styles.icon} size={48} color={item.color} /> {/* Reverted: Fixed icon size */}
-                <Text style={[styles.rectangleLabel, { color: item.color }]}>{item.label}</Text> {/* Reverted: Fixed text size */}
-              </Card.Content>
-            </Card>
-          );
-
-          if (item.href) {
-            return (
-              <Link
-                key={itemKey}
-                href={item.href}
-                asChild
-                // style prop removed from Link
-              >
-                <AnimatedCard index={index} style={dynamicSizeStyle}> {/* Apply style to AnimatedCard directly */}
-                  {card} 
-                </AnimatedCard>
-              </Link>
-            );
-          }
-
-          // For non-linked items
-          return (
-            <AnimatedCard key={itemKey} index={index} style={dynamicSizeStyle}>
-              {card}
-            </AnimatedCard>
-          );
-        })}
-        </View>
-      </ScrollView>
-    </LinearGradient>
+    <FlatList
+      data={navigationItems}
+      keyExtractor={(_, index) => index.toString()}
+      numColumns={2}
+      columnWrapperStyle={styles.row}
+      contentContainerStyle={styles.container}
+      renderItem={({ item }) => {
+        const content = (
+          <View style={[styles.item, { backgroundColor: item.backgroundColor }]}>
+            <MaterialIcons name={item.icon} size={48} color={item.color} style={styles.icon} />
+            <Text style={[styles.label, { color: item.color }]}>{item.label}</Text>
+          </View>
+        );
+        return item.href ? (
+          <Link href={item.href} asChild>
+            <TouchableOpacity style={styles.itemWrapper}>{content}</TouchableOpacity>
+          </Link>
+        ) : (
+          <View style={styles.itemWrapper}>{content}</View>
+        );
+      }}
+    />
   );
 }
 
 interface Styles {
-  outerContainer: ViewStyle; // Renamed from container
-  scrollView: ViewStyle;
-  scrollContentContainer: ViewStyle;
-  gridContainer: ViewStyle;
-  rectangle: ViewStyle; // Will now primarily hold non-size related styles
-  cardContentInternal: ViewStyle; // Renamed from cardContent to avoid conflict if Card.Content has 'cardContent' prop
-  disabledRectangle: ViewStyle;
-  placeholder: ViewStyle;
+  container: ViewStyle;
+  row: ViewStyle;
+  itemWrapper: ViewStyle;
+  item: ViewStyle;
   icon: TextStyle;
-  circleDecoration: ViewStyle;
-  rectangleLabel: TextStyle;
+  label: TextStyle;
+  badge: ViewStyle;
 }
 
 const styles = StyleSheet.create<Styles>({
-  outerContainer: { // Renamed from container
-    flex: 1,
+  container: {
+    padding: spacing.lg,
   },
-  scrollView: {
-    flex: 1,
-  },
-  scrollContentContainer: {
-    padding: spacing.lg, // Uniform padding for the content
-  },
-  gridContainer: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+  row: {
     justifyContent: 'space-between',
-    gap: GAP_SIZE, // Use the global constant
+    marginBottom: spacing.lg,
   },
-  rectangle: {
-    // width and height are now dynamic, applied via dynamicSizeStyle
-    borderRadius: 16,
-    overflow: 'hidden',
-    flex: 1, // Ensure Card fills AnimatedCard
-  },
-  cardContentInternal: {
+  itemWrapper: {
     flex: 1,
+    marginHorizontal: spacing.sm / 2,
+  },
+  item: {
+    aspectRatio: 1,
+    borderRadius: 16,
     justifyContent: 'center',
     alignItems: 'center',
-    height: '100%',
-    padding: spacing.sm, // Add some internal padding
-  },
-  // linkWrapper is removed as AnimatedCard handles its own sizing
-  disabledRectangle: {
-    opacity: 0.5,
-  },
-  placeholder: {
-    opacity: 0.6,
-    borderStyle: 'dashed',
-    borderColor: colors.border || '#bbb',
-    borderWidth: 1,
-  },
-  circleDecoration: {
-    position: 'absolute',
-    // width, height, borderRadius, top, right are now dynamic, applied via dynamicCircleStyle
-    backgroundColor: 'rgba(255,255,255,0.2)',
   },
   icon: {
-    fontSize: 48,
     marginBottom: spacing.sm,
-    textAlign: 'center',
-    textShadowColor: 'rgba(0,0,0,0.08)',
-    textShadowOffset: { width: 1, height: 2 },
-    textShadowRadius: 2,
   },
-  rectangleLabel: {
+  label: {
     ...(typography.button as TextStyle),
     fontWeight: 'bold',
     textAlign: 'center',
-    fontSize: 18,
-    letterSpacing: 0.5,
-    marginTop: 2,
+  },
+  badge: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
   },
 });

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+
+export default function NotificationsScreen() {
+  return <View style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});


### PR DESCRIPTION
## Summary
- rebuild the home screen with a simpler two-column grid layout
- add header bell button with badge leading to a new notifications page
- enable header on the home tab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842f7b403988326a93d3b253122d6a6