### PR TITLE
Fix search category codes and improve UI details

### DIFF
--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -86,7 +86,7 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
           {item.subtitulo && <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>}
         </View>
         <ScrollView contentContainerStyle={styles.pageContent}>
-          <Text>{item.texto}</Text>
+          <Text style={styles.pageText}>{item.texto}</Text>
         </ScrollView>
       </View>
     );
@@ -233,6 +233,10 @@ const createStyles = (scheme: ColorSchemeName, introColor: string) => {
   },
   pageContent: {
     padding: spacing.lg,
+  },
+  pageText: {
+    color: theme.text,
+    fontSize: 16,
   },
   dotsContainer: {
     flexDirection: 'row',

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -84,20 +84,26 @@ export default function SongsListScreen({ route, navigation }: {
           for (const originalCategoryKey in songsData) {
             if (Object.prototype.hasOwnProperty.call(songsData, originalCategoryKey)) {
               const categorySongs = songsData[originalCategoryKey].songs;
+              const categoryTitle = songsData[originalCategoryKey].categoryTitle;
+              const categoryLetterMatch = categoryTitle.match(/^[A-Za-z]/);
+              const categoryLetter = categoryLetterMatch
+                ? categoryLetterMatch[0].toUpperCase()
+                : originalCategoryKey.charAt(0).toUpperCase();
+
               const songsWithMetadata = categorySongs.map(song => {
                 const titleMatch = song.title.match(/^(\d{1,3})\.\s*/);
                 let numericPart = '';
                 if (titleMatch && titleMatch[1]) {
-                  numericPart = titleMatch[1].padStart(2, '0');
+                  numericPart = String(parseInt(titleMatch[1], 10));
                 } else {
                   const filenameMatch = song.filename.match(/_(\d+)\.html$/);
                   if (filenameMatch && filenameMatch[1]) {
-                    numericPart = filenameMatch[1].padStart(2, '0');
+                    numericPart = String(parseInt(filenameMatch[1], 10));
                   }
                 }
                 return {
                   ...song,
-                  originalCategoryKey: originalCategoryKey.charAt(0).toUpperCase(), // Take only the first character and ensure it's uppercase
+                  originalCategoryKey: categoryLetter,
                   numericFilenamePart: numericPart,
                 };
               });
@@ -296,7 +302,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       fontSize: 16,
       paddingLeft: 0,
       paddingTop: 0,
-      textAlignVertical: 'top',
+      textAlignVertical: 'center',
       color: isDark ? Colors.dark.text : Colors.light.text,
     },
     categoryTitle: {

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -117,10 +117,10 @@ const SongListItem: React.FC<SongListItemProps> = ({ song, onPress, isSearchAllM
             <View style={styles.metaLine}>
               {isSearchAllMode && song.originalCategoryKey && song.numericFilenamePart ? (
                 <Text style={styles.subtitleText} numberOfLines={1} ellipsizeMode="tail">
-                  {`${song.originalCategoryKey}.${song.numericFilenamePart}`}
+                  {`${song.originalCategoryKey}${song.numericFilenamePart}`}
                   {song.author && (
                     <Text style={styles.subtitleAuthor}>
-                      {`   ${song.author}`} {/* Three spaces for separation */}
+                      {`   ${song.author}`}
                     </Text>
                   )}
                 </Text>


### PR DESCRIPTION
## Summary
- ensure search results use category letter from `categoryTitle`
- remove leading zeros and period in search result codes
- vertically center text in search bar
- display material page text in theme color for dark mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851f1dff8d083268338bfb0710bc9ce