### PR TITLE
Fix Jubilee layout and material screen

### DIFF
--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Text, TouchableOpacity, FlatList, useWindowDimensions, ViewStyle, TextStyle } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity, ViewStyle, TextStyle, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -30,90 +30,28 @@ export default function JubileoHomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<JubileoStackParamList>>();
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
-  const { width } = useWindowDimensions();
-
-  let numColumns = 2;
-  if (width >= 1100) {
-    numColumns = 4;
-  } else if (width >= 700) {
-    numColumns = 3;
-  }
-
-  // Tamaños responsivos
-  // Tamaños responsivos SOLO para el cuadrado, icono/texto siempre igual
+  const { width, height } = useWindowDimensions();
+  const itemWidth = width / 2;
+  const itemHeight = height / 3;
   const iconSize = 48;
   const labelFontSize = 18;
-  let dynamicMaxWidth = 220;
-  if (width < 400) {
-    dynamicMaxWidth = 120;
-  } else if (width < 700) {
-    dynamicMaxWidth = 180;
-  } else if (width >= 1100) {
-    dynamicMaxWidth = 800;
-  } else {
-    dynamicMaxWidth = 220;
-  }
-
-  const renderItem = ({ item }: { item: NavigationItem }) => {
-    return (
-      <TouchableOpacity
-        style={[styles.item, { maxWidth: dynamicMaxWidth, aspectRatio: 1 }]}
-        onPress={() => {
-          navigation.navigate(item.target as any);
-        }}
-        activeOpacity={0.85}
-      >
-        <View style={[styles.card, { backgroundColor: item.backgroundColor }]}> 
-          <View style={styles.cardContent}>
-            <Text style={[styles.iconPlaceholder, { color: '#fff', fontSize: iconSize }]}>{item.icon}</Text>
-            <Text style={[styles.rectangleLabel, { color: '#fff', fontSize: labelFontSize }]}>{item.label}</Text>
-          </View>
-        </View>
-      </TouchableOpacity>
-    );
-  };
-
-  // Si el número de botones es impar, añade un placeholder invisible para cuadrar la última fila
-  let itemsToShow = navigationItems;
-  if (navigationItems.length % numColumns !== 0) {
-    const placeholdersToAdd = numColumns - (navigationItems.length % numColumns);
-    itemsToShow = [
-      ...navigationItems,
-      ...Array(placeholdersToAdd).fill({ label: '', icon: '', target: '' as any, backgroundColor: 'transparent', isPlaceholder: true })
-    ];
-  }
-
-  const renderItemWithPlaceholder = ({ item }: { item: NavigationItem & { isPlaceholder?: boolean } }) => {
-    if (item.isPlaceholder) {
-      return <View style={[styles.item, { backgroundColor: 'transparent' }]} pointerEvents="none" />;
-    }
-    return renderItem({ item });
-  };
-
-  // Centrado vertical solo en móvil
-  const isMobile = width < 700;
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[scheme ?? 'light'].background, justifyContent: isMobile ? 'center' : 'flex-start' }}>
-      <FlatList
-        data={itemsToShow}
-        renderItem={renderItemWithPlaceholder}
-        keyExtractor={(item, idx) => item.label + idx}
-        numColumns={numColumns}
-        key={numColumns.toString()}
-        contentContainerStyle={[
-          isMobile ? { alignItems: 'center' } : null,
-          styles.container,
-          { flexGrow: 1, paddingTop: spacing.md, paddingBottom: spacing.md },
-          width >= 1100 && {
-            alignSelf: 'center',
-            maxWidth: 1200,
-            justifyContent: 'flex-start',
-            alignItems: 'center',
-          },
-        ]}
-        showsVerticalScrollIndicator={false}
-      />
+    <SafeAreaView style={[styles.container, { backgroundColor: Colors[scheme ?? 'light'].background }]}>
+      {navigationItems.map((item, idx) => (
+        <TouchableOpacity
+          key={idx}
+          style={[
+            styles.item,
+            { width: itemWidth, height: itemHeight, backgroundColor: item.backgroundColor },
+          ]}
+          onPress={() => navigation.navigate(item.target as any)}
+          activeOpacity={0.85}
+        >
+          <Text style={[styles.iconPlaceholder, { color: '#fff', fontSize: iconSize }]}>{item.icon}</Text>
+          <Text style={[styles.rectangleLabel, { color: '#fff', fontSize: labelFontSize }]}>{item.label}</Text>
+        </TouchableOpacity>
+      ))}
     </SafeAreaView>
   );
 }
@@ -121,8 +59,6 @@ export default function JubileoHomeScreen() {
 interface Styles {
   container: ViewStyle;
   item: ViewStyle;
-  card: ViewStyle;
-  cardContent: ViewStyle;
   headerWrapper: ViewStyle;
   headerText: TextStyle;
   iconPlaceholder: TextStyle;
@@ -133,29 +69,18 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create<Styles>({
     container: {
-    backgroundColor: theme.background,
-    // padding eliminado para evitar espacio en blanco excesivo
-  },
-  item: {
-    flex: 1,
-    margin: spacing.sm,
-    aspectRatio: 1,
-    alignItems: 'stretch',
-    minWidth: 100,
-    // maxWidth se aplica dinámicamente en el renderItem
-  },
-  card: {
-    flex: 1,
-    borderRadius: 16,
-    overflow: 'hidden',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  cardContent: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
+      flex: 1,
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.background,
+    },
+    item: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: 16,
+    },
   headerWrapper: {
     marginBottom: spacing.lg,
   },

--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { View, StyleSheet, Dimensions, Text, FlatList, ScrollView, TouchableOpacity, Platform, DimensionValue, ViewStyle } from 'react-native';
+import { View, StyleSheet, Dimensions, Text, FlatList, ScrollView, TouchableOpacity, Platform, DimensionValue, ViewStyle, type ColorSchemeName } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -42,60 +42,6 @@ const generateRandomCircles = (count: number = 5) => {
   return circles;
 };
 
-// Component for the Introduction Page
-interface IntroPageItemProps {
-  actividad: Actividad;
-  fecha: string;
-  width: number;
-}
-const IntroPageItem: React.FC<IntroPageItemProps> = ({ actividad, fecha, width }) => {
-  const circlesData = React.useMemo(() => generateRandomCircles(5), []);
-
-  return (
-    <View style={[styles.introPage, { width, backgroundColor: 'transparent' }]}>
-      {circlesData.map((circle, idx) => (
-        <View
-          key={`deco-${idx}`}
-          style={{
-            position: 'absolute',
-            width: circle.size,
-            height: circle.size,
-            borderRadius: circle.size / 2,
-            backgroundColor: circle.color,
-            opacity: circle.opacity,
-            top: circle.top as DimensionValue,
-            left: circle.left as DimensionValue,
-            // transform: [{ translateX: -circle.size / 2 }, { translateY: -circle.size / 2 }],
-          } as ViewStyle}
-        />
-      ))}
-      <Text style={styles.introEmoji}>{actividad.emoji}</Text>
-      <Text style={styles.introTitle}>{actividad.nombre.toUpperCase()}</Text>
-      <Text style={styles.introDate}>{fecha}</Text>
-      <Text style={styles.introHint}>Desliza para ver el material</Text>
-    </View>
-  );
-};
-
-// Component for Content Pages
-interface ContentPageItemProps {
-  item: Pagina; // Assuming 'Pagina' is the type for a content page object
-  actividadColor: string;
-  width: number;
-}
-const ContentPageItem: React.FC<ContentPageItemProps> = ({ item, actividadColor, width }) => {
-  return (
-    <View style={[styles.page, { width }]}>
-      <View style={[styles.pageHeader, { backgroundColor: actividadColor }]}>
-        <Text style={styles.pageTitle}>{item.titulo}</Text>
-        {item.subtitulo && <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>}
-      </View>
-      <ScrollView contentContainerStyle={styles.pageContent}>
-        <Text>{item.texto}</Text>
-      </ScrollView>
-    </View>
-  );
-};
 
 export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
   const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -104,17 +50,56 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
   const introBackgroundColor = actividad.color || colors.primary; // Fallback color
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme, introBackgroundColor), [scheme, introBackgroundColor]);
+
+  const IntroPageItem = ({ actividad }: { actividad: Actividad; }) => {
+    const circlesData = React.useMemo(() => generateRandomCircles(5), []);
+    return (
+      <View style={[styles.introPage, { width, backgroundColor: 'transparent' }]}>
+        {circlesData.map((circle, idx) => (
+          <View
+            key={`deco-${idx}`}
+            style={{
+              position: 'absolute',
+              width: circle.size,
+              height: circle.size,
+              borderRadius: circle.size / 2,
+              backgroundColor: circle.color,
+              opacity: circle.opacity,
+              top: circle.top as DimensionValue,
+              left: circle.left as DimensionValue,
+            } as ViewStyle}
+          />
+        ))}
+        <Text style={styles.introEmoji}>{actividad.emoji}</Text>
+        <Text style={styles.introTitle}>{actividad.nombre.toUpperCase()}</Text>
+        <Text style={styles.introDate}>{fecha}</Text>
+        <Text style={styles.introHint}>Desliza para ver el material</Text>
+      </View>
+    );
+  };
+
+  const ContentPageItem = ({ item }: { item: Pagina }) => {
+    return (
+      <View style={[styles.page, { width }]}>
+        <View style={[styles.pageHeader, { backgroundColor: actividad.color }]}>
+          <Text style={styles.pageTitle}>{item.titulo}</Text>
+          {item.subtitulo && <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>}
+        </View>
+        <ScrollView contentContainerStyle={styles.pageContent}>
+          <Text>{item.texto}</Text>
+        </ScrollView>
+      </View>
+    );
+  };
   const [index, setIndex] = useState(0);
   const pages = [{ intro: true }, ...actividad.paginas];
   const { width } = Dimensions.get('window');
 
   const renderItem = ({ item }: { item: any }) => {
     if (item.intro) {
-      return <IntroPageItem actividad={actividad} fecha={fecha} width={width} />;
+      return <IntroPageItem actividad={actividad} />;
     }
-    // Assuming 'item' for content pages is of type 'Pagina'
-    // You might need to adjust the type assertion if 'item' can be something else
-    return <ContentPageItem item={item as Pagina} actividadColor={actividad.color} width={width} />;
+    return <ContentPageItem item={item as Pagina} />;
   };
 
   const getItemLayout = (_data: any, itemIndex: number) => ({
@@ -199,7 +184,8 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark' | null, introColor: string) => {
+
+const createStyles = (scheme: ColorSchemeName, introColor: string) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     container: { flex: 1 },


### PR DESCRIPTION
## Summary
- rebuild Jubileo home screen layout with 3x2 grid and no scroll
- fix MaterialPagesScreen by embedding item components and cleaning type errors

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68461addaf408326ae12516bf0e0a770