### PR TITLE
Fix Jubileo dark mode

### DIFF
--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { ScrollView, StyleSheet, View, Linking } from 'react-native';
 import { List, IconButton, Avatar } from 'react-native-paper';
 import contacts from '@/assets/jubileo-contactos.json';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 interface Contacto {
   nombre: string;
@@ -11,6 +12,8 @@ interface Contacto {
 }
 
 export default function ContactosScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const data = contacts as Contacto[];
 
   const getInitials = (name: string) =>
@@ -59,10 +62,13 @@ export default function ContactosScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background },
-  actions: { flexDirection: 'row' },
-  name: { fontSize: 18, fontWeight: 'bold', marginTop: 4 },
-  avatar: { marginLeft: 8 },
-  itemContent: { paddingVertical: 8 },
-});
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.background },
+    actions: { flexDirection: 'row' },
+    name: { fontSize: 18, fontWeight: 'bold', marginTop: 4, color: theme.text },
+    avatar: { marginLeft: 8 },
+    itemContent: { paddingVertical: 8 },
+  });
+};

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { ScrollView, StyleSheet, View, TouchableOpacity } from 'react-native';
 import { List, IconButton, Text } from 'react-native-paper';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import gruposData from '@/assets/jubileo-grupos.json';
 
 interface Grupo {
@@ -14,6 +15,8 @@ interface Grupo {
 type Data = Record<string, Grupo[]>;
 
 export default function GruposScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const data = gruposData as Data;
   const categorias = [
     { name: 'Movilidad', icon: 'walk', color: colors.info },
@@ -84,8 +87,10 @@ export default function GruposScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.background },
   catList: { padding: 16 },
   catCard: {
     height: 120,
@@ -98,7 +103,8 @@ const styles = StyleSheet.create({
   catLabel: { fontSize: 18, fontWeight: 'bold', color: colors.white },
   groupListTitle: { fontSize: 16 },
   backWrapper: { padding: 8 },
-  sectionHeader: { fontSize: 16, fontWeight: 'bold' },
+  sectionHeader: { fontSize: 16, fontWeight: 'bold', color: theme.text },
   groupContainer: { paddingHorizontal: 16 },
-  groupTitle: { fontSize: 22, fontWeight: 'bold', marginVertical: 8 },
+  groupTitle: { fontSize: 22, fontWeight: 'bold', marginVertical: 8, color: theme.text },
 });
+};

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -4,7 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
@@ -27,6 +28,8 @@ const navigationItems: NavigationItem[] = [
 
 export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const { width } = useWindowDimensions();
 
   let numColumns = 2;
@@ -91,7 +94,7 @@ export default function JubileoHomeScreen() {
   const isMobile = width < 700;
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[scheme ?? 'light'].background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
       <FlatList
         data={itemsToShow}
         renderItem={renderItemWithPlaceholder}
@@ -126,9 +129,11 @@ interface Styles {
   rectangleLabel: TextStyle;
 }
 
-const styles = StyleSheet.create<Styles>({
-  container: {
-    backgroundColor: colors.background,
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create<Styles>({
+    container: {
+    backgroundColor: theme.background,
     // padding eliminado para evitar espacio en blanco excesivo
   },
   item: {
@@ -158,7 +163,7 @@ const styles = StyleSheet.create<Styles>({
     fontSize: 22,
     fontWeight: 'bold',
     textAlign: 'center',
-    color: colors.text,
+    color: theme.text,
   },
   iconPlaceholder: {
     fontWeight: 'bold',
@@ -175,4 +180,5 @@ const styles = StyleSheet.create<Styles>({
     letterSpacing: 0.5,
     marginTop: 2,
   },
-});
+  });
+};

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { List, Text } from 'react-native-paper';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import profundiza from '@/assets/jubileo-profundiza.json';
 
 interface Pagina {
@@ -12,6 +13,8 @@ interface Pagina {
 }
 
 export default function ProfundizaScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const data = profundiza as {
     titulo: string;
     introduccion: string;
@@ -44,20 +47,23 @@ export default function ProfundizaScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background },
-  content: { padding: 16 },
-  mainTitle: { fontSize: 24, fontWeight: 'bold', marginBottom: 8 },
-  intro: { fontSize: 16, marginBottom: 16 },
-  accordion: { marginBottom: 12, borderRadius: 16 },
-  accordionTitle: { color: colors.white, fontWeight: 'bold' },
-  accordionContent: {
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 12,
-    padding: 12,
-    margin: 8,
-  },
-  subtitulo: { fontWeight: 'bold', marginBottom: 8 },
-  texto: { marginBottom: 12 },
-});
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.background },
+    content: { padding: 16 },
+    mainTitle: { fontSize: 24, fontWeight: 'bold', marginBottom: 8, color: theme.text },
+    intro: { fontSize: 16, marginBottom: 16, color: theme.text },
+    accordion: { marginBottom: 12, borderRadius: 16 },
+    accordionTitle: { color: colors.white, fontWeight: 'bold' },
+    accordionContent: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 12,
+      padding: 12,
+      margin: 8,
+    },
+    subtitulo: { fontWeight: 'bold', marginBottom: 8, color: theme.text },
+    texto: { marginBottom: 12, color: theme.text },
+  });
+};

--- a/mcm-app/app/screens/VisitasScreen.tsx
+++ b/mcm-app/app/screens/VisitasScreen.tsx
@@ -7,7 +7,8 @@ import {
   Image,
 } from 'react-native';
 import { Card, IconButton, Modal, Portal, Text } from 'react-native-paper';
-import colors from '@/constants/colors';
+import { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import visitas from '@/assets/jubileo-visitas.json';
 
 interface Visita {
@@ -51,6 +52,8 @@ function formatDate(fecha?: string) {
 }
 
 export default function VisitasScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const [selected, setSelected] = useState<Visita | null>(null);
 
   const openMap = (url?: string) => {
@@ -114,10 +117,12 @@ export default function VisitasScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.background },
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.background },
   list: { padding: 16 },
-  card: { marginBottom: 16 },
+  card: { marginBottom: 16, backgroundColor: theme.background },
   image: {
     width: '100%',
     height: 160,
@@ -128,15 +133,16 @@ const styles = StyleSheet.create({
     marginBottom: 16, // spacing below image
   },
   cardContent: { flexDirection: 'row', alignItems: 'center' },
-  title: { fontSize: 16, fontWeight: 'bold', marginBottom: 4 },
-  subtitle: { fontSize: 14, marginBottom: 4 },
+  title: { fontSize: 16, fontWeight: 'bold', marginBottom: 4, color: theme.text },
+  subtitle: { fontSize: 14, marginBottom: 4, color: theme.text },
   dateRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
   modal: {
-    backgroundColor: 'white',
+    backgroundColor: theme.background,
     margin: 20,
     padding: 20,
     borderRadius: 8,
   },
-  modalTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
-  modalText: { fontSize: 14, marginBottom: 12 },
+  modalTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8, color: theme.text },
+  modalText: { fontSize: 14, marginBottom: 12, color: theme.text },
 });
+};

--- a/mcm-app/components/DateSelector.tsx
+++ b/mcm-app/components/DateSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FlatList, TouchableOpacity, View, Text, StyleSheet } from 'react-native';
-import colors from '@/constants/colors';
+import colors, { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 
 const MONTHS = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
@@ -15,6 +16,9 @@ interface Props {
 }
 
 export default function DateSelector({ dates, selectedDate, onSelectDate }: Props) {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+
   const renderItem = ({ item, index }: { item: DateOption; index: number }) => {
     const date = new Date(item.fecha);
     const label = `${date.getDate()} ${MONTHS[date.getMonth()]}`;
@@ -41,34 +45,37 @@ export default function DateSelector({ dates, selectedDate, onSelectDate }: Prop
   );
 }
 
-const styles = StyleSheet.create({
-  list: {
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.lg,
-  },
-  item: {
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    borderRadius: 12,
-    backgroundColor: '#eeeeee',
-    marginRight: spacing.md,
-    alignItems: 'center',
-    minWidth: 90,
-  },
-  itemSelected: {
-    backgroundColor: colors.accent,
-  },
-  dateText: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: colors.text,
-  },
-  weekdayText: {
-    fontSize: 14,
-    textTransform: 'capitalize',
-    color: colors.text,
-  },
-  textSelected: {
-    color: colors.white,
-  },
-});
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    list: {
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.lg,
+    },
+    item: {
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.md,
+      borderRadius: 12,
+      backgroundColor: scheme === 'dark' ? '#3E3E42' : '#eeeeee',
+      marginRight: spacing.md,
+      alignItems: 'center',
+      minWidth: 90,
+    },
+    itemSelected: {
+      backgroundColor: colors.accent,
+    },
+    dateText: {
+      fontSize: 18,
+      fontWeight: 'bold',
+      color: theme.text,
+    },
+    weekdayText: {
+      fontSize: 14,
+      textTransform: 'capitalize',
+      color: theme.text,
+    },
+    textSelected: {
+      color: colors.white,
+    },
+  });
+};

--- a/mcm-app/components/EventItem.tsx
+++ b/mcm-app/components/EventItem.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Card } from 'react-native-paper';
-import colors from '@/constants/colors';
+import { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 
 export interface EventItemData {
@@ -13,6 +14,8 @@ export interface EventItemData {
 }
 
 export default function EventItem({ event }: { event: EventItemData }) {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   return (
     <Card style={styles.card}>
       <Card.Content>
@@ -29,25 +32,29 @@ export default function EventItem({ event }: { event: EventItemData }) {
   );
 }
 
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: spacing.md,
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.md,
-  },
-  emoji: {
-    fontSize: 24,
-  },
-  title: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: colors.text,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: colors.text,
-  },
-});
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    card: {
+      marginBottom: spacing.md,
+      backgroundColor: theme.background,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.md,
+    },
+    emoji: {
+      fontSize: 24,
+    },
+    title: {
+      fontSize: 16,
+      fontWeight: 'bold',
+      color: theme.text,
+    },
+    subtitle: {
+      fontSize: 14,
+      color: theme.text,
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- revamp dark mode in Jubileo screens
- use current color scheme in DateSelector and EventItem components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684612dc7cb48326a4d956cd9cc6feb4