### PR TITLE
Remove unused chord translation feature

### DIFF
--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -44,7 +44,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
 
   // Settings from context
   const { settings, setSettings, isLoadingSettings } = useSettings(); // <<<--- USE SETTINGS HOOK
-  const { chordsVisible, fontSize: currentFontSizeEm, fontFamily: currentFontFamily, notation } = settings;
+  const { chordsVisible, fontSize: currentFontSizeEm, fontFamily: currentFontFamily } = settings;
 
   // songHtml state is now managed by useSongProcessor
   const [isFileLoading, setIsFileLoading] = useState(true); // Renamed from isLoading
@@ -55,7 +55,6 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   const [originalChordPro, setOriginalChordPro] = useState<string | null>(null);
   // const [chordsVisible, setChordsVisible] = useState(true); // From context
   const [currentTranspose, setCurrentTranspose] = useState(0); // Transpose remains local
-  // const [notation, setNotation] = useState<'english' | 'spanish'>('english'); // From context
   // const [currentFontSizeEm, setCurrentFontSizeEm] = useState(1.0); // From context
   // const [currentFontFamily, setCurrentFontFamily] = useState(availableFonts[0].cssValue); // From context
 
@@ -73,7 +72,6 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
     author, // Pass author from route.params
     key,    // Pass key from route.params
     capo,   // Pass capo from route.params
-    notation, // From context
   });
 
   // Effect for setting header button
@@ -152,9 +150,6 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   // Handlers for actual state changes, now using setSettings from context
   const handleToggleChords = () => setSettings({ chordsVisible: !chordsVisible });
 
-  const handleChangeNotation = () => {
-    setSettings({ notation: notation === 'english' ? 'spanish' : 'english' });
-  };
 
   const handleSetTranspose = (semitones: number) => {
     let newTranspose = semitones;
@@ -244,13 +239,11 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
         currentTranspose={currentTranspose} // Transpose is local
         currentFontSizeEm={currentFontSizeEm}
         currentFontFamily={currentFontFamily}
-        notation={notation} // Pass notation state
         availableFonts={availableFonts}
         onToggleChords={handleToggleChords}
         onSetTranspose={handleSetTranspose} // Local handler
         onSetFontSize={handleSetFontSize}
         onSetFontFamily={handleSetFontFamily}
-        onChangeNotation={handleChangeNotation}
       />
     </Animated.View>
   );

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -14,13 +14,11 @@ interface SongControlsProps {
   currentTranspose: number;
   currentFontSizeEm: number;
   currentFontFamily: string;
-  notation?: 'english' | 'spanish'; // Added notation prop
   availableFonts: FontOption[];
   onToggleChords: () => void;
   onSetTranspose: (semitones: number) => void;
   onSetFontSize: (sizeEm: number) => void;
   onSetFontFamily: (fontFamily: string) => void;
-  onChangeNotation: () => void; // For "Notación (Próximamente)"
 }
 
 const SongControls: React.FC<SongControlsProps> = ({
@@ -28,13 +26,11 @@ const SongControls: React.FC<SongControlsProps> = ({
   currentTranspose,
   currentFontSizeEm,
   currentFontFamily,
-  notation = 'english', // Default to English if not provided
   availableFonts,
   onToggleChords,
   onSetTranspose,
   onSetFontSize,
   onSetFontFamily,
-  onChangeNotation,
 }) => {
   const [showActionButtons, setShowActionButtons] = useState(false);
   const [showTransposeModal, setShowTransposeModal] = useState(false);
@@ -75,11 +71,6 @@ const SongControls: React.FC<SongControlsProps> = ({
             <TouchableOpacity style={[styles.fabAction, currentTranspose !== 0 && styles.fabActionActive]} onPress={handleOpenTransposeModal}>
               <Text style={[styles.fabActionText, currentTranspose !== 0 && styles.fabActionTextActive]}>Cambiar tono</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.fabAction, notation === 'spanish' && styles.fabActionActive]} onPress={onChangeNotation}>
-              <Text style={[styles.fabActionText, notation === 'spanish' && styles.fabActionTextActive]}>
-                {notation === 'english' ? 'Notación (Esp)' : 'Notación (Eng)'}
-              </Text>
-            </TouchableOpacity>
             <TouchableOpacity style={[styles.fabAction, currentFontSizeEm !== 1.0 && styles.fabActionActive]} onPress={handleOpenFontSizeModal}>
               <Text style={[styles.fabActionText, currentFontSizeEm !== 1.0 && styles.fabActionTextActive]}>Tamaño Letra</Text>
             </TouchableOpacity>
@@ -89,7 +80,7 @@ const SongControls: React.FC<SongControlsProps> = ({
           </View>
         )}
         <View style={{ position: 'relative' }}>
-          {(currentTranspose !== 0 || !chordsVisible || notation === 'spanish' || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue)) && (
+          {(currentTranspose !== 0 || !chordsVisible || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue)) && (
             <View style={styles.badge} />
           )}
           <TouchableOpacity 

--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -6,7 +6,6 @@ export interface SongSettings {
   chordsVisible: boolean;
   fontSize: number; // Using number for em value
   fontFamily: string;
-  notation: 'english' | 'spanish';
 }
 
 // Define the shape of the context value
@@ -21,7 +20,6 @@ const defaultSettings: SongSettings = {
   chordsVisible: true,
   fontSize: 1.0, // 1.0em
   fontFamily: "'Roboto Mono', 'Courier New', monospace", // Default font
-  notation: 'english',
 };
 
 // Storage key
@@ -48,8 +46,9 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         const storedSettings = await AsyncStorage.getItem(SETTINGS_STORAGE_KEY);
         if (storedSettings) {
           const parsedSettings = JSON.parse(storedSettings);
+          const { notation, ...restParsed } = parsedSettings;
           // Merge with defaults to ensure all keys are present if some were missing
-          setAppSettings(prev => ({ ...defaultSettings, ...parsedSettings, fontSize: parsedSettings.fontSize || defaultSettings.fontSize }));
+          setAppSettings(prev => ({ ...defaultSettings, ...restParsed, fontSize: restParsed.fontSize || defaultSettings.fontSize }));
         } else {
           setAppSettings(defaultSettings);
         }

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -2,31 +2,6 @@ import { useState, useEffect } from 'react';
 import { ChordProParser, HtmlDivFormatter, Song, ChordLyricsPair } from 'chordsheetjs';
 import { AppColors } from '../app/styles/theme'; // Ensure this path is correct relative to the hooks folder
 
-// Map of single note names used for translation
-const NOTE_MAP: Record<string, string> = {
-  'C': 'DO',
-  'D': 'RE',
-  'E': 'MI',
-  'F': 'FA',
-  'G': 'SOL',
-  'A': 'LA',
-  'B': 'SI',
-};
-
-// Generic chord translator that keeps suffixes (m, 7, etc.) and supports slash chords
-const translateChordToSpanish = (chord: string): string => {
-  return chord
-    .split('/')
-    .map(part => {
-      const match = part.match(/^([A-G])([#b]?)(.*)$/);
-      if (!match) return part;
-      const [, root, accidental, rest] = match;
-      const translatedRoot = NOTE_MAP[root] || root;
-      return `${translatedRoot}${accidental || ''}${rest}`;
-    })
-    .join('/');
-};
-
 interface UseSongProcessorParams {
   originalChordPro: string | null;
   currentTranspose: number;
@@ -36,7 +11,6 @@ interface UseSongProcessorParams {
   author?: string; // Added to pass author
   key?: string; // Added to pass key
   capo?: number; // Added to pass capo
-  notation?: 'english' | 'spanish'; // Added for notation preference
 }
 
 export const useSongProcessor = ({
@@ -48,7 +22,6 @@ export const useSongProcessor = ({
   author,
   key,
   capo,
-  notation = 'english', // Default to English
 }: UseSongProcessorParams) => {
   const [songHtml, setSongHtml] = useState<string>('Cargando…');
   const [isLoadingSong, setIsLoadingSong] = useState<boolean>(true);
@@ -95,12 +68,6 @@ export const useSongProcessor = ({
       const formatter = new HtmlDivFormatter();
       let formattedSong = formatter.format(songForFormatting);
 
-      if (notation === 'spanish') {
-        formattedSong = formattedSong.replace(/<span class="chord">(.*?)<\/span>/g, (_m, chordText) => {
-          return `<span class="chord">${translateChordToSpanish(chordText)}</span>`;
-        });
-      }
-
       let metaInsert = '';
       if (author) {
         metaInsert += `<div class="song-meta-author">${author}</div>`;
@@ -127,9 +94,6 @@ export const useSongProcessor = ({
         }
       }
 
-      if (notation === 'spanish' && displayKey) {
-        displayKey = translateChordToSpanish(displayKey);
-      }
 
       if (displayKey) {
         finalKeyCapoString += `<strong>${displayKey}</strong>`;
@@ -258,7 +222,7 @@ export const useSongProcessor = ({
     } finally {
       setIsLoadingSong(false);
     }
-  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily, author, key, capo, notation]);
+  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily, author, key, capo]);
 
   return { songHtml, isLoadingSong };
 };


### PR DESCRIPTION
## Summary
- eliminate the Spanish/English chord translation option
- drop notation from song settings context and loading logic
- clean up SongControls and SongDetailScreen
- simplify useSongProcessor

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846130f809c8326b2ca7f425b7234dc