### PR TITLE
Add notation toggle and Spanish chord display

### DIFF
--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -45,7 +45,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
 
   // Settings from context
   const { settings, setSettings, isLoadingSettings } = useSettings(); // <<<--- USE SETTINGS HOOK
-  const { chordsVisible, fontSize: currentFontSizeEm, fontFamily: currentFontFamily } = settings;
+  const { chordsVisible, fontSize: currentFontSizeEm, fontFamily: currentFontFamily, notation } = settings;
 
   // songHtml state is now managed by useSongProcessor
   const [isFileLoading, setIsFileLoading] = useState(true); // Renamed from isLoading
@@ -70,6 +70,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
     chordsVisible, // From context
     currentFontSizeEm, // From context
     currentFontFamily, // From context
+    notation,
     author, // Pass author from route.params
     key,    // Pass key from route.params
     capo,   // Pass capo from route.params
@@ -169,6 +170,10 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
     setSettings({ fontFamily: newFontFamily });
   };
 
+  const handleToggleNotation = () => {
+    setSettings({ notation: notation === 'EN' ? 'ES' : 'EN' });
+  };
+
   const handleNavigateToFullscreen = () => {
     navigation.navigate('SongFullscreen', {
       filename,
@@ -253,10 +258,12 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
         currentFontSizeEm={currentFontSizeEm}
         currentFontFamily={currentFontFamily}
         availableFonts={availableFonts}
+        notation={notation}
         onToggleChords={handleToggleChords}
         onSetTranspose={handleSetTranspose} // Local handler
         onSetFontSize={handleSetFontSize}
         onSetFontFamily={handleSetFontFamily}
+        onToggleNotation={handleToggleNotation}
         onNavigateToFullscreen={handleNavigateToFullscreen}
       />
     </Animated.View>

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -15,10 +15,12 @@ interface SongControlsProps {
   currentFontSizeEm: number;
   currentFontFamily: string;
   availableFonts: FontOption[];
+  notation: 'EN' | 'ES';
   onToggleChords: () => void;
   onSetTranspose: (semitones: number) => void;
   onSetFontSize: (sizeEm: number) => void;
   onSetFontFamily: (fontFamily: string) => void;
+  onToggleNotation: () => void;
   onNavigateToFullscreen: () => void;
 }
 
@@ -28,10 +30,12 @@ const SongControls: React.FC<SongControlsProps> = ({
   currentFontSizeEm,
   currentFontFamily,
   availableFonts,
+  notation,
   onToggleChords,
   onSetTranspose,
   onSetFontSize,
   onSetFontFamily,
+  onToggleNotation,
   onNavigateToFullscreen,
 }) => {
   const [showActionButtons, setShowActionButtons] = useState(false);
@@ -79,13 +83,16 @@ const SongControls: React.FC<SongControlsProps> = ({
             <TouchableOpacity style={[styles.fabAction, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionActive]} onPress={handleOpenFontFamilyModal}>
               <Text style={[styles.fabActionText, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionTextActive]}>Tipo de Letra</Text>
             </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, notation !== 'EN' && styles.fabActionActive]} onPress={onToggleNotation}>
+              <Text style={[styles.fabActionText, notation !== 'EN' && styles.fabActionTextActive]}>Notación: {notation}</Text>
+            </TouchableOpacity>
             <TouchableOpacity style={styles.fabAction} onPress={onNavigateToFullscreen}>
               <Text style={styles.fabActionText}>Pantalla completa</Text>
             </TouchableOpacity>
           </View>
         )}
         <View style={{ position: 'relative' }}>
-          {(currentTranspose !== 0 || !chordsVisible || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue)) && (
+          {(currentTranspose !== 0 || !chordsVisible || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue) || notation !== 'EN') && (
             <View style={styles.badge} />
           )}
           <TouchableOpacity 

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -5,6 +5,8 @@ import { useSelectedSongs } from '../contexts/SelectedSongsContext'; // Correcte
 import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
+import { useSettings } from '../contexts/SettingsContext';
+import { convertChord } from '../utils/chordNotation';
 
 // Type for song data
 interface Song {
@@ -26,6 +28,8 @@ interface SongListItemProps {
 
 const SongListItem: React.FC<SongListItemProps> = ({ song, onPress, isSearchAllMode = false }) => {
   const { addSong, removeSong, isSongSelected } = useSelectedSongs();
+  const { settings } = useSettings();
+  const { notation } = settings;
   const scheme = useColorScheme();
   const styles = useMemo(() => createStyles(scheme || 'light'), [scheme]);
   const swipeableRow = useRef<Swipeable>(null);
@@ -141,7 +145,7 @@ const SongListItem: React.FC<SongListItemProps> = ({ song, onPress, isSearchAllM
           </View>
           <View style={styles.keyCapoContainer}>
             {song.key ? (
-              <Text style={styles.songKey}>{song.key.toUpperCase()}</Text>
+              <Text style={styles.songKey}>{convertChord(song.key.toUpperCase(), notation)}</Text>
             ) : null}
             {song.capo && song.capo > 0 ? (
               <Text style={styles.songCapo}>{`C/${song.capo}`}</Text>

--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -6,6 +6,7 @@ export interface SongSettings {
   chordsVisible: boolean;
   fontSize: number; // Using number for em value
   fontFamily: string;
+  notation: 'EN' | 'ES';
 }
 
 // Define the shape of the context value
@@ -20,6 +21,7 @@ const defaultSettings: SongSettings = {
   chordsVisible: true,
   fontSize: 1.0, // 1.0em
   fontFamily: "'Roboto Mono', 'Courier New', monospace", // Default font
+  notation: 'EN',
 };
 
 // Storage key
@@ -46,9 +48,12 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
         const storedSettings = await AsyncStorage.getItem(SETTINGS_STORAGE_KEY);
         if (storedSettings) {
           const parsedSettings = JSON.parse(storedSettings);
-          const { notation, ...restParsed } = parsedSettings;
           // Merge with defaults to ensure all keys are present if some were missing
-          setAppSettings(prev => ({ ...defaultSettings, ...restParsed, fontSize: restParsed.fontSize || defaultSettings.fontSize }));
+          setAppSettings(prev => ({
+            ...defaultSettings,
+            ...parsedSettings,
+            fontSize: parsedSettings.fontSize || defaultSettings.fontSize,
+          }));
         } else {
           setAppSettings(defaultSettings);
         }

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { ChordProParser, HtmlDivFormatter, Song, ChordLyricsPair } from 'chordsheetjs';
 import { AppColors } from '../app/styles/theme'; // Ensure this path is correct relative to the hooks folder
+import { convertHtmlChords, convertChord, Notation } from '../utils/chordNotation';
 
 interface UseSongProcessorParams {
   originalChordPro: string | null;
@@ -8,6 +9,7 @@ interface UseSongProcessorParams {
   chordsVisible: boolean;
   currentFontSizeEm: number;
   currentFontFamily: string;
+  notation: Notation;
   author?: string; // Added to pass author
   key?: string; // Added to pass key
   capo?: number; // Added to pass capo
@@ -19,6 +21,7 @@ export const useSongProcessor = ({
   chordsVisible,
   currentFontSizeEm,
   currentFontFamily,
+  notation,
   author,
   key,
   capo,
@@ -96,7 +99,7 @@ export const useSongProcessor = ({
 
 
       if (displayKey) {
-        finalKeyCapoString += `<strong>${displayKey}</strong>`;
+        finalKeyCapoString += `<strong>${convertChord(displayKey, notation)}</strong>`;
       }
 
       if (capo !== undefined && capo > 0) {
@@ -131,7 +134,7 @@ export const useSongProcessor = ({
 
       const chordsCss = chordsVisible ? '' : '<style>.chord { display: none !important; }</style>';
 
-      const finalHtml = `
+      let finalHtml = `
         <html>
         <head>
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
@@ -215,6 +218,7 @@ export const useSongProcessor = ({
         </body>
         </html>
       `;
+      finalHtml = convertHtmlChords(finalHtml, notation);
       setSongHtml(finalHtml);
     } catch (err) {
       console.error('Error procesando canción en useSongProcessor:', err);
@@ -222,7 +226,7 @@ export const useSongProcessor = ({
     } finally {
       setIsLoadingSong(false);
     }
-  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily, author, key, capo]);
+  }, [originalChordPro, currentTranspose, chordsVisible, currentFontSizeEm, currentFontFamily, notation, author, key, capo]);
 
   return { songHtml, isLoadingSong };
 };

--- a/mcm-app/utils/chordNotation.ts
+++ b/mcm-app/utils/chordNotation.ts
@@ -12,7 +12,12 @@ const EN_TO_ES_MAP: Record<string,string> = {
 
 export function convertChord(chord: string, notation: Notation): string {
   if (notation === 'EN') return chord;
-  return chord.replace(/(^|[\\/|-])([A-G])/g, (_, prefix: string, root: string) => prefix + EN_TO_ES_MAP[root] || root);
+  const converted = chord.replace(/(^|[\\/|-])([A-G])/g, (_, prefix: string, root: string) => {
+    return prefix + (EN_TO_ES_MAP[root] || root);
+  });
+
+  const isMinor = /[A-G][#b]?m(?![a-z])/i.test(chord);
+  return isMinor ? converted.toLowerCase() : converted;
 }
 
 export function convertHtmlChords(html: string, notation: Notation): string {

--- a/mcm-app/utils/chordNotation.ts
+++ b/mcm-app/utils/chordNotation.ts
@@ -1,13 +1,13 @@
 export type Notation = 'EN' | 'ES';
 
 const EN_TO_ES_MAP: Record<string,string> = {
-  A: 'La',
-  B: 'Si',
-  C: 'Do',
-  D: 'Re',
-  E: 'Mi',
-  F: 'Fa',
-  G: 'Sol',
+  A: 'LA',
+  B: 'SI',
+  C: 'DO',
+  D: 'RE',
+  E: 'MI',
+  F: 'FA',
+  G: 'SOL',
 };
 
 export function convertChord(chord: string, notation: Notation): string {

--- a/mcm-app/utils/chordNotation.ts
+++ b/mcm-app/utils/chordNotation.ts
@@ -1,0 +1,23 @@
+export type Notation = 'EN' | 'ES';
+
+const EN_TO_ES_MAP: Record<string,string> = {
+  A: 'La',
+  B: 'Si',
+  C: 'Do',
+  D: 'Re',
+  E: 'Mi',
+  F: 'Fa',
+  G: 'Sol',
+};
+
+export function convertChord(chord: string, notation: Notation): string {
+  if (notation === 'EN') return chord;
+  return chord.replace(/(^|[\\/|-])([A-G])/g, (_, prefix: string, root: string) => prefix + EN_TO_ES_MAP[root] || root);
+}
+
+export function convertHtmlChords(html: string, notation: Notation): string {
+  if (notation === 'EN') return html;
+  return html.replace(/(<div class="chord"[^>]*>)([^<]*)(<\/div>)/g, (_m, p1: string, chord: string, p3: string) => {
+    return p1 + convertChord(chord, notation) + p3;
+  });
+}


### PR DESCRIPTION
## Summary
- support storing chord notation in `SettingsContext`
- translate chords and HTML output via new utilities
- add notation toggle button in song controls
- display keys in selected notation in song list
- pass notation through song processing hooks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851f00fa39c8326a40f321344e28052