### PR TITLE
Update songs structure with category metadata

### DIFF
--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -30,9 +30,14 @@ export default function CategoriesScreen({
       'songs'
     );
   const actualCategories = songsData ? Object.keys(songsData) : [];
+  const sortedCategories = actualCategories.sort((a, b) => {
+    const titleA = songsData?.[a]?.categoryTitle ?? a;
+    const titleB = songsData?.[b]?.categoryTitle ?? b;
+    return titleA.localeCompare(titleB);
+  });
   const displayCategories = [
     { id: SELECTED_SONGS_CATEGORY_ID, name: SELECTED_SONGS_CATEGORY_NAME },
-    ...actualCategories.map(cat => ({
+    ...sortedCategories.map(cat => ({
       id: cat,
       name: songsData?.[cat]?.categoryTitle ?? cat,
     }))

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -24,11 +24,18 @@ export default function CategoriesScreen({
 }) {
   const scheme = useColorScheme();
   const styles = useMemo(() => createStyles(scheme), [scheme]);
-  const { data: songsData, loading } = useFirebaseData<Record<string, any[]>>('songs', 'songs');
+  const { data: songsData, loading } =
+    useFirebaseData<Record<string, { categoryTitle: string; songs: any[] }>>(
+      'songs',
+      'songs'
+    );
   const actualCategories = songsData ? Object.keys(songsData) : [];
   const displayCategories = [
     { id: SELECTED_SONGS_CATEGORY_ID, name: SELECTED_SONGS_CATEGORY_NAME },
-    ...actualCategories.map(cat => ({ id: cat, name: `${cat}` }))
+    ...actualCategories.map(cat => ({
+      id: cat,
+      name: songsData?.[cat]?.categoryTitle ?? cat,
+    }))
   ];
 
   useLayoutEffect(() => {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -87,6 +87,9 @@ const SelectedSongsScreen: React.FC = () => {
           });
         }
       }
+      categories.sort((a, b) =>
+        a.categoryTitle.localeCompare(b.categoryTitle)
+      );
       setCategorizedSelectedSongs(categories);
     };
 

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -21,17 +21,22 @@ interface Song {
   numericFilenamePart?: string; // For consistent number display
 }
 
+interface SongCategory {
+  categoryTitle: string;
+  songs: Song[];
+}
+
 // Ensure the data is in the correct format
-const getSongsData = (data: any): Record<string, Song[]> => {
+const getSongsData = (data: any): Record<string, SongCategory> => {
   try {
     // If the data is already in the correct format, return it
     if (data && typeof data === 'object' && !Array.isArray(data)) {
-      return data as Record<string, Song[]>;
+      return data as Record<string, SongCategory>;
     }
     
     // If the data is an array, try to convert it to the correct format
     if (Array.isArray(data)) {
-      return { 'All': data };
+      return { All: { categoryTitle: 'All', songs: data } };
     }
     
     // If we can't determine the format, return an empty object
@@ -47,7 +52,8 @@ export default function SongsListScreen({ route, navigation }: {
   route: { params: { categoryId: string; categoryName: string } };
   navigation: any;
 }) {
-  const { data: firebaseSongs, loading: loadingSongs } = useFirebaseData<Record<string, Song[]>>('songs', 'songs');
+  const { data: firebaseSongs, loading: loadingSongs } =
+    useFirebaseData<Record<string, SongCategory>>('songs', 'songs');
   const songsData = useMemo(() => getSongsData(firebaseSongs), [firebaseSongs]);
   const { categoryId, categoryName } = route.params;
   const scheme = useColorScheme();
@@ -71,7 +77,7 @@ export default function SongsListScreen({ route, navigation }: {
           let allSongs: Song[] = [];
           for (const originalCategoryKey in songsData) {
             if (Object.prototype.hasOwnProperty.call(songsData, originalCategoryKey)) {
-              const categorySongs = songsData[originalCategoryKey];
+              const categorySongs = songsData[originalCategoryKey].songs;
               const songsWithMetadata = categorySongs.map(song => {
                 const titleMatch = song.title.match(/^(\d{1,3})\.\s*/);
                 let numericPart = '';
@@ -109,9 +115,11 @@ export default function SongsListScreen({ route, navigation }: {
           console.log('Found category key:', categoryKey);
           
           if (categoryKey) {
-            const categorySongs = songsData[categoryKey];
-            console.log(`Found category '${categoryKey}' with ${categorySongs?.length || 0} songs`);
-            
+            const categorySongs = songsData[categoryKey].songs;
+            console.log(
+              `Found category '${categoryKey}' with ${categorySongs?.length || 0} songs`
+            );
+
             if (categorySongs && Array.isArray(categorySongs)) {
               const songsWithNumericPart = categorySongs.map(song => {
                 const titleMatch = song.title.match(/^(\d{1,3})\.\s*/);

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -29,6 +29,11 @@ interface SongCategory {
 // Ensure the data is in the correct format
 const getSongsData = (data: any): Record<string, SongCategory> => {
   try {
+    // If the data is null (expected during initial loading), return empty object
+    if (data === null) {
+      return {};
+    }
+    
     // If the data is already in the correct format, return it
     if (data && typeof data === 'object' && !Array.isArray(data)) {
       return data as Record<string, SongCategory>;
@@ -65,6 +70,7 @@ export default function SongsListScreen({ route, navigation }: {
 
   useEffect(() => {
     if (!songsData) return;
+    // TODO - Eliminar estos comentarios
     console.log('Accessing category:', categoryId);
     console.log('Available categories:', Object.keys(songsData));
     

--- a/mcm-app/assets/songs.json
+++ b/mcm-app/assets/songs.json
@@ -1,62 +1,71 @@
 {
-  "A. Canciones Entrada 🎉": [
-    {
-      "title": "01. Ven a Celebrar",
-      "filename": "ven_a_celebrar.cho",
-      "author": "",
-      "key": "G",
-      "capo": 0,
-      "info": "",
-      "content": "{title: Ven a Celebrar}\n{key: G}\n\n\n[G]VEN A [bm]CELEBRAR EL [C]AMOR DE [G]DIOS, SE [C]DERRAMARÁ [G]COMO [C]AGUA [D]LIMPIA  \n[C]INUNDANDO [G]NUESTRAS [C]VIDAS DE [D]SU [D]PRESENCIA (bis)\n\n[em]Os [bm]aseguro [C]que [G]yo [C]estaré [G]cuando [C]dos o [D]más por [D]mí os reunáis.  \nEs [G]LA [C]mejor [D]forma de [D]creer en nuestra amistad (bis)\n"
-    },
-    {
-      "title": "02. Dios está aquí",
-      "filename": "dios_esta_aqui.cho",
-      "author": "",
-      "key": "C",
-      "capo": 1,
-      "info": "",
-      "content": "\n{title: Dios Está Aquí}\n{key: C}\n{capo: 1}\n{chordsize:14}\n{soc}\n[C]DIOS [G]ESTÁ [am]AQUÍ TAN [F]CIERTO COMO EL [G]AIRE QUE [C]RESPIRO  \n[F]TAN [G]CIERTO COMO LA [C-em-am]MAÑANA SE LEVANTA  \n[F]TAN [G]CIERTO COMO [C]QUE ESTE CANTO LO PUEDES OÍR  \n{eoc}\n[G]LO [F]PUEDES [C]SENTIR MOVIÉNDOSE ENTRE LOS QUE AMAN  \n[G]LO [F]PUEDES [G]OÍR CANTANDO CON NOSOTROS [C]AQUÍ  \n[G]LO [F]PUEDES [C]LLEVAR CUANDO POR ESA PUERTA [G]SALGAS  \n[G]LO [F]PUEDES [G]GUARDAR POR SIEMPRE EN TU [C]CORAZÓN (G7)\n"
-    }
-  ],
-  "C. Salmos 📖": [
-    {
-      "title": "01. El lote de mi Heredad",
-      "filename": "lote_heredad.cho",
-      "author": "",
-      "key": "D",
-      "capo": 0,
-      "info": "",
-      "content": "{title: El Lote de Mi Heredad}\n{key: D}\n\n{start_of_chorus}\n[D]EL [A]SEÑOR ES EL [bm]LOTE DE MI [G]HEREDAD, [D]ALELUYA  \n[bm]POR [A]SIEMPRE MI [G]ALMA TE [A]CANTARÁ, [D]ALELUYA\n{end_of_chorus}\n\n[bm]Protégeme [G]Dios [D]mío, me [G]refugio en [A]ti. Yo [G]digo al [A]Señor tú [D]eres MI bien.  \n[D]Los dioses y [A]señores de [bm]LA tierra no [G]me satisfacen.  \n\n[D]El Señor es el [A]lote de MI [bm]heredad. MI [G]suerte está en [A]tu mano.  \n[G]Me ha tocado un [A]lote hermoso, me [G]encanta MI [A]heredad.  \n\n[D]Bendeciré al [A]Señor que me [G]aconseja. Hasta de [A]noche me instruye internamente.  \n[D]Tengo siempre [A]presente al [G]Señor, con él a [A]MI derecha, no vacilaré.  \n\n[D]Me enseñarás el [A]sendero de [em]LA vida, me [G]saciarás, de gozo en tu presencia  \n[A]de alegría. [D]Por siempre a [A]tu derecha.\n"
-    },
-    {
-      "title": "02. El Señor es mi Pastor",
-      "filename": "senor_pastor.cho",
-      "author": "Nico Montero",
-      "key": "G",
-      "capo": 1,
-      "info": "",
-      "content": "{title: El Señor es Mi Pastor}\n{key: G}\n{capo: 1}\n\n[G]EL [D]SEÑOR ES MI [Em]PASTOR NADA ME [C]FALTA, EL SEÑOR ES MI [Am]PASTOR (bis)\n\n[G]En praderas [Bm]reposa [Em]MI alma, en su [C]agua descansa MI sed.  \n[C]Él me guía por [Am]senderos [D]justos, por amor por amor de su nombre.  \nAunque pase por valles oscuros, ningún  \n[Bm]mal ningún mal [Em]temeré, porque sé que el Señor va conmigo, su cayado sostiene mi feeeee.  \n[G]Tú preparas por mí una mesa, frente a aquellos que buscan MI mal. Con  \n[Em]Con aceite me ungiste Señor, y mi copa rebosa de ti, Gloria a Dios, Padre Omnipotente,  \n[Bm]y a su hijo Jesús, el Señor, y al Espíritu que habita en el mundo, por los siglos eternos amén  \n[C] [Am-A7] [D] [D7]\n"
-    }
-  ],
-  "D. Aleluya - Palabra 🎊": [
-    {
-      "title": "01. Aleluya Cantará",
-      "filename": "aleluya_cantara.cho",
-      "author": "Brotes de Olivo",
-      "key": "E",
-      "capo": 0,
-      "info": "",
-      "content": "{title: Aleluya Cantará}\n{key: E}\n\n[E]ALELUYA [A]CANTARÁ [B]QUIEN [E]PERDIÓ LA ESPERANZA Y LA TIERRA SONREIRÁ, ALELUYA.  \n[f#m] [G#7] [c#m] [A] [B] [E] [c#m] [B] [E]\n"
-    },
-    {
-      "title": "02. Aleluya",
-      "filename": "nunca_dejare.cho",
-      "author": "Kairoi",
-      "key": "C",
-      "capo": 2,
-      "info": "",
-      "content": "{title: Aleluya}\n{author: Kairoi}\n{key: C}\n{capo: 2}\n\n{soc}\n[C]ALELU[em]YA, [F]ALELU[G]YA, [C]ALELU[em]YA, [F]A[G]LELU[C]YA    \n{eoc}\n\n[C]Nunca [G]deja[am]ré [F]de can[dm]tar, \n[G]que tú eres LA luz y el amor  \n[C]Tu [G]ca[am]mi[F]no [dm]quie[G]ro seguir, no me dejes solo Señor.\n"
-    }
-  ]
+  "entrada": {
+    "categoryTitle": "A. Canciones Entrada 🎉",
+    "songs": [
+      {
+        "title": "01. Ven a Celebrar",
+        "filename": "ven_a_celebrar.cho",
+        "author": "",
+        "key": "G",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Ven a Celebrar}\n{key: G}\n\n\n[G]VEN A [bm]CELEBRAR EL [C]AMOR DE [G]DIOS, SE [C]DERRAMARÁ [G]COMO [C]AGUA [D]LIMPIA  \n[C]INUNDANDO [G]NUESTRAS [C]VIDAS DE [D]SU [D]PRESENCIA (bis)\n\n[em]Os [bm]aseguro [C]que [G]yo [C]estaré [G]cuando [C]dos o [D]más por [D]mí os reunáis.  \nEs [G]LA [C]mejor [D]forma de [D]creer en nuestra amistad (bis)\n"
+      },
+      {
+        "title": "02. Dios está aquí",
+        "filename": "dios_esta_aqui.cho",
+        "author": "",
+        "key": "C",
+        "capo": 1,
+        "info": "",
+        "content": "\n{title: Dios Está Aquí}\n{key: C}\n{capo: 1}\n{chordsize:14}\n{soc}\n[C]DIOS [G]ESTÁ [am]AQUÍ TAN [F]CIERTO COMO EL [G]AIRE QUE [C]RESPIRO  \n[F]TAN [G]CIERTO COMO LA [C-em-am]MAÑANA SE LEVANTA  \n[F]TAN [G]CIERTO COMO [C]QUE ESTE CANTO LO PUEDES OÍR  \n{eoc}\n[G]LO [F]PUEDES [C]SENTIR MOVIÉNDOSE ENTRE LOS QUE AMAN  \n[G]LO [F]PUEDES [G]OÍR CANTANDO CON NOSOTROS [C]AQUÍ  \n[G]LO [F]PUEDES [C]LLEVAR CUANDO POR ESA PUERTA [G]SALGAS  \n[G]LO [F]PUEDES [G]GUARDAR POR SIEMPRE EN TU [C]CORAZÓN (G7)\n"
+      }
+    ]
+  },
+  "salmos": {
+    "categoryTitle": "C. Salmos 📖",
+    "songs": [
+      {
+        "title": "01. El lote de mi Heredad",
+        "filename": "lote_heredad.cho",
+        "author": "",
+        "key": "D",
+        "capo": 0,
+        "info": "",
+        "content": "{title: El Lote de Mi Heredad}\n{key: D}\n\n{start_of_chorus}\n[D]EL [A]SEÑOR ES EL [bm]LOTE DE MI [G]HEREDAD, [D]ALELUYA  \n[bm]POR [A]SIEMPRE MI [G]ALMA TE [A]CANTARÁ, [D]ALELUYA\n{end_of_chorus}\n\n[bm]Protégeme [G]Dios [D]mío, me [G]refugio en [A]ti. Yo [G]digo al [A]Señor tú [D]eres MI bien.  \n[D]Los dioses y [A]señores de [bm]LA tierra no [G]me satisfacen.  \n\n[D]El Señor es el [A]lote de MI [bm]heredad. MI [G]suerte está en [A]tu mano.  \n[G]Me ha tocado un [A]lote hermoso, me [G]encanta MI [A]heredad.  \n\n[D]Bendeciré al [A]Señor que me [G]aconseja. Hasta de [A]noche me instruye internamente.  \n[D]Tengo siempre [A]presente al [G]Señor, con él a [A]MI derecha, no vacilaré.  \n\n[D]Me enseñarás el [A]sendero de [em]LA vida, me [G]saciarás, de gozo en tu presencia  \n[A]de alegría. [D]Por siempre a [A]tu derecha.\n"
+      },
+      {
+        "title": "02. El Señor es mi Pastor",
+        "filename": "senor_pastor.cho",
+        "author": "Nico Montero",
+        "key": "G",
+        "capo": 1,
+        "info": "",
+        "content": "{title: El Señor es Mi Pastor}\n{key: G}\n{capo: 1}\n\n[G]EL [D]SEÑOR ES MI [Em]PASTOR NADA ME [C]FALTA, EL SEÑOR ES MI [Am]PASTOR (bis)\n\n[G]En praderas [Bm]reposa [Em]MI alma, en su [C]agua descansa MI sed.  \n[C]Él me guía por [Am]senderos [D]justos, por amor por amor de su nombre.  \nAunque pase por valles oscuros, ningún  \n[Bm]mal ningún mal [Em]temeré, porque sé que el Señor va conmigo, su cayado sostiene mi feeeee.  \n[G]Tú preparas por mí una mesa, frente a aquellos que buscan MI mal. Con  \n[Em]Con aceite me ungiste Señor, y mi copa rebosa de ti, Gloria a Dios, Padre Omnipotente,  \n[Bm]y a su hijo Jesús, el Señor, y al Espíritu que habita en el mundo, por los siglos eternos amén  \n[C] [Am-A7] [D] [D7]\n"
+      }
+    ]
+  },
+  "aleluya": {
+    "categoryTitle": "D. Aleluya - Palabra 🎊",
+    "songs": [
+      {
+        "title": "01. Aleluya Cantará",
+        "filename": "aleluya_cantara.cho",
+        "author": "Brotes de Olivo",
+        "key": "E",
+        "capo": 0,
+        "info": "",
+        "content": "{title: Aleluya Cantará}\n{key: E}\n\n[E]ALELUYA [A]CANTARÁ [B]QUIEN [E]PERDIÓ LA ESPERANZA Y LA TIERRA SONREIRÁ, ALELUYA.  \n[f#m] [G#7] [c#m] [A] [B] [E] [c#m] [B] [E]\n"
+      },
+      {
+        "title": "02. Aleluya",
+        "filename": "nunca_dejare.cho",
+        "author": "Kairoi",
+        "key": "C",
+        "capo": 2,
+        "info": "",
+        "content": "{title: Aleluya}\n{author: Kairoi}\n{key: C}\n{capo: 2}\n\n{soc}\n[C]ALELU[em]YA, [F]ALELU[G]YA, [C]ALELU[em]YA, [F]A[G]LELU[C]YA    \n{eoc}\n\n[C]Nunca [G]deja[am]ré [F]de can[dm]tar, \n[G]que tú eres LA luz y el amor  \n[C]Tu [G]ca[am]mi[F]no [dm]quie[G]ro seguir, no me dejes solo Señor.\n"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- restructure `songs.json` to use simple keys and store titles via `categoryTitle`
- update categories screen to read new metadata
- update song list screen logic for new structure
- update selected songs screen logic for new structure

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851a7a204f88326bd1bb01a56397816