### PR TITLE
Fix swipe transitions and chord notation

### DIFF
--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -1,9 +1,10 @@
 import { FlatList, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useLayoutEffect, useMemo } from 'react';
 import songsData from '../../assets/songs.json';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { useMemo } from 'react';
 import { Colors } from '@/constants/colors';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 const ALL_SONGS_CATEGORY_ID = '__ALL__';
 const ALL_SONGS_CATEGORY_NAME = '🔎 Buscar una canción...';
@@ -24,10 +25,27 @@ export default function CategoriesScreen({
   const styles = useMemo(() => createStyles(scheme), [scheme]);
   const actualCategories = Object.keys(songsData);
   const displayCategories = [
-    { id: ALL_SONGS_CATEGORY_ID, name: ALL_SONGS_CATEGORY_NAME },
-    { id: SELECTED_SONGS_CATEGORY_ID, name: SELECTED_SONGS_CATEGORY_NAME }, // Added new category
+    { id: SELECTED_SONGS_CATEGORY_ID, name: SELECTED_SONGS_CATEGORY_NAME },
     ...actualCategories.map(cat => ({ id: cat, name: `${cat}` }))
   ];
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('SongsList', {
+              categoryId: ALL_SONGS_CATEGORY_ID,
+              categoryName: ALL_SONGS_CATEGORY_NAME,
+            })
+          }
+          style={{ paddingHorizontal: 12 }}
+        >
+          <MaterialIcons name="search" size={26} color="#fff" />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation]);
 
   return (
     <FlatList

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { View, StyleSheet, Text, TouchableOpacity, FlatList, useWindowDimensions, ViewStyle, TextStyle } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useColorScheme } from '@/hooks/useColorScheme';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Card } from 'react-native-paper';
 
 import colors from '@/constants/colors';
 import spacing from '@/constants/spacing';
@@ -28,7 +26,6 @@ const navigationItems: NavigationItem[] = [
 
 export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
-  const scheme = useColorScheme();
   const { width } = useWindowDimensions();
 
   let numColumns = 2;
@@ -95,17 +92,23 @@ export default function JubileoHomeScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
-        contentContainerStyle={isMobile ? { alignItems: 'center' } : undefined}
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
         keyExtractor={(item, idx) => item.label + idx}
         numColumns={numColumns}
         key={numColumns.toString()}
-        contentContainerStyle={[ // si lo toco se rompe xdddd
+        contentContainerStyle={[
+          isMobile ? { alignItems: 'center' } : null,
           styles.container,
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
-          width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
-        ]}        showsVerticalScrollIndicator={false}
+          width >= 1100 && {
+            alignSelf: 'center',
+            maxWidth: 1200,
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+          },
+        ]}
+        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -172,7 +172,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   const handleSwipeLeft = () => {
     if (navigationList && typeof currentIndex === 'number' && currentIndex > 0) {
       const prevSong = navigationList[currentIndex - 1];
-      navigation.replace('SongDetail', {
+      navigation.setParams({
         ...prevSong,
         navigationList,
         currentIndex: currentIndex - 1,
@@ -188,7 +188,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
       currentIndex < navigationList.length - 1
     ) {
       const nextSong = navigationList[currentIndex + 1];
-      navigation.replace('SongDetail', {
+      navigation.setParams({
         ...nextSong,
         navigationList,
         currentIndex: currentIndex + 1,

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState, useLayoutEffect } from 'react'; // Added useLayoutEffect
+import { useEffect, useState, useLayoutEffect, useRef } from 'react';
 // Cleaned up unused imports
-import { StyleSheet, View, TouchableOpacity, Platform } from 'react-native';
+import { StyleSheet, View, TouchableOpacity, Platform, Dimensions, Animated } from 'react-native';
 import GestureRecognizer from 'react-native-swipe-gestures';
 import SongDisplay from '../../components/SongDisplay';
 import { useSongProcessor } from '../../hooks/useSongProcessor';
 import SongControls from '../../components/SongControls'; // Added import
-import { RouteProp, NavigationProp } from '@react-navigation/native'; // Added NavigationProp
+import { RouteProp, NavigationProp } from '@react-navigation/native';
 import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSelectedSongs } from '../../contexts/SelectedSongsContext'; // Import context hook
 import { IconSymbol } from '../../components/ui/IconSymbol'; // Import IconSymbol
@@ -58,6 +58,9 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   // const [notation, setNotation] = useState<'english' | 'spanish'>('english'); // From context
   // const [currentFontSizeEm, setCurrentFontSizeEm] = useState(1.0); // From context
   // const [currentFontFamily, setCurrentFontFamily] = useState(availableFonts[0].cssValue); // From context
+
+  const slideAnim = useRef(new Animated.Value(0)).current;
+  const screenWidth = Dimensions.get('window').width;
 
 
   // Call the hook to process the song
@@ -169,15 +172,38 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
     setSettings({ fontFamily: newFontFamily });
   };
 
+  const animateAndSet = (
+    params: any,
+    direction: 'next' | 'prev'
+  ) => {
+    const toValue = direction === 'next' ? -screenWidth : screenWidth;
+    Animated.timing(slideAnim, {
+      toValue,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => {
+      navigation.setParams(params);
+      slideAnim.setValue(-toValue);
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    });
+  };
+
   const handleSwipeLeft = () => {
     if (navigationList && typeof currentIndex === 'number' && currentIndex > 0) {
       const prevSong = navigationList[currentIndex - 1];
-      navigation.setParams({
-        ...prevSong,
-        navigationList,
-        currentIndex: currentIndex - 1,
-        source,
-      });
+      animateAndSet(
+        {
+          ...prevSong,
+          navigationList,
+          currentIndex: currentIndex - 1,
+          source,
+        },
+        'prev'
+      );
     }
   };
 
@@ -188,12 +214,15 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
       currentIndex < navigationList.length - 1
     ) {
       const nextSong = navigationList[currentIndex + 1];
-      navigation.setParams({
-        ...nextSong,
-        navigationList,
-        currentIndex: currentIndex + 1,
-        source,
-      });
+      animateAndSet(
+        {
+          ...nextSong,
+          navigationList,
+          currentIndex: currentIndex + 1,
+          source,
+        },
+        'next'
+      );
     }
   };
 
@@ -208,7 +237,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   // Removed handleOpenTransposeModal, handleOpenFontSizeModal, handleOpenFontFamilyModal
 
   const contentView = (
-    <View style={styles.container}>
+    <Animated.View style={[styles.container, { transform: [{ translateX: slideAnim }] }]}>
       <SongDisplay songHtml={songHtml} isLoading={isFileLoading || isSongProcessing || isLoadingSettings} />
       <SongControls
         chordsVisible={chordsVisible}
@@ -223,7 +252,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
         onSetFontFamily={handleSetFontFamily}
         onChangeNotation={handleChangeNotation}
       />
-    </View>
+    </Animated.View>
   );
 
   if (navigationList && typeof currentIndex === 'number') {

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -2,49 +2,29 @@ import { useState, useEffect } from 'react';
 import { ChordProParser, HtmlDivFormatter, Song, Line, ChordLyricsPair } from 'chordsheetjs';
 import { AppColors } from '../app/styles/theme'; // Ensure this path is correct relative to the hooks folder
 
-// Placeholder dictionary for English to Spanish chord translation
-// USER: Please expand this dictionary with all common chords and their variations (m, 7, maj7, sus, dim, aug, #, b, slash chords like G/B, etc.)
-// Example: 'C': 'DO', 'Am': 'LAm', 'G/B': 'SOL/SI', 'C#m7': 'DO#m7'
-const ENGLISH_TO_SPANISH_CHORDS: { [key: string]: string } = {
-  'C': 'DO', 'D': 'RE', 'E': 'MI', 'F': 'FA', 'G': 'SOL', 'A': 'LA', 'B': 'SI',
-  'Cm': 'DOm', 'Dm': 'REm', 'Em': 'MIm', 'Fm': 'FAm', 'Gm': 'SOLm', 'Am': 'LAm', 'Bm': 'SIm',
-  
-  'C#': 'DO#', 'Db': 'REb',
-  'D#': 'RE#', 'Eb': 'MIb',
-  'F#': 'FA#', 'Gb': 'SOLb',
-  'G#': 'SOL#', 'Ab': 'LAb', // LAb is more common than SOL#b for Ab in Spanish
-  'A#': 'LA#', 'Bb': 'SIb',
+// Map of single note names used for translation
+const NOTE_MAP: Record<string, string> = {
+  'C': 'DO',
+  'D': 'RE',
+  'E': 'MI',
+  'F': 'FA',
+  'G': 'SOL',
+  'A': 'LA',
+  'B': 'SI',
+};
 
-  'C#m': 'DO#m', 'Dbm': 'REbm',
-  'D#m': 'RE#m', 'Ebm': 'MIbm',
-  'F#m': 'FA#m', 'Gbm': 'SOLbm',
-  'G#m': 'SOL#m', 'Abm': 'LAbm',
-  'A#m': 'LA#m', 'Bbm': 'SIbm',
-
-  // Add 7ths (dominant)
-  'C7': 'DO7', 'D7': 'RE7', 'E7': 'MI7', 'F7': 'FA7', 'G7': 'SOL7', 'A7': 'LA7', 'B7': 'SI7',
-  'C#7': 'DO#7', 'Db7': 'REb7', 
-  'D#7': 'RE#7', 'Eb7': 'MIb7',
-  'F#7': 'FA#7', 'Gb7': 'SOLb7',
-  'G#7': 'SOL#7', 'Ab7': 'LAb7',
-  'A#7': 'LA#7', 'Bb7': 'SIb7',
-
-  // Add minor 7ths
-  'Cm7': 'DOm7', 'Dm7': 'REm7', 'Em7': 'MIm7', 'Fm7': 'FAm7', 'Gm7': 'SOLm7', 'Am7': 'LAm7', 'Bm7': 'SIm7',
-  // ... and so on for all sharp/flat minor 7ths ...
-
-  // Add major 7ths
-  'Cmaj7': 'DOmaj7', 'Dmaj7': 'REmaj7', 'Emaj7': 'MImáj7', 'Fmaj7': 'FAmaj7', 'Gmaj7': 'SOLmaj7', 'Amaj7': 'LAmaj7', 'Bmaj7': 'SImáj7',
-  // ... and so on for all sharp/flat major 7ths ...
-
-  // Slash chords (examples)
-  'G/B': 'SOL/SI', 
-  'C/E': 'DO/MI',
-  'Am/G': 'LAm/SOL',
-
-  // Sus chords (examples)
-  'Dsus4': 'REsus4', 'Gsus': 'SOLsus', 'Asus4': 'LAsus4',
-  // User should continue populating this dictionary extensively.
+// Generic chord translator that keeps suffixes (m, 7, etc.) and supports slash chords
+const translateChordToSpanish = (chord: string): string => {
+  return chord
+    .split('/')
+    .map(part => {
+      const match = part.match(/^([A-G])([#b]?)(.*)$/);
+      if (!match) return part;
+      const [, root, accidental, rest] = match;
+      const translatedRoot = NOTE_MAP[root] || root;
+      return `${translatedRoot}${accidental || ''}${rest}`;
+    })
+    .join('/');
 };
 
 interface UseSongProcessorParams {
@@ -121,21 +101,19 @@ export const useSongProcessor = ({
                 const translatedChordsString = chordsToTranslate
                   .split(/(\s+)/) // Split by whitespace, keeping delimiters
                   .map(part => {
-                    if (part.match(/^\s+$/)) return part; // if it's whitespace, keep it
-                    // Ensure we handle cases like 'Am/G' - only translate the main chord part if needed
-                    // This basic dictionary won't handle complex chords like 'Am/G' correctly for translation yet.
-                    // For now, it translates whole chord names found in the dictionary.
-                    return ENGLISH_TO_SPANISH_CHORDS[part] || part;
+                    if (part.match(/^\s+$/)) return part; // keep whitespace
+                    return translateChordToSpanish(part);
                   })
                   .join('');
 
-                // Reconstruct the ChordPro segment string, e.g., "[Lam]Lyrics"
-                // Ensure lyrics are included. If lyrics are null/empty, it becomes e.g. "[Lam]"
-                const newChordProSegment = `[${translatedChordsString}]${item.lyrics || ''}`;
                 try {
-                  return new ChordLyricsPair(newChordProSegment);
+                  return new ChordLyricsPair(
+                    translatedChordsString,
+                    item.lyrics || '',
+                    item.annotation || undefined
+                  );
                 } catch (e) {
-                  console.error('Error creating new ChordLyricsPair with segment:', newChordProSegment, e);
+                  console.error('Error creating new ChordLyricsPair with chords:', translatedChordsString, e);
                   return item; // Fallback to original item on error
                 }
               }
@@ -176,9 +154,7 @@ export const useSongProcessor = ({
       }
 
       if (notation === 'spanish' && displayKey) {
-        displayKey = ENGLISH_TO_SPANISH_CHORDS[displayKey.replace(/#/g, 's').replace(/b/g, 'f')] || 
-                     ENGLISH_TO_SPANISH_CHORDS[displayKey] || 
-                     displayKey; // Attempt to translate (basic sharp/flat to common Spanish, then direct)
+        displayKey = translateChordToSpanish(displayKey);
       }
 
       if (displayKey) {


### PR DESCRIPTION
## Summary
- prevent stack animation when swiping between songs
- move search from categories list to header button
- improve chord translation logic so chords align correctly

## Testing
- `npm run lint` *(fails: No duplicate props allowed in JubileoHomeScreen.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684560000a048326adcea226ffc91430