### PR TITLE
Fix Jubileo home screen layout

### DIFF
--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, StyleSheet, Text, TouchableOpacity, FlatList, Dimensions, ViewStyle, TextStyle } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity, FlatList, useWindowDimensions, ViewStyle, TextStyle } from 'react-native';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Card } from 'react-native-paper';
@@ -14,31 +15,41 @@ interface NavigationItem {
   icon: string;
   target: keyof JubileoStackParamList;
   backgroundColor: string;
-  color: string;
 }
 
 const navigationItems: NavigationItem[] = [
-  { label: 'Horario', icon: '⏰', target: 'Horario', backgroundColor: '#FF8A65', color: colors.black },
-  { label: 'Materiales', icon: '📦', target: 'Materiales', backgroundColor: '#4FC3F7', color: colors.black },
-  { label: 'Visitas', icon: '🚌', target: 'Visitas', backgroundColor: '#81C784', color: colors.black },
-  { label: 'Profundiza', icon: '📖', target: 'Profundiza', backgroundColor: '#BA68C8', color: colors.black },
-  { label: 'Grupos', icon: '👥', target: 'Grupos', backgroundColor: '#FFD54F', color: colors.black },
+  { label: 'Horario', icon: '⏰', target: 'Horario', backgroundColor: '#FF8A65' },
+  { label: 'Materiales', icon: '📦', target: 'Materiales', backgroundColor: '#4FC3F7' },
+  { label: 'Visitas', icon: '🚌', target: 'Visitas', backgroundColor: '#81C784' },
+  { label: 'Profundiza', icon: '📖', target: 'Profundiza', backgroundColor: '#BA68C8' },
+  { label: 'Grupos', icon: '👥', target: 'Grupos', backgroundColor: '#FFD54F' },
 ];
-
-const { width } = Dimensions.get('window');
-const numColumns = width > 700 ? 3 : 2;
 
 export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
+  const scheme = useColorScheme();
+  const { width } = useWindowDimensions();
+
+  let numColumns = 2;
+  if (width >= 1100) {
+    numColumns = 4;
+  } else if (width >= 700) {
+    numColumns = 3;
+  }
+
+  const textColor = scheme === 'dark' ? colors.white : colors.black;
 
   const renderItem = ({ item }: { item: NavigationItem }) => (
-    <TouchableOpacity style={styles.item} onPress={() => {
-      navigation.navigate(item.target as any);
-    }}>
+    <TouchableOpacity
+      style={styles.item}
+      onPress={() => {
+        navigation.navigate(item.target as any);
+      }}
+    >
       <Card style={[styles.card, { backgroundColor: item.backgroundColor }]} elevation={2}>
         <Card.Content style={styles.cardContent}>
-          <Text style={[styles.iconPlaceholder, { color: item.color }]}>{item.icon}</Text>
-          <Text style={[styles.rectangleLabel, { color: item.color }]}>{item.label}</Text>
+          <Text style={[styles.iconPlaceholder, { color: textColor }]}>{item.icon}</Text>
+          <Text style={[styles.rectangleLabel, { color: textColor }]}>{item.label}</Text>
         </Card.Content>
       </Card>
     </TouchableOpacity>
@@ -50,12 +61,11 @@ export default function JubileoHomeScreen() {
       renderItem={renderItem}
       keyExtractor={(item) => item.label}
       numColumns={numColumns}
-      contentContainerStyle={styles.container}
-      /*ListHeaderComponent={
-        <View style={styles.headerWrapper}>
-          <Text style={styles.headerText}>¡Bienvenido al Jubileo!</Text>
-        </View>
-      }*/
+      key={numColumns.toString()}
+      contentContainerStyle={[
+        styles.container,
+        width >= 1100 && { alignSelf: 'center', maxWidth: 1200 },
+      ]}
     />
   );
 }


### PR DESCRIPTION
## Summary
- refactor JubileoHomeScreen
  - responsive column count using `useWindowDimensions`
  - dynamic text color based on theme
  - center content on very wide displays

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844e9d61b8083269142b9d7d5ceaa9d