### PR TITLE
Restore system dark mode detection

### DIFF
--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -1,8 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Appearance } from 'react-native';
 
-export type ThemeScheme = 'light' | 'dark';
+export type ThemeScheme = 'light' | 'dark' | null;
 
 interface AppSettings {
   fontScale: number;
@@ -17,7 +16,7 @@ interface AppSettingsContextType {
 
 const defaultSettings: AppSettings = {
   fontScale: 1,
-  theme: Appearance.getColorScheme() === 'dark' ? 'dark' : 'light',
+  theme: null,
 };
 
 const STORAGE_KEY = '@app_settings';

--- a/mcm-app/hooks/useColorScheme.ts
+++ b/mcm-app/hooks/useColorScheme.ts
@@ -5,5 +5,5 @@ export function useColorScheme(): 'light' | 'dark' {
   const { settings } = useAppSettings();
   const scheme = useRNColorScheme();
   const deviceScheme = scheme === 'dark' ? 'dark' : 'light';
-  return settings.theme || deviceScheme;
+  return settings.theme ?? deviceScheme;
 }


### PR DESCRIPTION
## Summary
- use `null` theme to follow device appearance
- improve color scheme hook logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685463fda41483268cc6e91fbecbe675