### PR TITLE
Implement jubileo group and profundiza improvements

### DIFF
--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -7,6 +7,7 @@ import MaterialPagesScreen from '../screens/MaterialPagesScreen';
 import VisitasScreen from '../screens/VisitasScreen';
 import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
+import ContactosScreen from '../screens/ContactosScreen';
 
 export type JubileoStackParamList = {
   Home: undefined;
@@ -16,6 +17,7 @@ export type JubileoStackParamList = {
   Visitas: undefined;
   Profundiza: undefined;
   Grupos: undefined;
+  Contactos: undefined;
 };
 
 const Stack = createNativeStackNavigator<JubileoStackParamList>();
@@ -39,6 +41,7 @@ export default function JubileoTab() {
       <Stack.Screen name="Visitas" component={VisitasScreen} options={{ title: 'Visitas' }} />
       <Stack.Screen name="Profundiza" component={ProfundizaScreen} options={{ title: 'Profundiza' }} />
       <Stack.Screen name="Grupos" component={GruposScreen} options={{ title: 'Grupos' }} />
+      <Stack.Screen name="Contactos" component={ContactosScreen} options={{ title: 'Contactos' }} />
     </Stack.Navigator>
   );
 }

--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Linking } from 'react-native';
+import { Card } from 'react-native-paper';
+import contactsData from '@/assets/jubileo-contactos.json';
+import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import { ThemedText } from '@/components/ThemedText';
+
+interface Contacto {
+  nombre: string;
+  responsabilidad: string;
+  telefono: string;
+}
+
+export default function ContactosScreen() {
+  const contactos: Contacto[] = contactsData as Contacto[];
+
+  const handlePress = (telefono: string) => {
+    Linking.openURL(`tel:${telefono}`);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {contactos.map((c, idx) => (
+        <Card key={idx} style={styles.card} onPress={() => handlePress(c.telefono)}>
+          <Card.Title
+            title={<ThemedText style={styles.title}>{c.nombre}</ThemedText>}
+            subtitle={<ThemedText style={styles.subtitle}>{c.responsabilidad}</ThemedText>}
+            right={() => <ThemedText style={styles.phone}>{c.telefono}</ThemedText>}
+          />
+        </Card>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: spacing.lg,
+    backgroundColor: colors.background,
+  },
+  card: {
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: colors.text,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: colors.text,
+  },
+  phone: {
+    fontSize: 16,
+    color: colors.accent,
+    marginRight: spacing.md,
+  },
+});

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -1,14 +1,84 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { Collapsible } from '@/components/Collapsible';
+import groupsData from '@/assets/jubileo-grupos.json';
 import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+
+interface Grupo {
+  nombre: string;
+  responsable: string;
+  miembros: string[];
+  subtitulo?: string;
+}
 
 export default function GruposScreen() {
-  return <View style={styles.container} />;
+  const categorias = Object.keys(groupsData) as Array<keyof typeof groupsData>;
+  const [openCat, setOpenCat] = useState<string | null>(null);
+  const [openGroup, setOpenGroup] = useState<string | null>(null);
+
+  const total = categorias.reduce(
+    (sum, c) =>
+      sum + (groupsData as any)[c].reduce((s: number, g: Grupo) => s + g.miembros.length, 0),
+    0
+  );
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <ThemedText style={styles.total}>{`Total participantes: ${total}`}</ThemedText>
+      {categorias.map((cat) => {
+        const grupos: Grupo[] = (groupsData as any)[cat] as Grupo[];
+        const catCount = grupos.reduce((s, g) => s + g.miembros.length, 0);
+        return (
+          <Collapsible
+            key={cat}
+            title={`${cat} (${catCount})`}
+            isOpen={openCat === cat}
+            onToggle={(open) => {
+              setOpenCat(open ? cat : null);
+              setOpenGroup(null);
+            }}
+          >
+            {grupos.map((g, idx) => (
+              <Collapsible
+                key={idx}
+                title={`${g.nombre} - ${g.responsable} (${g.miembros.length})`}
+                isOpen={openGroup === `${cat}-${idx}`}
+                onToggle={(open) => setOpenGroup(open ? `${cat}-${idx}` : null)}
+              >
+                {g.subtitulo && <ThemedText style={styles.subtitle}>{g.subtitulo}</ThemedText>}
+                {g.miembros.map((m, i) => (
+                  <ThemedText key={i} style={styles.member}>{m}</ThemedText>
+                ))}
+              </Collapsible>
+            ))}
+          </Collapsible>
+        );
+      })}
+    </ScrollView>
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    padding: spacing.lg,
     backgroundColor: colors.background,
+  },
+  total: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: spacing.lg,
+    color: colors.text,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+    color: colors.text,
+  },
+  member: {
+    fontSize: 15,
+    color: colors.text,
   },
 });

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -24,6 +24,7 @@ const navigationItems: NavigationItem[] = [
   { label: 'Visitas', icon: '🚌', target: 'Visitas', backgroundColor: '#81C784' },
   { label: 'Profundiza', icon: '📖', target: 'Profundiza', backgroundColor: '#BA68C8' },
   { label: 'Grupos', icon: '👥', target: 'Grupos', backgroundColor: '#FFD54F' },
+  { label: 'Contactos', icon: '📞', target: 'Contactos', backgroundColor: '#64B5F6' },
 ];
 
 export default function JubileoHomeScreen() {

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -1,14 +1,52 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { Collapsible } from '@/components/Collapsible';
 import colors from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import profundizaData from '@/assets/jubileo-profundiza.json';
+
+interface Pagina {
+  titulo: string;
+  texto: string;
+  subtitulo?: string;
+  color?: string;
+}
 
 export default function ProfundizaScreen() {
-  return <View style={styles.container} />;
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const paginas: Pagina[] = (profundizaData as any).paginas as Pagina[];
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <ThemedText style={styles.intro}>{(profundizaData as any).introduccion}</ThemedText>
+      {paginas.map((p, idx) => (
+        <Collapsible
+          key={idx}
+          title={p.titulo}
+          isOpen={openIndex === idx}
+          onToggle={(value) => setOpenIndex(value ? idx : null)}
+        >
+          <ThemedText style={styles.text}>{p.texto}</ThemedText>
+        </Collapsible>
+      ))}
+    </ScrollView>
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    padding: spacing.lg,
     backgroundColor: colors.background,
+  },
+  intro: {
+    fontSize: 17,
+    textAlign: 'justify',
+    marginBottom: spacing.lg,
+    color: colors.text,
+  },
+  text: {
+    fontSize: 16,
+    color: colors.text,
   },
 });

--- a/mcm-app/components/Collapsible.tsx
+++ b/mcm-app/components/Collapsible.tsx
@@ -8,15 +8,29 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
-export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
-  const [isOpen, setIsOpen] = useState(false);
+export function Collapsible({
+  children,
+  title,
+  isOpen: controlledOpen,
+  onToggle,
+}: PropsWithChildren & { title: string; isOpen?: boolean; onToggle?: (open: boolean) => void }) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = controlledOpen ?? internalOpen;
   const theme = useColorScheme() ?? 'light';
+
+  const toggle = () => {
+    const newValue = !isOpen;
+    if (controlledOpen === undefined) {
+      setInternalOpen(newValue);
+    }
+    onToggle?.(newValue);
+  };
 
   return (
     <ThemedView>
       <TouchableOpacity
         style={styles.heading}
-        onPress={() => setIsOpen((value) => !value)}
+        onPress={toggle}
         activeOpacity={0.8}>
         <IconSymbol
           name="chevron.right"
@@ -28,7 +42,14 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
 
         <ThemedText type="defaultSemiBold">{title}</ThemedText>
       </TouchableOpacity>
-      {isOpen && <ThemedView style={styles.content}>{children}</ThemedView>}
+      {isOpen && (
+        <ThemedView style={[
+          styles.content,
+          { borderColor: theme === 'light' ? Colors.light.border : Colors.dark.shadow }
+        ]}>
+          {children}
+        </ThemedView>
+      )}
     </ThemedView>
   );
 }
@@ -37,10 +58,14 @@ const styles = StyleSheet.create({
   heading: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.sm, // Use spacing.sm for gap
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
   },
   content: {
-    marginTop: spacing.sm, // Use spacing.sm for marginTop
-    marginLeft: spacing.lg, // Use spacing.lg for marginLeft
+    marginTop: spacing.sm,
+    marginLeft: spacing.lg,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderRadius: 8,
   },
 });


### PR DESCRIPTION
## Summary
- add collapsible props and borders
- implement grupos listing with counts
- make profundiza section use collapsible items
- show contact list screen
- link new screen from the jubileo stack and home

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68457d6435b48326b6067040dafb3441