### PR TITLE
Improve dark mode experience

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -4,7 +4,7 @@ import { MaterialIcons } from '@expo/vector-icons'; // Asegúrate de tenerlo imp
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import colors from '@/constants/colors'; //
+import colors, { Colors } from '@/constants/colors'; //
 
 export default function TabsLayout() {
   const scheme = useColorScheme(); //
@@ -20,9 +20,9 @@ export default function TabsLayout() {
             fontWeight: 'bold',
           },
           headerTitleAlign: 'center', // Center the title
-          tabBarActiveTintColor: colors.primary, //
-          tabBarInactiveTintColor: colors.secondary, //
-          tabBarStyle: { backgroundColor: colors.background }, //
+          tabBarActiveTintColor: Colors[scheme ?? 'light'].tint,
+          tabBarInactiveTintColor: Colors[scheme ?? 'light'].icon,
+          tabBarStyle: { backgroundColor: Colors[scheme ?? 'light'].background },
         }}
       >
         <Tabs.Screen
@@ -76,7 +76,7 @@ export default function TabsLayout() {
         />
       </Tabs>
     
-      <StatusBar style="auto" />
+      <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
     </ThemeProvider>
   );
 }

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -60,6 +60,15 @@ export default function Calendario() {
         markedDates={markedDates}
         markingType="multi-dot"
         style={styles.calendar}
+        theme={{
+          calendarBackground: Colors[scheme ?? 'light'].background,
+          dayTextColor: Colors[scheme ?? 'light'].text,
+          monthTextColor: Colors[scheme ?? 'light'].text,
+          textSectionTitleColor: Colors[scheme ?? 'light'].text,
+          selectedDayBackgroundColor: colors.primary,
+          selectedDayTextColor: colors.white,
+          arrowColor: Colors[scheme ?? 'light'].tint,
+        }}
       />
       <View style={styles.checkboxContainer}>
         {calendarConfigs.map((cal, idx) => (
@@ -169,7 +178,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
   },
   eventLocation: {
     ...typography.body,
-    color: colors.secondary,
+    color: theme.icon,
   },
   noEvents: {
     ...typography.body,

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -3,7 +3,8 @@ import React, { useState, useMemo } from 'react';
 import { View, StyleSheet, ScrollView, ViewStyle, TextStyle } from 'react-native';
 import { Calendar, CalendarProps } from 'react-native-calendars';
 import { Checkbox, Text } from 'react-native-paper';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 import useCalendarEvents, { CalendarConfig, CalendarEvent } from '@/hooks/useCalendarEvents';
@@ -22,6 +23,8 @@ const calendarConfigs: CalendarConfig[] = [
 ];
 
 export default function Calendario() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const [visibleCalendars, setVisibleCalendars] = useState<boolean[]>(calendarConfigs.map(() => true));
   const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().split('T')[0]);
   const { eventsByDate } = useCalendarEvents(calendarConfigs);
@@ -109,11 +112,13 @@ interface Styles {
   noEvents: TextStyle;
 }
 
-const styles = StyleSheet.create<Styles>({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create<Styles>({
+    container: {
+      flex: 1,
+      backgroundColor: theme.background,
+    },
   calendar: {
     marginBottom: spacing.md,
   },
@@ -132,7 +137,7 @@ const styles = StyleSheet.create<Styles>({
   },
   checkboxLabel: {
     ...typography.body,
-    color: colors.text,
+    color: theme.text,
   },
   eventList: {
     paddingHorizontal: spacing.md,
@@ -140,7 +145,7 @@ const styles = StyleSheet.create<Styles>({
   },
   eventListTitle: {
     ...typography.h2,
-    color: colors.text,
+    color: theme.text,
     marginBottom: spacing.sm,
     fontWeight: 'bold',
   },
@@ -160,7 +165,7 @@ const styles = StyleSheet.create<Styles>({
   },
   eventTitle: {
     ...typography.body,
-    color: colors.text,
+    color: theme.text,
   },
   eventLocation: {
     ...typography.body,
@@ -168,7 +173,8 @@ const styles = StyleSheet.create<Styles>({
   },
   noEvents: {
     ...typography.body,
-    color: colors.text,
+    color: theme.text,
     fontStyle: 'italic',
   },
-});
+  });
+};

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -5,6 +5,7 @@ import { Button, ActivityIndicator } from 'react-native-paper';
 import AlbumCard from '@/components/AlbumCard';
 import allAlbumsData from '@/assets/albums.json';
 import { Colors as ThemeColors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 const ALBUMS_PER_PAGE = 4;
 
@@ -28,6 +29,8 @@ interface FotosScreenStyles {
 
 export default function FotosScreen() {
   const { width } = useWindowDimensions();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const [displayedAlbums, setDisplayedAlbums] = useState<Album[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [allAlbumsLoaded, setAllAlbumsLoaded] = useState<boolean>(false);
@@ -126,11 +129,13 @@ export default function FotosScreen() {
   );
 }
 
-const styles = StyleSheet.create<FotosScreenStyles>({
-  container: {
-    flex: 1,
-    backgroundColor: ThemeColors.light.background,
-  },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = ThemeColors[scheme ?? 'light'];
+  return StyleSheet.create<FotosScreenStyles>({
+    container: {
+      flex: 1,
+      backgroundColor: theme.background,
+    },
 
   listContentContainer: {
     paddingTop: 15,
@@ -149,6 +154,7 @@ const styles = StyleSheet.create<FotosScreenStyles>({
   loadMoreButton: {
     marginVertical: 20,
     alignSelf: 'center',
-    backgroundColor: ThemeColors.light.tint,
+    backgroundColor: theme.tint,
   },
-});
+  });
+};

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -4,7 +4,8 @@ import { Link, LinkProps } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Badge } from 'react-native-paper';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 
@@ -65,6 +66,7 @@ function SettingsButton() {
 
 export default function Home() {
   const navigation = useNavigation();
+  const scheme = useColorScheme();
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -80,6 +82,7 @@ export default function Home() {
 
   return (
     <FlatList
+      style={{ backgroundColor: Colors[scheme ?? 'light'].background }}
       data={navigationItems}
       keyExtractor={(_, index) => index.toString()}
       numColumns={2}

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -26,23 +26,27 @@ const navigationItems: NavigationItem[] = [
   { label: 'Y mas cosas....', icon: 'hourglass-empty', backgroundColor: colors.danger, color: colors.black },
 ];
 
-function NotificationsButton() {
+interface IconButtonProps { color: string }
+
+function NotificationsButton({ color }: IconButtonProps) {
   return (
     <Link href="/notifications" asChild>
       <TouchableOpacity style={{ padding: 8, marginLeft: 4 }}>
         <View>
-          <MaterialIcons name="notifications" size={24} color={colors.primary} />
-          <View style={{
-            position: 'absolute',
-            right: -4,
-            top: -2,
-            backgroundColor: colors.danger,
-            borderRadius: 8,
-            width: 16,
-            height: 16,
-            justifyContent: 'center',
-            alignItems: 'center'
-          }}>
+          <MaterialIcons name="notifications" size={24} color={color} />
+          <View
+            style={{
+              position: 'absolute',
+              right: -4,
+              top: -2,
+              backgroundColor: colors.danger,
+              borderRadius: 8,
+              width: 16,
+              height: 16,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
             <Text style={{ color: 'white', fontSize: 10, fontWeight: 'bold' }}>1</Text>
           </View>
         </View>
@@ -51,7 +55,7 @@ function NotificationsButton() {
   );
 }
 
-function SettingsButton() {
+function SettingsButton({ color }: IconButtonProps) {
   const handlePress = () => {
     // Mostrar un alert temporal
     alert('Configuración: Próximamente...');
@@ -59,7 +63,7 @@ function SettingsButton() {
 
   return (
     <TouchableOpacity onPress={handlePress} style={{ padding: 8, marginLeft: 0 }}>
-      <MaterialIcons name="settings" size={24} color={colors.primary} />
+      <MaterialIcons name="settings" size={24} color={color} />
     </TouchableOpacity>
   );
 }
@@ -72,13 +76,13 @@ export default function Home() {
     navigation.setOptions({
       headerRight: () => (
         <View style={[styles.headerButtons, { paddingRight: spacing.md }]}>
-          <SettingsButton />
-          <NotificationsButton />
+          <SettingsButton color={Colors[scheme ?? 'light'].icon} />
+          <NotificationsButton color={Colors[scheme ?? 'light'].icon} />
         </View>
       ),
       title: 'Inicio',
     });
-  }, [navigation]);
+  }, [navigation, scheme]);
 
   return (
     <FlatList

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -12,7 +12,7 @@ export type JubileoStackParamList = {
   Home: undefined;
   Horario: undefined;
   Materiales: undefined;
-  MaterialPages: { actividad: any };
+  MaterialPages: { actividad: any; fecha: string };
   Visitas: undefined;
   Profundiza: undefined;
   Grupos: undefined;

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -141,7 +141,7 @@ export default function RootLayout() {
       <PaperProvider theme={paperTheme}>
         <NavThemeProvider value={navigationTheme}>
           <Slot />
-          <StatusBar style="auto" />
+          <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
         </NavThemeProvider>
       </PaperProvider>
     </GestureHandlerRootView>

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -17,7 +17,7 @@ export default function NotificationsScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: Colors[scheme ?? 'light'].background }]}>
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
+          <Ionicons name="arrow-back" size={24} color={Colors[scheme ?? 'light'].text} />
         </TouchableOpacity>
         <Text style={styles.title}>Notificaciones</Text>
         <View style={styles.headerRight} />
@@ -25,7 +25,7 @@ export default function NotificationsScreen() {
 
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.emptyState}>
-          <MaterialIcons name="notifications-none" size={64} color={colors.secondary} />
+          <MaterialIcons name="notifications-none" size={64} color={Colors[scheme ?? 'light'].icon} />
           <Text style={styles.emptyTitle}>No hay notificaciones</Text>
           <Text style={styles.emptyText}>
             Aquí aparecerán tus notificaciones cuando las tengas.
@@ -63,6 +63,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     fontSize: 18, // Tamaño más pequeño que h1
     flex: 1,
     textAlign: 'center',
+    color: theme.text,
   },
   content: {
     flexGrow: 1,
@@ -79,12 +80,12 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     marginTop: spacing.lg,
     marginBottom: spacing.sm,
     textAlign: 'center',
-    color: colors.text,
+    color: theme.text,
   },
   emptyText: {
     ...(typography.body as any),
     textAlign: 'center',
-    color: colors.secondary, // Usando secondary en lugar de textSecondary
+    color: theme.icon,
     lineHeight: 22,
   },
   });

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -3,15 +3,18 @@ import { View, StyleSheet, Text, ScrollView, TouchableOpacity } from 'react-nati
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 
 export default function NotificationsScreen() {
   const navigation = useNavigation();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={[styles.container, { backgroundColor: Colors[scheme ?? 'light'].background }]}>
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
           <Ionicons name="arrow-back" size={24} color="black" />
@@ -34,19 +37,21 @@ export default function NotificationsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-    backgroundColor: colors.background,
-  },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.background,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+      backgroundColor: theme.background,
+    },
   backButton: {
     marginRight: spacing.md,
   },
@@ -82,4 +87,5 @@ const styles = StyleSheet.create({
     color: colors.secondary, // Usando secondary en lugar de textSecondary
     lineHeight: 22,
   },
-});
+  });
+};

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import horarioData from '@/assets/jubileo-horario.json';
 import DateSelector from '@/components/DateSelector';
@@ -8,6 +9,8 @@ import EventItem from '@/components/EventItem';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function HorarioScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const [index, setIndex] = useState(0);
   const fechas = horarioData.map((d) => ({ fecha: d.fecha, titulo: d.titulo }));
   const dia = horarioData[index];
@@ -31,11 +34,13 @@ export default function HorarioScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.background,
+    },
   titleWrapper: {
     backgroundColor: colors.danger,
     marginHorizontal: spacing.lg,
@@ -53,4 +58,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingBottom: spacing.lg,
   },
-});
+  });
+};

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Card } from 'react-native-paper';
 
-import colors, { Colors } from '@/constants/colors';
+import colors from '@/constants/colors';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
@@ -29,7 +29,6 @@ const navigationItems: NavigationItem[] = [
 export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const { width } = useWindowDimensions();
 
   let numColumns = 2;
@@ -94,7 +93,7 @@ export default function JubileoHomeScreen() {
   const isMobile = width < 700;
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[scheme ?? 'light'].background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
@@ -102,9 +101,9 @@ export default function JubileoHomeScreen() {
         numColumns={numColumns}
         key={numColumns.toString()}
         contentContainerStyle={[
-          isMobile ? { alignItems: 'center' } : undefined,
           styles.container,
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
+          isMobile && { alignItems: 'center' },
           width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
         ]}
         showsVerticalScrollIndicator={false}
@@ -124,13 +123,11 @@ interface Styles {
   rectangleLabel: TextStyle;
 }
 
-const createStyles = (scheme: 'light' | 'dark' | null) => {
-  const theme = Colors[scheme ?? 'light'];
-  return StyleSheet.create<Styles>({
-    container: {
-      backgroundColor: theme.background,
-      // padding eliminado para evitar espacio en blanco excesivo
-    },
+const styles = StyleSheet.create<Styles>({
+  container: {
+    backgroundColor: colors.background,
+    // padding eliminado para evitar espacio en blanco excesivo
+  },
   item: {
     flex: 1,
     margin: spacing.sm,
@@ -158,7 +155,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     fontSize: 22,
     fontWeight: 'bold',
     textAlign: 'center',
-    color: theme.text,
+    color: colors.text,
   },
   iconPlaceholder: {
     fontWeight: 'bold',
@@ -175,5 +172,4 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     letterSpacing: 0.5,
     marginTop: 2,
   },
-  });
-};
+});

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Card } from 'react-native-paper';
 
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
@@ -29,6 +29,7 @@ const navigationItems: NavigationItem[] = [
 export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
   const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const { width } = useWindowDimensions();
 
   let numColumns = 2;
@@ -93,19 +94,20 @@ export default function JubileoHomeScreen() {
   const isMobile = width < 700;
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[scheme ?? 'light'].background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
-        contentContainerStyle={isMobile ? { alignItems: 'center' } : undefined}
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
         keyExtractor={(item, idx) => item.label + idx}
         numColumns={numColumns}
         key={numColumns.toString()}
-        contentContainerStyle={[ // si lo toco se rompe xdddd
+        contentContainerStyle={[
+          isMobile ? { alignItems: 'center' } : undefined,
           styles.container,
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
           width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
-        ]}        showsVerticalScrollIndicator={false}
+        ]}
+        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );
@@ -122,11 +124,13 @@ interface Styles {
   rectangleLabel: TextStyle;
 }
 
-const styles = StyleSheet.create<Styles>({
-  container: {
-    backgroundColor: colors.background,
-    // padding eliminado para evitar espacio en blanco excesivo
-  },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create<Styles>({
+    container: {
+      backgroundColor: theme.background,
+      // padding eliminado para evitar espacio en blanco excesivo
+    },
   item: {
     flex: 1,
     margin: spacing.sm,
@@ -154,7 +158,7 @@ const styles = StyleSheet.create<Styles>({
     fontSize: 22,
     fontWeight: 'bold',
     textAlign: 'center',
-    color: colors.text,
+    color: theme.text,
   },
   iconPlaceholder: {
     fontWeight: 'bold',
@@ -171,4 +175,5 @@ const styles = StyleSheet.create<Styles>({
     letterSpacing: 0.5,
     marginTop: 2,
   },
-});
+  });
+};

--- a/mcm-app/app/screens/MaterialesScreen.tsx
+++ b/mcm-app/app/screens/MaterialesScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity, Text } from 'react-native';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import materialesData from '@/assets/jubileo-materiales.json';
 import DateSelector from '@/components/DateSelector';
@@ -19,6 +20,8 @@ type Nav = NativeStackNavigationProp<JubileoStackParamList, 'MaterialPages'>;
 
 export default function MaterialesScreen() {
   const navigation = useNavigation<Nav>();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const [index, setIndex] = useState(0);
   const fechas = materialesData.map((d) => ({ fecha: d.fecha }));
   const dia = materialesData[index];
@@ -31,7 +34,7 @@ export default function MaterialesScreen() {
           <TouchableOpacity
             key={idx}
             style={[styles.card, { backgroundColor: act.color || colors.primary }]}
-            onPress={() => navigation.navigate('MaterialPages', { actividad: act })}
+            onPress={() => navigation.navigate('MaterialPages', { actividad: act, fecha: dia.fecha })}
           >
             <Text style={styles.emoji}>{act.emoji}</Text>
             <Text style={styles.cardText}>{act.nombre.toUpperCase()}</Text>
@@ -42,26 +45,29 @@ export default function MaterialesScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background },
-  list: {
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.lg,
-  },
-  card: {
-    borderRadius: 12,
-    paddingVertical: spacing.xl,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: spacing.md,
-  },
-  emoji: {
-    fontSize: 40,
-    marginBottom: spacing.sm,
-  },
-  cardText: {
-    color: colors.white,
-    fontWeight: 'bold',
-    fontSize: 18,
-  },
-});
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.background },
+    list: {
+      paddingHorizontal: spacing.lg,
+      paddingBottom: spacing.lg,
+    },
+    card: {
+      borderRadius: 12,
+      paddingVertical: spacing.xl,
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: spacing.md,
+    },
+    emoji: {
+      fontSize: 40,
+      marginBottom: spacing.sm,
+    },
+    cardText: {
+      color: colors.white,
+      fontWeight: 'bold',
+      fontSize: 18,
+    },
+  });
+};

--- a/mcm-app/constants/colors.ts
+++ b/mcm-app/constants/colors.ts
@@ -18,7 +18,7 @@ export const Colors = {
   },
   dark: {
     text: '#FFFFFF',
-    background: '#1C1C1E',
+    background: '#2C2C2E',
     tint: tintColorDark,
     icon: '#C5C5C7',
     tabIconDefault: '#C5C5C7',


### PR DESCRIPTION
## Summary
- lighten dark theme colors
- adapt tab bar styling to theme
- tweak status bar style
- add dark mode support to calendar, photos, notifications and jubilee screens
- refine materials pages layout and intro text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684561064c3483269dd91ecc3d4252ad