### PR TITLE
Fix agenda calendar display on web

### DIFF
--- a/mcm-app/.env.example
+++ b/mcm-app/.env.example
@@ -5,3 +5,4 @@ FIREBASE_PROJECT_ID=your_project_id
 FIREBASE_STORAGE_BUCKET=your_storage_bucket
 FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 FIREBASE_APP_ID=your_app_id
+CORS_PROXY_URL=https://corsproxy.io/?

--- a/mcm-app/app.config.ts
+++ b/mcm-app/app.config.ts
@@ -12,5 +12,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     firebaseStorageBucket: process.env.FIREBASE_STORAGE_BUCKET,
     firebaseMessagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
     firebaseAppId: process.env.FIREBASE_APP_ID,
+    corsProxyUrl: process.env.CORS_PROXY_URL,
   },
 });

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Constants from 'expo-constants';
 
 export interface CalendarConfig {
   url: string;
@@ -96,7 +97,7 @@ export default function useCalendarEvents(calendars: CalendarConfig[]) {
         const cfg = calendars[i];
         try {
 
-          const proxyBase = process.env.CORS_PROXY_URL;
+          const proxyBase = Constants.expoConfig?.extra?.corsProxyUrl ?? process.env.CORS_PROXY_URL;
           const proxyUrl = proxyBase ? proxyBase + encodeURIComponent(cfg.url) : null;
           let res: Response | null = null;
           if (proxyUrl) {


### PR DESCRIPTION
## Summary
- expose `CORS_PROXY_URL` in app config and env example
- use Expo constants to read proxy URL when fetching calendars

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851f744d03c8326bd528a1878338212