### PR TITLE
Implement jubileo sections

### DIFF
--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -9,6 +9,7 @@ import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
 import ContactosScreen from '../screens/ContactosScreen';
 
+
 export type JubileoStackParamList = {
   Home: undefined;
   Horario: undefined;

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -7,6 +7,7 @@ import MaterialPagesScreen from '../screens/MaterialPagesScreen';
 import VisitasScreen from '../screens/VisitasScreen';
 import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
+import ContactosScreen from '../screens/ContactosScreen';
 
 export type JubileoStackParamList = {
   Home: undefined;
@@ -16,6 +17,7 @@ export type JubileoStackParamList = {
   Visitas: undefined;
   Profundiza: undefined;
   Grupos: undefined;
+  Contactos: undefined;
 };
 
 const Stack = createNativeStackNavigator<JubileoStackParamList>();
@@ -39,6 +41,7 @@ export default function JubileoTab() {
       <Stack.Screen name="Visitas" component={VisitasScreen} options={{ title: 'Visitas' }} />
       <Stack.Screen name="Profundiza" component={ProfundizaScreen} options={{ title: 'Profundiza' }} />
       <Stack.Screen name="Grupos" component={GruposScreen} options={{ title: 'Grupos' }} />
+      <Stack.Screen name="Contactos" component={ContactosScreen} options={{ title: 'Contactos' }} />
     </Stack.Navigator>
   );
 }

--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ScrollView, StyleSheet, View, Linking } from 'react-native';
+import { List, IconButton } from 'react-native-paper';
+import contacts from '@/assets/jubileo-contactos.json';
+import colors from '@/constants/colors';
+
+interface Contacto {
+  nombre: string;
+  responsabilidad: string;
+  telefono: string;
+}
+
+export default function ContactosScreen() {
+  const data = contacts as Contacto[];
+
+  const call = (tel: string) => Linking.openURL(`tel:${tel}`);
+  const whatsapp = (tel: string) => {
+    const clean = tel.replace('+', '');
+    Linking.openURL(`https://wa.me/${clean}`);
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      {data.map((c, idx) => (
+        <List.Item
+          key={idx}
+          title={c.nombre}
+          description={c.responsabilidad}
+          right={() => (
+            <View style={styles.actions}>
+              <IconButton icon="phone" size={24} onPress={() => call(c.telefono)} />
+              <IconButton
+                icon="whatsapp"
+                size={24}
+                onPress={() => whatsapp(c.telefono)}
+              />
+            </View>
+          )}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  actions: { flexDirection: 'row' },
+});

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -1,14 +1,79 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { List, IconButton, Text } from 'react-native-paper';
 import colors from '@/constants/colors';
+import gruposData from '@/assets/jubileo-grupos.json';
+
+interface Grupo {
+  nombre: string;
+  responsable?: string;
+  miembros: string[];
+  subtitulo?: string;
+}
+
+type Data = Record<string, Grupo[]>;
 
 export default function GruposScreen() {
-  return <View style={styles.container} />;
+  const data = gruposData as Data;
+  const categorias = ['Movilidad', 'Conso+', 'Autobuses'];
+  const [categoria, setCategoria] = useState<string | null>(null);
+  const [grupo, setGrupo] = useState<Grupo | null>(null);
+
+  if (!categoria) {
+    return (
+      <ScrollView style={styles.container}>
+        {categorias.map((c) => (
+          <List.Item key={c} title={c} onPress={() => setCategoria(c)} />
+        ))}
+      </ScrollView>
+    );
+  }
+
+  if (categoria && !grupo) {
+    return (
+      <ScrollView style={styles.container}>
+        <List.Item
+          title="Volver"
+          left={(props) => <IconButton {...props} icon="arrow-back" />}
+          onPress={() => setCategoria(null)}
+        />
+        {data[categoria].map((g, idx) => (
+          <List.Item
+            key={idx}
+            title={g.nombre}
+            description={g.subtitulo}
+            onPress={() => setGrupo(g)}
+          />
+        ))}
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <List.Item
+        title="Volver"
+        left={(props) => <IconButton {...props} icon="arrow-back" />}
+        onPress={() => setGrupo(null)}
+      />
+      {grupo && (
+        <View style={styles.groupContainer}>
+          <Text style={styles.groupTitle}>{grupo.nombre}</Text>
+          {grupo.responsable && (
+            <List.Item title="Responsable" description={grupo.responsable} />
+          )}
+          <List.Subheader>Miembros</List.Subheader>
+          {grupo.miembros.map((m, idx) => (
+            <List.Item key={idx} title={m} />
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
+  container: { flex: 1, backgroundColor: colors.background },
+  groupContainer: { paddingHorizontal: 16 },
+  groupTitle: { fontSize: 20, fontWeight: 'bold', marginVertical: 8 },
 });

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -24,6 +24,7 @@ const navigationItems: NavigationItem[] = [
   { label: 'Visitas', icon: '🚌', target: 'Visitas', backgroundColor: '#81C784' },
   { label: 'Profundiza', icon: '📖', target: 'Profundiza', backgroundColor: '#BA68C8' },
   { label: 'Grupos', icon: '👥', target: 'Grupos', backgroundColor: '#FFD54F' },
+  { label: 'Contactos', icon: '☎️', target: 'Contactos', backgroundColor: '#9FA8DA' },
 ];
 
 export default function JubileoHomeScreen() {
@@ -95,17 +96,18 @@ export default function JubileoHomeScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
-        contentContainerStyle={isMobile ? { alignItems: 'center' } : undefined}
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
         keyExtractor={(item, idx) => item.label + idx}
         numColumns={numColumns}
         key={numColumns.toString()}
-        contentContainerStyle={[ // si lo toco se rompe xdddd
+        contentContainerStyle={[
           styles.container,
+          isMobile && { alignItems: 'center' },
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
           width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
-        ]}        showsVerticalScrollIndicator={false}
+        ]}
+        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -96,18 +96,17 @@ export default function JubileoHomeScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
+        contentContainerStyle={isMobile ? { alignItems: 'center' } : undefined}
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
         keyExtractor={(item, idx) => item.label + idx}
         numColumns={numColumns}
         key={numColumns.toString()}
-        contentContainerStyle={[
+        contentContainerStyle={[ // si lo toco se rompe xdddd
           styles.container,
-          isMobile && { alignItems: 'center' },
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
           width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
-        ]}
-        showsVerticalScrollIndicator={false}
+        ]}        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
   content: { padding: 16 },
   mainTitle: { fontSize: 22, fontWeight: 'bold', marginBottom: 8 },
   intro: { fontSize: 14, marginBottom: 16 },
-  accordion: { marginBottom: 12 },
+  accordion: { marginBottom: 12, borderRadius: 16 },
   accordionTitle: { color: colors.white, fontWeight: 'bold' },
   subtitulo: { fontWeight: 'bold', marginBottom: 8 },
   texto: { marginBottom: 12 },

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -1,14 +1,51 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { List, Text } from 'react-native-paper';
 import colors from '@/constants/colors';
+import profundiza from '@/assets/jubileo-profundiza.json';
+
+interface Pagina {
+  titulo: string;
+  subtitulo?: string;
+  texto?: string;
+  color?: string;
+}
 
 export default function ProfundizaScreen() {
-  return <View style={styles.container} />;
+  const data = profundiza as {
+    titulo: string;
+    introduccion: string;
+    paginas: Pagina[];
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.mainTitle}>{data.titulo}</Text>
+      <Text style={styles.intro}>{data.introduccion}</Text>
+      <View style={{ marginTop: 16 }}>
+        {data.paginas.map((p, idx) => (
+          <List.Accordion
+            key={idx}
+            title={p.titulo}
+            titleStyle={styles.accordionTitle}
+            style={[styles.accordion, { backgroundColor: p.color || colors.primary }]}
+          >
+            {p.subtitulo && <Text style={styles.subtitulo}>{p.subtitulo}</Text>}
+            {p.texto && <Text style={styles.texto}>{p.texto}</Text>}
+          </List.Accordion>
+        ))}
+      </View>
+    </ScrollView>
+  );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: 16 },
+  mainTitle: { fontSize: 22, fontWeight: 'bold', marginBottom: 8 },
+  intro: { fontSize: 14, marginBottom: 16 },
+  accordion: { marginBottom: 12 },
+  accordionTitle: { color: colors.white, fontWeight: 'bold' },
+  subtitulo: { fontWeight: 'bold', marginBottom: 8 },
+  texto: { marginBottom: 12 },
 });

--- a/mcm-app/app/screens/VisitasScreen.tsx
+++ b/mcm-app/app/screens/VisitasScreen.tsx
@@ -1,14 +1,134 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  Linking,
+  Image,
+} from 'react-native';
+import { Card, IconButton, Modal, Portal, Text } from 'react-native-paper';
 import colors from '@/constants/colors';
+import visitas from '@/assets/jubileo-visitas.json';
+
+interface Visita {
+  titulo: string;
+  subtitulo?: string;
+  fecha?: string;
+  imagen?: string;
+  texto?: string;
+  mapa?: string;
+}
+
+const MONTHS = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+];
+const WEEKDAYS = [
+  'domingo',
+  'lunes',
+  'martes',
+  'miércoles',
+  'jueves',
+  'viernes',
+  'sábado',
+];
+
+function formatDate(fecha?: string) {
+  if (!fecha) return '';
+  const d = new Date(fecha);
+  if (isNaN(d.getTime())) return fecha; // if string not parseable, return as is
+  return `${WEEKDAYS[d.getDay()]} ${d.getDate()} ${MONTHS[d.getMonth()]}`;
+}
 
 export default function VisitasScreen() {
-  return <View style={styles.container} />;
+  const [selected, setSelected] = useState<Visita | null>(null);
+
+  const openMap = (url?: string) => {
+    if (url) Linking.openURL(url);
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.list}>
+        {(visitas as Visita[]).map((v, idx) => (
+          <Card key={idx} style={styles.card} onPress={() => setSelected(v)}>
+            {v.imagen && (
+              <Image
+                source={{ uri: v.imagen }}
+                style={styles.image}
+                resizeMode="cover"
+              />
+            )}
+            <Card.Content style={styles.cardContent}>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.title}>{v.titulo}</Text>
+                {v.subtitulo && <Text style={styles.subtitle}>{v.subtitulo}</Text>}
+                {v.fecha && (
+                  <View style={styles.dateRow}>
+                    <IconButton icon="calendar-today" size={18} />
+                    <Text>{formatDate(v.fecha)}</Text>
+                  </View>
+                )}
+              </View>
+              {v.mapa && (
+                <IconButton
+                  icon="map"
+                  onPress={() => openMap(v.mapa)}
+                  accessibilityLabel="Abrir mapa"
+                />
+              )}
+            </Card.Content>
+          </Card>
+        ))}
+      </ScrollView>
+      <Portal>
+        <Modal
+          visible={!!selected}
+          onDismiss={() => setSelected(null)}
+          contentContainerStyle={styles.modal}
+        >
+          {selected && (
+            <View>
+              <Text style={styles.modalTitle}>{selected.titulo}</Text>
+              {selected.texto && <Text style={styles.modalText}>{selected.texto}</Text>}
+              {selected.mapa && (
+                <View style={{ alignItems: 'flex-end' }}>
+                  <IconButton icon="map" onPress={() => openMap(selected.mapa)} />
+                </View>
+              )}
+            </View>
+          )}
+        </Modal>
+      </Portal>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
+  container: { flex: 1, backgroundColor: colors.background },
+  list: { padding: 16 },
+  card: { marginBottom: 16 },
+  image: { width: '100%', height: 160 },
+  cardContent: { flexDirection: 'row', alignItems: 'center' },
+  title: { fontSize: 16, fontWeight: 'bold', marginBottom: 4 },
+  subtitle: { fontSize: 14, marginBottom: 4 },
+  dateRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  modal: {
+    backgroundColor: 'white',
+    margin: 20,
+    padding: 20,
+    borderRadius: 8,
   },
+  modalTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
+  modalText: { fontSize: 14, marginBottom: 12 },
 });

--- a/mcm-app/app/screens/VisitasScreen.tsx
+++ b/mcm-app/app/screens/VisitasScreen.tsx
@@ -118,7 +118,15 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
   list: { padding: 16 },
   card: { marginBottom: 16 },
-  image: { width: '100%', height: 160 },
+  image: {
+    width: '100%',
+    height: 160,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    marginBottom: 16, // spacing below image
+  },
   cardContent: { flexDirection: 'row', alignItems: 'center' },
   title: { fontSize: 16, fontWeight: 'bold', marginBottom: 4 },
   subtitle: { fontSize: 14, marginBottom: 4 },

--- a/mcm-app/assets/jubileo-visitas.json
+++ b/mcm-app/assets/jubileo-visitas.json
@@ -3,7 +3,7 @@
     "titulo": "Catedral de San Ejemplo",
     "subtitulo": "Historia viva de la ciudad",
     "fecha": "2025-08-01",
-    "imagen": "catedral.jpg",
+    "imagen": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Palencia_Cathedral_2023_-_South_Fa%C3%A7ade.jpg/960px-Palencia_Cathedral_2023_-_South_Fa%C3%A7ade.jpg",
     "texto": "Durante esta visita conoceremos la arquitectura gótica de la catedral y su influencia en la comunidad local. También tendremos un espacio para la oración personal en la capilla del silencio.",
     "mapa": "https://maps.google.com/?q=Catedral+de+San+Ejemplo"
   },
@@ -11,7 +11,7 @@
     "titulo": "Ruta de los Mártires",
     "subtitulo": "Recorrido por lugares emblemáticos",
     "fecha": "2025-07-31",
-    "imagen": "ruta_martires.jpg",
+    "imagen": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTG8Hofzk6IfqmyIDuGupkhnaW3H1hcvqQUsg&s",
     "texto": "Caminaremos por distintos puntos donde la historia de la fe dejó huella. Será un tiempo para recordar y agradecer el testimonio de tantos creyentes.",
     "mapa": "https://maps.google.com/?q=Ruta+de+los+Martires"
   }


### PR DESCRIPTION
## Summary
- implement Visitas list with popup and map links
- add Profundiza accordion pages
- add dynamic group browsing and contacts list
- expose Contactos in navigation
- update Jubileo home menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845780708108326b33c7d3c9f9d94af