### PR TITLE
Implement Jubileo schedule and materials

### DIFF
--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import JubileoHomeScreen from '../screens/JubileoHomeScreen';
 import HorarioScreen from '../screens/HorarioScreen';
 import MaterialesScreen from '../screens/MaterialesScreen';
+import MaterialPagesScreen from '../screens/MaterialPagesScreen';
 import VisitasScreen from '../screens/VisitasScreen';
 import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
@@ -11,6 +12,7 @@ export type JubileoStackParamList = {
   Home: undefined;
   Horario: undefined;
   Materiales: undefined;
+  MaterialPages: { actividad: any };
   Visitas: undefined;
   Profundiza: undefined;
   Grupos: undefined;
@@ -32,7 +34,8 @@ export default function JubileoTab() {
     >
       <Stack.Screen name="Home" component={JubileoHomeScreen} options={{ title: 'Jubileo' }} />
       <Stack.Screen name="Horario" component={HorarioScreen} options={{ title: 'Horario' }} />
-      <Stack.Screen name="Materiales" component={MaterialesScreen} options={{ title: 'Materiales' }} />
+  <Stack.Screen name="Materiales" component={MaterialesScreen} options={{ title: 'Materiales' }} />
+      <Stack.Screen name="MaterialPages" component={MaterialPagesScreen} options={{ title: 'Material' }} />
       <Stack.Screen name="Visitas" component={VisitasScreen} options={{ title: 'Visitas' }} />
       <Stack.Screen name="Profundiza" component={ProfundizaScreen} options={{ title: 'Profundiza' }} />
       <Stack.Screen name="Grupos" component={GruposScreen} options={{ title: 'Grupos' }} />

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -1,14 +1,56 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
 import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import horarioData from '@/assets/jubileo-horario.json';
+import DateSelector from '@/components/DateSelector';
+import EventItem from '@/components/EventItem';
+import { ThemedText } from '@/components/ThemedText';
 
 export default function HorarioScreen() {
-  return <View style={styles.container} />;
+  const [index, setIndex] = useState(0);
+  const fechas = horarioData.map((d) => ({ fecha: d.fecha, titulo: d.titulo }));
+  const dia = horarioData[index];
+
+  return (
+    <View style={styles.container}>
+      <DateSelector
+        dates={fechas}
+        selectedDate={dia.fecha}
+        onSelectDate={(_, i) => setIndex(i)}
+      />
+      <View style={styles.titleWrapper}>
+        <ThemedText style={styles.titleText}>{dia.titulo}</ThemedText>
+      </View>
+      <ScrollView contentContainerStyle={styles.eventsContainer}>
+        {dia.eventos.map((ev, idx) => (
+          <EventItem key={idx} event={ev} />
+        ))}
+      </ScrollView>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
+  },
+  titleWrapper: {
+    backgroundColor: colors.danger,
+    marginHorizontal: spacing.lg,
+    padding: spacing.sm,
+    borderRadius: 8,
+    marginBottom: spacing.md,
+  },
+  titleText: {
+    color: colors.white,
+    textAlign: 'center',
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  eventsContainer: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
   },
 });

--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, Dimensions, Text, FlatList, ScrollView } from 'react-native';
+import { RouteProp } from '@react-navigation/native';
+import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import { JubileoStackParamList } from '../(tabs)/jubileo';
+
+interface Pagina {
+  titulo: string;
+  texto: string;
+  subtitulo?: string;
+}
+
+interface Actividad {
+  nombre: string;
+  emoji?: string;
+  color?: string;
+  paginas: Pagina[];
+}
+
+type RouteProps = RouteProp<JubileoStackParamList, 'MaterialPages'>;
+
+export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
+  const { actividad } = route.params;
+  const [index, setIndex] = useState(0);
+  const pages = [{ intro: true }, ...actividad.paginas];
+  const width = Dimensions.get('window').width;
+
+  const renderItem = ({ item }: { item: any }) => {
+    if (item.intro) {
+      return (
+        <View style={[styles.introPage, { width, backgroundColor: actividad.color }]}>
+          <Text style={styles.introEmoji}>{actividad.emoji}</Text>
+          <Text style={styles.introTitle}>{actividad.nombre}</Text>
+          <Text style={styles.introHint}>Desliza para continuar</Text>
+        </View>
+      );
+    }
+    return (
+      <View style={[styles.page, { width }]}>
+        <View style={[styles.pageHeader, { backgroundColor: actividad.color }]}>
+          <Text style={styles.pageTitle}>{item.titulo}</Text>
+          {item.subtitulo && <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>}
+        </View>
+        <ScrollView contentContainerStyle={styles.pageContent}>
+          <Text>{item.texto}</Text>
+        </ScrollView>
+      </View>
+    );
+  };
+
+  const onMomentumScrollEnd = (e: any) => {
+    const newIndex = Math.round(e.nativeEvent.contentOffset.x / width);
+    setIndex(newIndex);
+  };
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={pages}
+        keyExtractor={(_, i) => String(i)}
+        renderItem={renderItem}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={onMomentumScrollEnd}
+      />
+      <View style={styles.dotsContainer}>
+        {pages.map((_, i) => (
+          <View key={i} style={[styles.dot, index === i && styles.dotActive]} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  introPage: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  introEmoji: {
+    fontSize: 64,
+    marginBottom: spacing.lg,
+  },
+  introTitle: {
+    fontSize: 26,
+    fontWeight: 'bold',
+    color: colors.white,
+  },
+  introHint: {
+    marginTop: spacing.md,
+    color: colors.white,
+  },
+  page: {
+    flex: 1,
+  },
+  pageHeader: {
+    padding: spacing.md,
+  },
+  pageTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: colors.white,
+  },
+  pageSubtitle: {
+    fontSize: 16,
+    color: colors.white,
+    marginTop: 4,
+  },
+  pageContent: {
+    padding: spacing.lg,
+  },
+  dotsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    padding: spacing.md,
+    gap: 6,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#ccc',
+  },
+  dotActive: {
+    backgroundColor: colors.accent,
+  },
+});

--- a/mcm-app/app/screens/MaterialesScreen.tsx
+++ b/mcm-app/app/screens/MaterialesScreen.tsx
@@ -1,14 +1,67 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity, Text } from 'react-native';
 import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import materialesData from '@/assets/jubileo-materiales.json';
+import DateSelector from '@/components/DateSelector';
+import { JubileoStackParamList } from '../(tabs)/jubileo';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+
+interface Actividad {
+  nombre: string;
+  color?: string;
+  emoji?: string;
+  paginas: any[];
+}
+
+type Nav = NativeStackNavigationProp<JubileoStackParamList, 'MaterialPages'>;
 
 export default function MaterialesScreen() {
-  return <View style={styles.container} />;
+  const navigation = useNavigation<Nav>();
+  const [index, setIndex] = useState(0);
+  const fechas = materialesData.map((d) => ({ fecha: d.fecha }));
+  const dia = materialesData[index];
+
+  return (
+    <View style={styles.container}>
+      <DateSelector dates={fechas} selectedDate={dia.fecha} onSelectDate={(_, i) => setIndex(i)} />
+      <ScrollView contentContainerStyle={styles.list}>
+        {dia.actividades.map((act: Actividad, idx: number) => (
+          <TouchableOpacity
+            key={idx}
+            style={[styles.card, { backgroundColor: act.color || colors.primary }]}
+            onPress={() => navigation.navigate('MaterialPages', { actividad: act })}
+          >
+            <Text style={styles.emoji}>{act.emoji}</Text>
+            <Text style={styles.cardText}>{act.nombre.toUpperCase()}</Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
+  container: { flex: 1, backgroundColor: colors.background },
+  list: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+  },
+  card: {
+    borderRadius: 12,
+    paddingVertical: spacing.xl,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  emoji: {
+    fontSize: 40,
+    marginBottom: spacing.sm,
+  },
+  cardText: {
+    color: colors.white,
+    fontWeight: 'bold',
+    fontSize: 18,
   },
 });

--- a/mcm-app/assets/jubileo-horario.json
+++ b/mcm-app/assets/jubileo-horario.json
@@ -1,6 +1,7 @@
 [
   {
     "fecha": "2025-07-29",
+    "titulo": "Acogida",
     "eventos": [
       {
         "nombre": "Bienvenida y registro",
@@ -27,6 +28,7 @@
   },
   {
     "fecha": "2025-07-30",
+    "titulo": "Encuentro",
     "eventos": [
       {
         "nombre": "Oración de la mañana",
@@ -53,6 +55,7 @@
   },
   {
     "fecha": "2025-07-31",
+    "titulo": "Servicio",
     "eventos": [
       {
         "nombre": "Visita solidaria",
@@ -79,6 +82,7 @@
   },
   {
     "fecha": "2025-08-01",
+    "titulo": "Cultura",
     "eventos": [
       {
         "nombre": "Salida cultural",
@@ -98,6 +102,7 @@
   },
   {
     "fecha": "2025-08-02",
+    "titulo": "Hermandad",
     "eventos": [
       {
         "nombre": "Encuentro con testigos",
@@ -117,6 +122,7 @@
   },
   {
     "fecha": "2025-08-03",
+    "titulo": "Misión",
     "eventos": [
       {
         "nombre": "Oración de envío",
@@ -136,6 +142,7 @@
   },
   {
     "fecha": "2025-08-04",
+    "titulo": "Envío",
     "eventos": [
       {
         "nombre": "Eucaristía final",

--- a/mcm-app/assets/jubileo-materiales.json
+++ b/mcm-app/assets/jubileo-materiales.json
@@ -4,6 +4,8 @@
     "actividades": [
       {
         "nombre": "Oración de la mañana",
+        "emoji": "☀️",
+        "color": "#4FC3F7",
         "paginas": [
           {
             "titulo": "Seccion 1",
@@ -18,6 +20,8 @@
       },
       {
         "nombre": "Reflexión de la tarde",
+        "emoji": "🌙",
+        "color": "#BA68C8",
         "paginas": [
           {
             "titulo": "Seccion 1",
@@ -51,6 +55,8 @@
       },
       {
         "nombre": "Eucaristía",
+        "emoji": "✝️",
+        "color": "#FF8A65",
         "paginas": [
           {
             "titulo": "Seccion 1",
@@ -131,6 +137,8 @@
       },
       {
         "nombre": "Oración al atardecer",
+        "emoji": "🌆",
+        "color": "#FFA726",
         "paginas": [
           {
             "titulo": "Seccion 1",
@@ -230,6 +238,8 @@
       },
       {
         "nombre": "Eucaristía final",
+        "emoji": "✝️",
+        "color": "#FF8A65",
         "paginas": [
           {
             "titulo": "Seccion 1",

--- a/mcm-app/components/DateSelector.tsx
+++ b/mcm-app/components/DateSelector.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { FlatList, TouchableOpacity, View, Text, StyleSheet } from 'react-native';
+import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+
+const MONTHS = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+const WEEKDAYS = ['domingo','lunes','martes','miércoles','jueves','viernes','sábado'];
+
+export interface DateOption { fecha: string; titulo?: string }
+
+interface Props {
+  dates: DateOption[];
+  selectedDate: string;
+  onSelectDate: (date: string, index: number) => void;
+}
+
+export default function DateSelector({ dates, selectedDate, onSelectDate }: Props) {
+  const renderItem = ({ item, index }: { item: DateOption; index: number }) => {
+    const date = new Date(item.fecha);
+    const label = `${date.getDate()} ${MONTHS[date.getMonth()]}`;
+    const weekday = WEEKDAYS[date.getDay()];
+    const selected = item.fecha === selectedDate;
+    return (
+      <TouchableOpacity onPress={() => onSelectDate(item.fecha, index)}>
+        <View style={[styles.item, selected && styles.itemSelected]}>
+          <Text style={[styles.dateText, selected && styles.textSelected]}>{label}</Text>
+          <Text style={[styles.weekdayText, selected && styles.textSelected]}>{weekday}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+  return (
+    <FlatList
+      data={dates}
+      keyExtractor={(d) => d.fecha}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.list}
+      renderItem={renderItem}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+  },
+  item: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 12,
+    backgroundColor: '#eeeeee',
+    marginRight: spacing.md,
+    alignItems: 'center',
+    minWidth: 90,
+  },
+  itemSelected: {
+    backgroundColor: colors.accent,
+  },
+  dateText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+  },
+  weekdayText: {
+    fontSize: 14,
+    textTransform: 'capitalize',
+    color: colors.text,
+  },
+  textSelected: {
+    color: colors.white,
+  },
+});

--- a/mcm-app/components/EventItem.tsx
+++ b/mcm-app/components/EventItem.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+
+export interface EventItemData {
+  nombre: string;
+  hora: string;
+  subtitulo?: string;
+  lugar?: string;
+  icono?: string;
+}
+
+export default function EventItem({ event }: { event: EventItemData }) {
+  return (
+    <Card style={styles.card}>
+      <Card.Content>
+        <View style={styles.row}>
+          {event.icono && <Text style={styles.emoji}>{event.icono}</Text>}
+          <View style={{ flex: 1 }}>
+            <Text style={styles.title}>{`${event.hora} - ${event.nombre}`}</Text>
+            {event.subtitulo && <Text style={styles.subtitle}>{event.subtitulo}</Text>}
+            {event.lugar && <Text style={styles.subtitle}>{event.lugar}</Text>}
+          </View>
+        </View>
+      </Card.Content>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing.md,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  emoji: {
+    fontSize: 24,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: colors.text,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.text,
+  },
+});


### PR DESCRIPTION
## Summary
- implement date selector component for jubileo sections
- add schedule UI with events list
- add materials list with link to pages slider
- create material pages slider screen
- include titles in schedule data and color/emoji info in materials data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68439b595ab08326a589ee243f143efe