### PR TITLE
Add bottom settings panel with dark mode & font scaling

### DIFF
--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, ComponentProps } from 'react';
+import React, { useLayoutEffect, ComponentProps, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, ViewStyle, TextStyle } from 'react-native';
 import { Link, LinkProps } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
@@ -8,6 +8,7 @@ import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';
+import SettingsPanel from '@/components/SettingsPanel';
 
 interface NavigationItem {
   href?: LinkProps['href'];
@@ -26,7 +27,7 @@ const navigationItems: NavigationItem[] = [
   { label: 'Y mas cosas....', icon: 'hourglass-empty', backgroundColor: colors.danger, color: colors.black },
 ];
 
-interface IconButtonProps { color: string }
+interface IconButtonProps { color: string; onPress?: () => void }
 
 function NotificationsButton({ color }: IconButtonProps) {
   return (
@@ -55,14 +56,9 @@ function NotificationsButton({ color }: IconButtonProps) {
   );
 }
 
-function SettingsButton({ color }: IconButtonProps) {
-  const handlePress = () => {
-    // Mostrar un alert temporal
-    alert('Configuración: Próximamente...');
-  };
-
+function SettingsButton({ color, onPress }: IconButtonProps & { onPress: () => void }) {
   return (
-    <TouchableOpacity onPress={handlePress} style={{ padding: 8, marginLeft: 0 }}>
+    <TouchableOpacity onPress={onPress} style={{ padding: 8, marginLeft: 0 }}>
       <MaterialIcons name="settings" size={24} color={color} />
     </TouchableOpacity>
   );
@@ -71,12 +67,13 @@ function SettingsButton({ color }: IconButtonProps) {
 export default function Home() {
   const navigation = useNavigation();
   const scheme = useColorScheme();
+  const [settingsVisible, setSettingsVisible] = useState(false);
 
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (
         <View style={[styles.headerButtons, { paddingRight: spacing.md }]}>
-          <SettingsButton color={Colors[scheme ?? 'light'].icon} />
+          <SettingsButton color={Colors[scheme ?? 'light'].icon} onPress={() => setSettingsVisible(true)} />
           <NotificationsButton color={Colors[scheme ?? 'light'].icon} />
         </View>
       ),
@@ -85,7 +82,9 @@ export default function Home() {
   }, [navigation, scheme]);
 
   return (
-    <FlatList
+    <>
+      <SettingsPanel visible={settingsVisible} onClose={() => setSettingsVisible(false)} />
+      <FlatList
       style={{ backgroundColor: Colors[scheme ?? 'light'].background }}
       data={navigationItems}
       keyExtractor={(_, index) => index.toString()}
@@ -94,7 +93,7 @@ export default function Home() {
       contentContainerStyle={styles.container}
       renderItem={({ item }) => {
         const content = (
-          <View style={[styles.item, { backgroundColor: item.backgroundColor }]}>
+          <View style={[styles.item, { backgroundColor: item.backgroundColor }]}> 
             <MaterialIcons name={item.icon} size={48} color={item.color} style={styles.icon} />
             <Text style={[styles.label, { color: item.color }]}>{item.label}</Text>
           </View>
@@ -108,6 +107,7 @@ export default function Home() {
         );
       }}
     />
+    </>
   );
 }
 

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -18,6 +18,7 @@ import { ThemeProvider as NavThemeProvider, DarkTheme, DefaultTheme } from '@rea
 import { Slot } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { AppSettingsProvider } from '@/contexts/AppSettingsContext';
 import { HelloWave } from '@/components/HelloWave'; // Import HelloWave
 import { Provider as PaperProvider, MD3LightTheme, MD3DarkTheme, adaptNavigationTheme } from 'react-native-paper';
 import colors from '@/constants/colors';
@@ -26,6 +27,14 @@ import { useMemo } from 'react';
 
 
 export default function RootLayout() {
+  return (
+    <AppSettingsProvider>
+      <InnerLayout />
+    </AppSettingsProvider>
+  );
+}
+
+function InnerLayout() {
   const [showAnimation, setShowAnimation] = useState(true);
   const scheme = useColorScheme(); // Keep existing hooks
   

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import useFontScale from '@/hooks/useFontScale';
 import spacing from '@/constants/spacing';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
@@ -11,7 +12,8 @@ import { ThemedText } from '@/components/ThemedText';
 
 export default function HorarioScreen() {
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const fontScale = useFontScale();
+  const styles = React.useMemo(() => createStyles(scheme, fontScale), [scheme, fontScale]);
   const { data: horarioData, loading } = useFirebaseData<any[]>('jubileo/horario', 'jubileo_horario');
   const [index, setIndex] = useState(0);
   const fechas = horarioData ? horarioData.map((d) => ({ fecha: d.fecha, titulo: d.titulo })) : [];
@@ -40,7 +42,7 @@ export default function HorarioScreen() {
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark') => {
+const createStyles = (scheme: 'light' | 'dark', scale: number) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     container: {
@@ -58,7 +60,7 @@ const createStyles = (scheme: 'light' | 'dark') => {
     color: colors.white,
     textAlign: 'center',
     fontWeight: 'bold',
-    fontSize: 18,
+    fontSize: 18 * scale,
   },
   eventsContainer: {
     paddingHorizontal: spacing.lg,

--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, Dimensions, Text, FlatList, ScrollView, TouchableOpac
 import { RouteProp } from '@react-navigation/native';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import useFontScale from '@/hooks/useFontScale';
 import spacing from '@/constants/spacing';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
 
@@ -49,7 +50,8 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
   const { actividad, fecha } = route.params;
   const introBackgroundColor = actividad.color || colors.primary; // Fallback color
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme, introBackgroundColor), [scheme, introBackgroundColor]);
+  const fontScale = useFontScale(1.2);
+  const styles = React.useMemo(() => createStyles(scheme, introBackgroundColor, fontScale), [scheme, introBackgroundColor, fontScale]);
 
   const IntroPageItem = ({ actividad }: { actividad: Actividad; }) => {
     const circlesData = React.useMemo(() => generateRandomCircles(5), []);
@@ -185,7 +187,7 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
 }
 
 
-const createStyles = (scheme: ColorSchemeName, introColor: string) => {
+const createStyles = (scheme: ColorSchemeName, introColor: string, scale: number) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     container: { flex: 1 },
@@ -197,23 +199,23 @@ const createStyles = (scheme: ColorSchemeName, introColor: string) => {
     backgroundColor: introColor,
   },
   introEmoji: {
-    fontSize: 64,
+    fontSize: 64 * scale,
     marginBottom: spacing.lg,
   },
   introTitle: {
-    fontSize: 26,
+    fontSize: 26 * scale,
     fontWeight: 'bold',
     color: colors.white,
   },
   introDate: {
-    fontSize: 16,
+    fontSize: 16 * scale,
     color: colors.white,
     marginTop: 4,
   },
   introHint: {
     marginTop: spacing.md,
     color: colors.white,
-    fontSize: 12,
+    fontSize: 12 * scale,
   },
   page: {
     flex: 1,
@@ -222,12 +224,12 @@ const createStyles = (scheme: ColorSchemeName, introColor: string) => {
     padding: spacing.md,
   },
   pageTitle: {
-    fontSize: 20,
+    fontSize: 20 * scale,
     fontWeight: 'bold',
     color: colors.white,
   },
   pageSubtitle: {
-    fontSize: 16,
+    fontSize: 16 * scale,
     color: colors.white,
     marginTop: 4,
   },
@@ -236,7 +238,7 @@ const createStyles = (scheme: ColorSchemeName, introColor: string) => {
   },
   pageText: {
     color: theme.text,
-    fontSize: 16,
+    fontSize: 16 * scale,
   },
   dotsContainer: {
     flexDirection: 'row',
@@ -271,7 +273,7 @@ const createStyles = (scheme: ColorSchemeName, introColor: string) => {
   },
   arrowText: {
     color: colors.white,
-    fontSize: 28,
+    fontSize: 28 * scale,
     fontWeight: 'bold',
     lineHeight: 28,
   },

--- a/mcm-app/app/screens/MaterialesScreen.tsx
+++ b/mcm-app/app/screens/MaterialesScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity, Text } from 'react-native';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import useFontScale from '@/hooks/useFontScale';
 import spacing from '@/constants/spacing';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
@@ -22,7 +23,8 @@ type Nav = NativeStackNavigationProp<JubileoStackParamList, 'MaterialPages'>;
 export default function MaterialesScreen() {
   const navigation = useNavigation<Nav>();
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const fontScale = useFontScale(1.2);
+  const styles = React.useMemo(() => createStyles(scheme, fontScale), [scheme, fontScale]);
   const { data: materialesData, loading } = useFirebaseData<any[]>('jubileo/materiales', 'jubileo_materiales');
   const [index, setIndex] = useState(0);
   const fechas = materialesData ? materialesData.map((d) => ({ fecha: d.fecha })) : [];
@@ -51,7 +53,7 @@ export default function MaterialesScreen() {
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark') => {
+const createStyles = (scheme: 'light' | 'dark', scale: number) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     container: { flex: 1, backgroundColor: theme.background },
@@ -67,13 +69,13 @@ const createStyles = (scheme: 'light' | 'dark') => {
       marginBottom: spacing.md,
     },
     emoji: {
-      fontSize: 40,
+      fontSize: 40 * scale,
       marginBottom: spacing.sm,
     },
     cardText: {
       color: colors.white,
       fontWeight: 'bold',
-      fontSize: 18,
+      fontSize: 18 * scale,
     },
   });
 };

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -3,6 +3,7 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 import { List, Text } from 'react-native-paper';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import useFontScale from '@/hooks/useFontScale';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 
@@ -15,7 +16,8 @@ interface Pagina {
 
 export default function ProfundizaScreen() {
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const fontScale = useFontScale(1.2);
+  const styles = React.useMemo(() => createStyles(scheme, fontScale), [scheme, fontScale]);
   const { data: profundizaData, loading } = useFirebaseData<any>('jubileo/profundiza', 'jubileo_profundiza');
   const data = profundizaData as {
     titulo: string;
@@ -53,13 +55,13 @@ export default function ProfundizaScreen() {
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark') => {
+const createStyles = (scheme: 'light' | 'dark', scale: number) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     container: { flex: 1, backgroundColor: theme.background },
     content: { padding: 16 },
-    mainTitle: { fontSize: 24, fontWeight: 'bold', marginBottom: 8, color: theme.text },
-    intro: { fontSize: 16, marginBottom: 16, color: theme.text },
+    mainTitle: { fontSize: 24 * scale, fontWeight: 'bold', marginBottom: 8, color: theme.text },
+    intro: { fontSize: 16 * scale, marginBottom: 16, color: theme.text },
     accordion: { marginBottom: 12, borderRadius: 16 },
     accordionTitle: { color: colors.white, fontWeight: 'bold' },
     accordionContent: {
@@ -69,7 +71,7 @@ const createStyles = (scheme: 'light' | 'dark') => {
       padding: 12,
       margin: 8,
     },
-    subtitulo: { fontWeight: 'bold', marginBottom: 8, color: theme.text },
-    texto: { marginBottom: 12, color: theme.text },
+    subtitulo: { fontWeight: 'bold', marginBottom: 8, color: theme.text, fontSize: 14 * scale },
+    texto: { marginBottom: 12, color: theme.text, fontSize: 14 * scale },
   });
 };

--- a/mcm-app/components/EventItem.tsx
+++ b/mcm-app/components/EventItem.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { Card } from 'react-native-paper';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import useFontScale from '@/hooks/useFontScale';
 import spacing from '@/constants/spacing';
 
 export interface EventItemData {
@@ -15,7 +16,8 @@ export interface EventItemData {
 
 export default function EventItem({ event }: { event: EventItemData }) {
   const scheme = useColorScheme();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const fontScale = useFontScale();
+  const styles = React.useMemo(() => createStyles(scheme, fontScale), [scheme, fontScale]);
   return (
     <Card style={styles.card}>
       <Card.Content>
@@ -32,7 +34,7 @@ export default function EventItem({ event }: { event: EventItemData }) {
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark' | null) => {
+const createStyles = (scheme: 'light' | 'dark' | null, scale: number) => {
   const theme = Colors[scheme ?? 'light'];
   return StyleSheet.create({
     card: {
@@ -45,15 +47,15 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       gap: spacing.md,
     },
     emoji: {
-      fontSize: 24,
+      fontSize: 24 * scale,
     },
     title: {
-      fontSize: 16,
+      fontSize: 16 * scale,
       fontWeight: 'bold',
       color: theme.text,
     },
     subtitle: {
-      fontSize: 14,
+      fontSize: 14 * scale,
       color: theme.text,
     },
   });

--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Modal from 'react-native-modal';
+import { MaterialIcons } from '@expo/vector-icons';
+import useFontScale from '@/hooks/useFontScale';
+import { useAppSettings } from '@/contexts/AppSettingsContext';
+import { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsPanel({ visible, onClose }: Props) {
+  const { settings, setSettings } = useAppSettings();
+  const scheme = useColorScheme();
+  const theme = Colors[scheme];
+  const fontScale = useFontScale();
+
+  const increase = () => {
+    setSettings({ fontScale: Math.min(settings.fontScale + 0.1, 2) });
+  };
+
+  const decrease = () => {
+    setSettings({ fontScale: Math.max(1, settings.fontScale - 0.1) });
+  };
+
+  const toggleTheme = () => {
+    setSettings({ theme: settings.theme === 'light' ? 'dark' : 'light' });
+  };
+
+  return (
+    <Modal
+      isVisible={visible}
+      onBackdropPress={onClose}
+      style={styles.modal}
+      swipeDirection="down"
+      onSwipeComplete={onClose}
+      backdropOpacity={0.3}
+    >
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={styles.row}>
+          <TouchableOpacity onPress={decrease} disabled={settings.fontScale <= 1}>
+            <MaterialIcons name="text-fields" size={24} color={theme.text} style={{ transform: [{ scaleY: 0.8 }] }} />
+          </TouchableOpacity>
+          <Text style={[styles.value, { color: theme.text, fontSize: 16 * fontScale }]}>{(settings.fontScale * 100).toFixed(0)}%</Text>
+          <TouchableOpacity onPress={increase}>
+            <MaterialIcons name="text-fields" size={32} color={theme.text} />
+          </TouchableOpacity>
+        </View>
+        <TouchableOpacity style={styles.themeToggle} onPress={toggleTheme}>
+          <MaterialIcons
+            name={settings.theme === 'light' ? 'dark-mode' : 'light-mode'}
+            size={28}
+            color={theme.text}
+          />
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: { justifyContent: 'flex-end', margin: 0 },
+  container: {
+    padding: 20,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  value: {
+    fontWeight: 'bold',
+  },
+  themeToggle: {
+    marginTop: 20,
+    alignSelf: 'center',
+  },
+});

--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Appearance } from 'react-native';
+
+export type ThemeScheme = 'light' | 'dark';
+
+interface AppSettings {
+  fontScale: number;
+  theme: ThemeScheme;
+}
+
+interface AppSettingsContextType {
+  settings: AppSettings;
+  setSettings: (values: Partial<AppSettings>) => void;
+  loading: boolean;
+}
+
+const defaultSettings: AppSettings = {
+  fontScale: 1,
+  theme: Appearance.getColorScheme() === 'dark' ? 'dark' : 'light',
+};
+
+const STORAGE_KEY = '@app_settings';
+
+const AppSettingsContext = createContext<AppSettingsContextType | undefined>(undefined);
+
+export const AppSettingsProvider = ({ children }: { children: ReactNode }) => {
+  const [settings, setSettingsState] = useState<AppSettings>(defaultSettings);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await AsyncStorage.getItem(STORAGE_KEY);
+        if (data) {
+          setSettingsState(prev => ({ ...prev, ...JSON.parse(data) }));
+        }
+      } catch (e) {
+        console.error('Failed loading app settings', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (loading) return;
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings)).catch(e => {
+      console.error('Failed saving app settings', e);
+    });
+  }, [settings, loading]);
+
+  const update = (values: Partial<AppSettings>) => {
+    setSettingsState(prev => ({ ...prev, ...values }));
+  };
+
+  return (
+    <AppSettingsContext.Provider value={{ settings, setSettings: update, loading }}>
+      {children}
+    </AppSettingsContext.Provider>
+  );
+};
+
+export const useAppSettings = () => {
+  const ctx = useContext(AppSettingsContext);
+  if (!ctx) throw new Error('useAppSettings must be used within AppSettingsProvider');
+  return ctx;
+};

--- a/mcm-app/hooks/useColorScheme.ts
+++ b/mcm-app/hooks/useColorScheme.ts
@@ -1,6 +1,9 @@
 import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useAppSettings } from '@/contexts/AppSettingsContext';
 
 export function useColorScheme(): 'light' | 'dark' {
+  const { settings } = useAppSettings();
   const scheme = useRNColorScheme();
-  return scheme === 'dark' ? 'dark' : 'light';
+  const deviceScheme = scheme === 'dark' ? 'dark' : 'light';
+  return settings.theme || deviceScheme;
 }

--- a/mcm-app/hooks/useFontScale.ts
+++ b/mcm-app/hooks/useFontScale.ts
@@ -1,0 +1,6 @@
+import { useAppSettings } from '@/contexts/AppSettingsContext';
+
+export default function useFontScale(extra: number = 1) {
+  const { settings } = useAppSettings();
+  return settings.fontScale * extra;
+}

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -45,6 +45,7 @@
         "react-native": "0.79.3",
         "react-native-calendars": "^1.1312.1",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-modal": "^14.0.0-rc.1",
         "react-native-onesignal": "^5.2.11",
         "react-native-paper": "^5.14.4",
         "react-native-reanimated": "~3.17.4",
@@ -13188,6 +13189,15 @@
         }
       }
     },
+    "node_modules/react-native-animatable": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.4.0.tgz",
+      "integrity": "sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "node_modules/react-native-calendars": {
       "version": "1.1312.1",
       "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1312.1.tgz",
@@ -13253,6 +13263,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-modal": {
+      "version": "14.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-14.0.0-rc.1.tgz",
+      "integrity": "sha512-v5pvGyx1FlmBzdHyPqBsYQyS2mIJhVmuXyNo5EarIzxicKhuoul6XasXMviGcXboEUT0dTYWs88/VendojPiVw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-animatable": "1.4.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.70.0"
       }
     },
     "node_modules/react-native-onesignal": {

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -48,6 +48,7 @@
     "react-native": "0.79.3",
     "react-native-calendars": "^1.1312.1",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-modal": "^14.0.0-rc.1",
     "react-native-onesignal": "^5.2.11",
     "react-native-paper": "^5.14.4",
     "react-native-reanimated": "~3.17.4",


### PR DESCRIPTION
## Summary
- create `AppSettingsContext` to store theme and font scale in `AsyncStorage`
- add `SettingsPanel` bottom sheet to update font size and theme
- show settings panel from home screen
- allow custom theme via updated `useColorScheme`
- scale text sizes in Materiales, Profundiza, MaterialPages, Horario screens and event items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851fd0abd448326badc859e0ffeac63