### PR TITLE
Add configurable CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,9 @@ iPhone TestFlight (Build) ..... eas build -p ios --profile production
 iPhone TestFlight (Subir) ..... eas submit -p ios --latest
 Development Client (arrancar) . npx expo start --dev-client
 Instalar dependencias ......... npm install
+
+## Variables de entorno
+
+Puedes definir algunas variables para ajustar ciertas funciones de la app.
+
+- `CORS_PROXY_URL`: URL base de un proxy para evitar problemas de CORS al descargar calendarios `.ics`. Un ejemplo es `https://corsproxy.io/?`. Si no se define, se intentará acceder a las URLs directamente.

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -80,8 +80,20 @@ export default function useCalendarEvents(calendars: CalendarConfig[]) {
         const cfg = calendars[i];
         try {
 
-          const proxyUrl = 'https://corsproxy.io/?' + encodeURIComponent(cfg.url);
-          const res = await fetch(proxyUrl);
+          const proxyBase = process.env.CORS_PROXY_URL;
+          const proxyUrl = proxyBase ? proxyBase + encodeURIComponent(cfg.url) : null;
+          let res: Response | null = null;
+          if (proxyUrl) {
+            try {
+              res = await fetch(proxyUrl);
+              if (!res.ok) throw new Error('Proxy request failed');
+            } catch (err) {
+              // Fallback to direct fetch if proxy fails
+              res = await fetch(cfg.url);
+            }
+          } else {
+            res = await fetch(cfg.url);
+          }
           const text = await res.text();
           const events = parseICS(text);
 


### PR DESCRIPTION
## Summary
- make CORS proxy URL configurable through `process.env.CORS_PROXY_URL`
- document `CORS_PROXY_URL` in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68461e2986bc8326838db31f61f7ab9f