### PR TITLE
Setup web deploy GitHub Action

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,44 @@
+name: Deploy Web
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: mcm-app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mcm-app
+      - name: Export web build
+        run: npx expo export --platform web --output-dir dist
+        working-directory: mcm-app
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: mcm-app/dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mcmapp - Guía del Desarrollador
+[![Deploy Web](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg?branch=main)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
 
 Bienvenido/a al proyecto MCM App. Esta guía está diseñada para ayudarte a configurar el entorno de desarrollo, entender la estructura del proyecto y comenzar a trabajar con la aplicación.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to export and deploy web build
- show workflow status in README

## Testing
- `npm --version`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68461e1c9ae48326ba0acecc27e7ee2e