### PR TITLE
UI tweaks for Jubilee screens

### DIFF
--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ScrollView, StyleSheet, View, Linking } from 'react-native';
-import { List, IconButton } from 'react-native-paper';
+import { List, IconButton, Avatar } from 'react-native-paper';
 import contacts from '@/assets/jubileo-contactos.json';
 import colors from '@/constants/colors';
 
@@ -12,6 +12,14 @@ interface Contacto {
 
 export default function ContactosScreen() {
   const data = contacts as Contacto[];
+
+  const getInitials = (name: string) =>
+    name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
 
   const call = (tel: string) => Linking.openURL(`tel:${tel}`);
   const whatsapp = (tel: string) => {
@@ -25,7 +33,9 @@ export default function ContactosScreen() {
         <List.Item
           key={idx}
           title={c.nombre}
+          titleStyle={styles.name}
           description={c.responsabilidad}
+          left={() => <Avatar.Text size={40} label={getInitials(c.nombre)} />}
           right={() => (
             <View style={styles.actions}>
               <IconButton icon="phone" size={24} onPress={() => call(c.telefono)} />
@@ -45,4 +55,5 @@ export default function ContactosScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
   actions: { flexDirection: 'row' },
+  name: { fontSize: 18, fontWeight: 'bold' },
 });

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -19,11 +19,25 @@ export default function GruposScreen() {
   const [categoria, setCategoria] = useState<string | null>(null);
   const [grupo, setGrupo] = useState<Grupo | null>(null);
 
+  const totals: Record<string, number> = React.useMemo(() => {
+    const result: Record<string, number> = {};
+    categorias.forEach(c => {
+      result[c] = data[c].reduce((acc, g) => acc + g.miembros.length, 0);
+    });
+    return result;
+  }, []);
+
   if (!categoria) {
     return (
       <ScrollView style={styles.container}>
         {categorias.map((c) => (
-          <List.Item key={c} title={c} onPress={() => setCategoria(c)} />
+          <List.Item
+            key={c}
+            title={c}
+            description={`${totals[c]} personas`}
+            onPress={() => setCategoria(c)}
+            titleStyle={styles.categoryTitle}
+          />
         ))}
       </ScrollView>
     );
@@ -34,8 +48,9 @@ export default function GruposScreen() {
       <ScrollView style={styles.container}>
         <List.Item
           title="Volver"
-          left={(props) => <IconButton {...props} icon="arrow-back" />}
+          left={() => <List.Icon icon="arrow-left" color={colors.text} />}
           onPress={() => setCategoria(null)}
+          titleStyle={styles.backTitle}
         />
         {data[categoria].map((g, idx) => (
           <List.Item
@@ -43,6 +58,7 @@ export default function GruposScreen() {
             title={g.nombre}
             description={g.subtitulo}
             onPress={() => setGrupo(g)}
+            titleStyle={styles.groupListTitle}
           />
         ))}
       </ScrollView>
@@ -53,16 +69,20 @@ export default function GruposScreen() {
     <ScrollView style={styles.container}>
       <List.Item
         title="Volver"
-        left={(props) => <IconButton {...props} icon="arrow-back" />}
+        left={() => <List.Icon icon="arrow-left" color={colors.text} />}
         onPress={() => setGrupo(null)}
+        titleStyle={styles.backTitle}
       />
       {grupo && (
         <View style={styles.groupContainer}>
           <Text style={styles.groupTitle}>{grupo.nombre}</Text>
           {grupo.responsable && (
-            <List.Item title="Responsable" description={grupo.responsable} />
+            <>
+              <List.Subheader style={styles.sectionHeader}>Responsable</List.Subheader>
+              <List.Item title={grupo.responsable} />
+            </>
           )}
-          <List.Subheader>Miembros</List.Subheader>
+          <List.Subheader style={styles.sectionHeader}>Miembros ({grupo.miembros.length})</List.Subheader>
           {grupo.miembros.map((m, idx) => (
             <List.Item key={idx} title={m} />
           ))}
@@ -74,6 +94,10 @@ export default function GruposScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
+  categoryTitle: { fontSize: 18, fontWeight: 'bold' },
+  groupListTitle: { fontSize: 16 },
+  backTitle: { fontSize: 16 },
+  sectionHeader: { fontSize: 16, fontWeight: 'bold' },
   groupContainer: { paddingHorizontal: 16 },
-  groupTitle: { fontSize: 20, fontWeight: 'bold', marginVertical: 8 },
+  groupTitle: { fontSize: 22, fontWeight: 'bold', marginVertical: 8 },
 });

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -96,17 +96,18 @@ export default function JubileoHomeScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
-        contentContainerStyle={isMobile ? { alignItems: 'center' } : undefined}
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
         keyExtractor={(item, idx) => item.label + idx}
         numColumns={numColumns}
         key={numColumns.toString()}
-        contentContainerStyle={[ // si lo toco se rompe xdddd
+        contentContainerStyle={[
+          isMobile && { alignItems: 'center' },
           styles.container,
           { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
           width >= 1100 && { alignSelf: 'center', maxWidth: 1200, justifyContent: 'flex-start', alignItems: 'center' },
-        ]}        showsVerticalScrollIndicator={false}
+        ]}
+        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -23,17 +23,22 @@ export default function ProfundizaScreen() {
       <Text style={styles.mainTitle}>{data.titulo}</Text>
       <Text style={styles.intro}>{data.introduccion}</Text>
       <View style={{ marginTop: 16 }}>
-        {data.paginas.map((p, idx) => (
-          <List.Accordion
-            key={idx}
-            title={p.titulo}
-            titleStyle={styles.accordionTitle}
-            style={[styles.accordion, { backgroundColor: p.color || colors.primary }]}
-          >
-            {p.subtitulo && <Text style={styles.subtitulo}>{p.subtitulo}</Text>}
-            {p.texto && <Text style={styles.texto}>{p.texto}</Text>}
-          </List.Accordion>
-        ))}
+        <List.AccordionGroup>
+          {data.paginas.map((p, idx) => (
+            <List.Accordion
+              key={idx}
+              id={String(idx)}
+              title={p.titulo}
+              titleStyle={styles.accordionTitle}
+              style={[styles.accordion, { backgroundColor: p.color || colors.primary }]}
+            >
+              <View style={styles.accordionContent}>
+                {p.subtitulo && <Text style={styles.subtitulo}>{p.subtitulo}</Text>}
+                {p.texto && <Text style={styles.texto}>{p.texto}</Text>}
+              </View>
+            </List.Accordion>
+          ))}
+        </List.AccordionGroup>
       </View>
     </ScrollView>
   );
@@ -42,10 +47,17 @@ export default function ProfundizaScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
   content: { padding: 16 },
-  mainTitle: { fontSize: 22, fontWeight: 'bold', marginBottom: 8 },
-  intro: { fontSize: 14, marginBottom: 16 },
+  mainTitle: { fontSize: 24, fontWeight: 'bold', marginBottom: 8 },
+  intro: { fontSize: 16, marginBottom: 16, textAlign: 'justify' },
   accordion: { marginBottom: 12, borderRadius: 16 },
   accordionTitle: { color: colors.white, fontWeight: 'bold' },
+  accordionContent: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 12,
+    padding: 12,
+    margin: 8,
+  },
   subtitulo: { fontWeight: 'bold', marginBottom: 8 },
   texto: { marginBottom: 12 },
 });


### PR DESCRIPTION
## Summary
- fix duplicate prop warning in Jubileo home list
- show totals and improved layout in Grupos screen
- add avatar icons to Contactos
- tweak Profundiza styling and make accordions exclusive

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68457f9605208326b7eb51089e2dfdec