### PR TITLE
Add fullscreen song display with auto-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ Esto iniciará el servidor de desarrollo, y podrás abrir la app de Development 
 
 ---
 
+### Modo pantalla completa para canciones
+Desde la vista de detalle puedes pulsar el nuevo icono de *pantalla completa* para abrir la canción en modo presentación. El texto se muestra con una fuente grande y puedes activar o pausar el desplazamiento automático con el botón de reproducción.
+
+---
+
 ### 📝 Mini-post-it de comandos
 Un resumen rápido de los comandos más usados:
 

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-na
 import CategoriesScreen from '../screens/CategoriesScreen';
 import SongListScreen from '../screens/SongListScreen';
 import SongDetailScreen from '../screens/SongDetailScreen';
+import SongFullscreenScreen from '../screens/SongFullscreenScreen';
 import SelectedSongsScreen from '../screens/SelectedSongsScreen'; // Import the new screen
 
 // Importar el contexto de canciones seleccionadas
@@ -35,6 +36,14 @@ export type RootStackParamList = {
     navigationList?: SongNavItem[];
     currentIndex?: number;
     source?: 'category' | 'selection';
+  };
+  SongFullscreen: {
+    filename: string;
+    title: string;
+    author?: string;
+    key?: string;
+    capo?: number;
+    content: string;
   };
   SelectedSongs: undefined; // Add SelectedSongs screen
 };
@@ -72,11 +81,18 @@ export default function CancioneroTab() {
           component={SongListScreen} 
           options={({ route }) => ({ title: route.params?.categoryName || 'Canciones' })} 
         />
-        <Stack.Screen 
-          name="SongDetail" 
+        <Stack.Screen
+          name="SongDetail"
           component={SongDetailScreen}
-          options={({ route }) => ({ 
-            title: route.params?.title || 'Letra y Acordes' 
+          options={({ route }) => ({
+            title: route.params?.title || 'Letra y Acordes'
+          })}
+        />
+        <Stack.Screen
+          name="SongFullscreen"
+          component={SongFullscreenScreen}
+          options={({ route }) => ({
+            title: route.params?.title || 'Pantalla completa'
           })}
         />
         <Stack.Screen

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -10,6 +10,7 @@ import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSelectedSongs } from '../../contexts/SelectedSongsContext'; // Import context hook
 import { IconSymbol } from '../../components/ui/IconSymbol'; // Import IconSymbol
 import { useSettings } from '../../contexts/SettingsContext'; // <<<--- ADD THIS IMPORT
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 const availableFonts = [
   { name: 'Monoespaciada', cssValue: "'Roboto Mono', 'Courier New', monospace" },
@@ -101,6 +102,22 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
             size={26}
             color={'#fff'}
           />
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('SongFullscreen', {
+              filename,
+              title: _navScreenTitle,
+              author,
+              key,
+              capo,
+              content: content || ''
+            })
+          }
+          style={[styles.headerButton, { marginLeft: 12 }]}
+          accessibilityLabel="Pantalla completa"
+        >
+          <MaterialIcons name="fullscreen" size={26} color="#fff" />
         </TouchableOpacity>
       </View>
     );

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,0 +1,86 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { View, StyleSheet, TouchableOpacity, Platform } from 'react-native';
+import { RouteProp } from '@react-navigation/native';
+import { WebView } from 'react-native-webview';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { RootStackParamList } from '../(tabs)/cancionero';
+import { useSettings } from '../../contexts/SettingsContext';
+import { useSongProcessor } from '../../hooks/useSongProcessor';
+
+// Route type for this screen
+type SongFullscreenRouteProp = RouteProp<RootStackParamList, 'SongFullscreen'>;
+
+export default function SongFullscreenScreen({ route }: { route: SongFullscreenRouteProp }) {
+  const { author, key, capo, content } = route.params;
+  const { settings } = useSettings();
+  const { chordsVisible, fontSize, fontFamily, notation } = settings;
+
+  const { songHtml } = useSongProcessor({
+    originalChordPro: content || null,
+    currentTranspose: 0,
+    chordsVisible,
+    currentFontSizeEm: fontSize * 1.6,
+    currentFontFamily: fontFamily,
+    author,
+    key,
+    capo,
+    notation,
+  });
+
+  const webViewRef = useRef<WebView>(null);
+  const divRef = useRef<HTMLDivElement | null>(null);
+  const [autoScroll, setAutoScroll] = useState(false);
+
+  useEffect(() => {
+    if (!autoScroll) return;
+    const id = setInterval(() => {
+      if (Platform.OS === 'web') {
+        if (divRef.current) {
+          divRef.current.scrollBy({ top: 1 });
+        }
+      } else {
+        webViewRef.current?.injectJavaScript('window.scrollBy(0,1); true;');
+      }
+    }, 50);
+    return () => clearInterval(id);
+  }, [autoScroll]);
+
+  return (
+    <View style={styles.container}>
+      {Platform.OS === 'web' ? (
+        <div ref={divRef} style={styles.webContainer as any} dangerouslySetInnerHTML={{ __html: songHtml }} />
+      ) : (
+        <WebView
+          ref={webViewRef}
+          originWhitelist={['*']}
+          source={{ html: songHtml }}
+          style={{ flex: 1 }}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+      <TouchableOpacity style={styles.scrollButton} onPress={() => setAutoScroll(s => !s)}>
+        <MaterialIcons name={autoScroll ? 'pause' : 'play-arrow'} color="#fff" size={28} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  webContainer: {
+    width: '100%',
+    height: '100%',
+    overflowY: 'auto',
+    padding: 16,
+    boxSizing: 'border-box',
+  },
+  scrollButton: {
+    position: 'absolute',
+    right: 20,
+    bottom: 30,
+    backgroundColor: '#000',
+    padding: 12,
+    borderRadius: 30,
+    opacity: 0.7,
+  },
+});


### PR DESCRIPTION
## Summary
- add new `SongFullscreen` screen with auto-scrolling
- expose screen in the cancionero stack
- link to fullscreen from `SongDetailScreen` header
- document new feature in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68461e13b2f88326bae433fece9b853a