### PR TITLE
Refactor cantoral modals with SettingsPanel

### DIFF
--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Modal, Button, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import { View, Text, TouchableOpacity, Modal, Button, StyleSheet } from 'react-native';
 import theme from '../app/styles/theme'; // Default import for theme
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import SongTypographyPanel from './SongTypographyPanel';
 
 // Define availableFonts structure if not already globally defined
 interface FontOption {
@@ -40,12 +41,10 @@ const SongControls: React.FC<SongControlsProps> = ({
 }) => {
   const [showActionButtons, setShowActionButtons] = useState(false);
   const [showTransposeModal, setShowTransposeModal] = useState(false);
-  const [showFontSizeModal, setShowFontSizeModal] = useState(false);
-  const [showFontFamilyModal, setShowFontFamilyModal] = useState(false);
+  const [showTypographyPanel, setShowTypographyPanel] = useState(false);
 
   const handleOpenTransposeModal = () => setShowTransposeModal(true);
-  const handleOpenFontSizeModal = () => setShowFontSizeModal(true);
-  const handleOpenFontFamilyModal = () => setShowFontFamilyModal(true);
+  const handleOpenTypographyPanel = () => setShowTypographyPanel(true);
 
   // Wrapper for onSetTranspose to also close the modal
   const handleSetTransposeAndClose = (semitones: number) => {
@@ -53,16 +52,12 @@ const SongControls: React.FC<SongControlsProps> = ({
     //setShowTransposeModal(false); // Keep modal open to see changes, or close if preferred
   };
   
-  // Wrapper for onSetFontSize, modal can be kept open
-  const handleSetFontSizeAndClose = (size: number) => {
+  const handleSetFontSize = (size: number) => {
     onSetFontSize(size);
-    // setShowFontSizeModal(false); // Keep modal open
-  }
+  };
 
-  // Wrapper for onSetFontFamily to also close the modal
-  const handleSetFontFamilyAndClose = (fontFamily: string) => {
+  const handleSetFontFamily = (fontFamily: string) => {
     onSetFontFamily(fontFamily);
-    setShowFontFamilyModal(false);
   };
 
   return (
@@ -72,19 +67,16 @@ const SongControls: React.FC<SongControlsProps> = ({
         {showActionButtons && (
           <View style={styles.fabActionsContainer}>
             <TouchableOpacity style={[styles.fabAction, !chordsVisible && styles.fabActionActive]} onPress={onToggleChords}>
-              <Text style={[styles.fabActionText, !chordsVisible && styles.fabActionTextActive]}>Acordes {chordsVisible ? 'ON' : 'OFF'}</Text>
+              <Text style={[styles.fabActionText, !chordsVisible && styles.fabActionTextActive]}>Acordes: {chordsVisible ? 'ON' : 'OFF'}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.fabAction, notation !== 'ES' && styles.fabActionActive]} onPress={onToggleNotation}>
+              <Text style={[styles.fabActionText, notation !== 'ES' && styles.fabActionTextActive]}>Notación: {notation}</Text>
             </TouchableOpacity>
             <TouchableOpacity style={[styles.fabAction, currentTranspose !== 0 && styles.fabActionActive]} onPress={handleOpenTransposeModal}>
               <Text style={[styles.fabActionText, currentTranspose !== 0 && styles.fabActionTextActive]}>Cambiar tono</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.fabAction, currentFontSizeEm !== 1.0 && styles.fabActionActive]} onPress={handleOpenFontSizeModal}>
-              <Text style={[styles.fabActionText, currentFontSizeEm !== 1.0 && styles.fabActionTextActive]}>Tamaño Letra</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={[styles.fabAction, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionActive]} onPress={handleOpenFontFamilyModal}>
-              <Text style={[styles.fabActionText, availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue && styles.fabActionTextActive]}>Tipo de Letra</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={[styles.fabAction, notation !== 'EN' && styles.fabActionActive]} onPress={onToggleNotation}>
-              <Text style={[styles.fabActionText, notation !== 'EN' && styles.fabActionTextActive]}>Notación: {notation}</Text>
+            <TouchableOpacity style={[styles.fabAction, (currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue)) && styles.fabActionActive]} onPress={handleOpenTypographyPanel}>
+              <Text style={[styles.fabActionText, (currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue)) && styles.fabActionTextActive]}>Tipo de letra</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.fabAction} onPress={onNavigateToFullscreen}>
               <Text style={styles.fabActionText}>Pantalla completa</Text>
@@ -92,7 +84,7 @@ const SongControls: React.FC<SongControlsProps> = ({
           </View>
         )}
         <View style={{ position: 'relative' }}>
-          {(currentTranspose !== 0 || !chordsVisible || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue) || notation !== 'EN') && (
+          {(currentTranspose !== 0 || !chordsVisible || currentFontSizeEm !== 1.0 || (availableFonts.length > 0 && currentFontFamily !== availableFonts[0].cssValue) || notation !== 'ES') && (
             <View style={styles.badge} />
           )}
           <TouchableOpacity 
@@ -111,84 +103,37 @@ const SongControls: React.FC<SongControlsProps> = ({
         </View>
       </View>
 
-      {/* Font Size Modal */}
-      <Modal
-        transparent={true}
-        visible={showFontSizeModal}
-        onRequestClose={() => setShowFontSizeModal(false)}
-        animationType="fade"
-      >
-        <TouchableWithoutFeedback onPress={() => setShowFontSizeModal(false)}>
-          <View style={styles.modalOverlay}>
-            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-              <View style={styles.modalContent}>
-                <Text style={styles.modalTitle}>Ajustar Tamaño Letra</Text>
-                <View style={styles.fontSizeButtonRow}>
-                  <Button title="A+" onPress={() => handleSetFontSizeAndClose(currentFontSizeEm + 0.1)} />
-                  <Button title="A-" onPress={() => handleSetFontSizeAndClose(Math.max(0.5, currentFontSizeEm - 0.1))} />
-                </View>
-                <Button title={`Original (${(currentFontSizeEm * 100).toFixed(0)}%)`} onPress={() => handleSetFontSizeAndClose(1.0)} />
-                <Button title="Cerrar" onPress={() => setShowFontSizeModal(false)} color="#888"/>
-              </View>
-            </TouchableWithoutFeedback>
-          </View>
-        </TouchableWithoutFeedback>
-      </Modal>
 
-      {/* Font Family Modal */}
-      <Modal
-        transparent={true}
-        visible={showFontFamilyModal}
-        onRequestClose={() => setShowFontFamilyModal(false)}
-        animationType="fade"
-      >
-        <TouchableWithoutFeedback onPress={() => setShowFontFamilyModal(false)}>
-          <View style={styles.modalOverlay}>
-            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-              <View style={styles.modalContent}>
-                <Text style={styles.modalTitle}>Seleccionar Tipo de Letra</Text>
-                {availableFonts.map((font) => (
-                  <TouchableOpacity
-                    key={font.cssValue}
-                    style={styles.fontFamilyOptionButton}
-                    onPress={() => handleSetFontFamilyAndClose(font.cssValue)}
-                  >
-                    <Text style={[styles.fontFamilyOptionText, { fontFamily: font.cssValue }]}>{font.name}</Text>
-                  </TouchableOpacity>
-                ))}
-                <Button title="Cerrar" onPress={() => setShowFontFamilyModal(false)} color="#888"/>
-              </View>
-            </TouchableWithoutFeedback>
-          </View>
-        </TouchableWithoutFeedback>
-      </Modal>
+      <SongTypographyPanel
+        visible={showTypographyPanel}
+        onClose={() => setShowTypographyPanel(false)}
+        availableFonts={availableFonts}
+        onSetFontSize={handleSetFontSize}
+        onSetFontFamily={handleSetFontFamily}
+      />
 
       {/* Transpose Modal */}
       <Modal
-        transparent={true}
-        visible={showTransposeModal}
-        onRequestClose={() => setShowTransposeModal(false)}
-        animationType="fade"
+        isVisible={showTransposeModal}
+        onBackdropPress={() => setShowTransposeModal(false)}
+        style={styles.bottomModal}
+        swipeDirection="down"
+        onSwipeComplete={() => setShowTransposeModal(false)}
+        backdropOpacity={0.3}
       >
-        <TouchableWithoutFeedback onPress={() => setShowTransposeModal(false)}>
-          <View style={styles.modalOverlay}>
-            <TouchableWithoutFeedback onPress={(e) => e.stopPropagation()}>
-              <View style={styles.modalContent}>
-                <Text style={styles.modalTitle}>Cambio tono</Text>
-                <View style={styles.transposeButtonRow}>
-                  <Button title="+1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 1)} />
-                  <Button title="+1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 2)} />
-                </View>
-                <View style={styles.transposeButtonRow}>
-                  <Button title="-1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 1)} />
-                  <Button title="-1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 2)} />
-                </View>
-                <Button title="Tono Original 🔄" onPress={() => handleSetTransposeAndClose(0)} />
-                <Button title="Volver" onPress={() => setShowTransposeModal(false)} color="#888"/>
-              </View>
-            </TouchableWithoutFeedback>
+        <View style={styles.panel}>
+          <Text style={styles.modalTitle}>Cambio tono</Text>
+          <View style={styles.transposeButtonRow}>
+            <Button title="+1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 1)} />
+            <Button title="+1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose + 2)} />
           </View>
-        </TouchableWithoutFeedback>
+          <View style={styles.transposeButtonRow}>
+            <Button title="-1/2 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 1)} />
+            <Button title="-1 tono" onPress={() => handleSetTransposeAndClose(currentTranspose - 2)} />
+          </View>
+          <Button title="Tono Original 🔄" onPress={() => handleSetTransposeAndClose(0)} />
+          <Button title="Cerrar" onPress={() => setShowTransposeModal(false)} color="#888" />
+        </View>
       </Modal>
     </>
   );
@@ -207,7 +152,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   fabAction: {
-    backgroundColor: theme.backgroundLight,
+    backgroundColor: theme.accentYellow,
     paddingVertical: 8,
     paddingHorizontal: 16,
     borderRadius: 20,
@@ -225,7 +170,7 @@ const styles = StyleSheet.create({
     borderColor: theme.primaryDark,
   },
   fabActionText: {
-    color: theme.primary,
+    color: theme.textDark,
     fontWeight: 'bold',
   },
   fabActionTextActive: {
@@ -249,12 +194,6 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: 'bold',
   },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: theme.modalOverlay,
-  },
   badge: {
     position: 'absolute',
     right: -4,
@@ -273,49 +212,25 @@ const styles = StyleSheet.create({
     // Center icon in FAB
     alignSelf: 'center',
   },
-  modalContent: {
-    backgroundColor: 'white',
-    padding: 20,
-    borderRadius: 10,
-    width: '80%',
-    alignItems: 'center',
-    // Add shadow for modals if desired, e.g.:
-    // shadowColor: '#000',
-    // shadowOffset: { width: 0, height: 2 },
-    // shadowOpacity: 0.25,
-    // shadowRadius: 3.84,
-    // elevation: 5,
-  },
   modalTitle: {
     fontSize: 18,
     fontWeight: 'bold',
     marginBottom: 15,
     color: theme.textDark, // Ensure text color is appropriate
   },
-  fontFamilyOptionButton: {
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    backgroundColor: '#e9ecef',
-    marginBottom: 10,
-    alignItems: 'center',
-    width: '100%', // Make buttons take full width of modal content
-  },
-  fontFamilyOptionText: {
-    fontSize: 16,
-    color: theme.textDark,
+  bottomModal: { justifyContent: 'flex-end', margin: 0 },
+  panel: {
+    backgroundColor: theme.backgroundLight,
+    padding: 20,
+    paddingBottom: 40,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
   },
   transposeButtonRow: {
     flexDirection: 'row',
     justifyContent: 'space-around', // Or 'space-between'
     marginBottom: 15,
     width: '100%',
-  },
-  fontSizeButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-around', // Or 'space-between'
-    width: '100%',
-    marginBottom: 10,
   },
   // Ensure all necessary styles from SongDetailScreen related to FABs and Modals are here
 });

--- a/mcm-app/components/SongTypographyPanel.tsx
+++ b/mcm-app/components/SongTypographyPanel.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Modal from 'react-native-modal';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { useSettings } from '@/contexts/SettingsContext';
+
+interface FontOption {
+  name: string;
+  cssValue: string;
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  availableFonts: FontOption[];
+  onSetFontSize?: (sizeEm: number) => void;
+  onSetFontFamily?: (fontFamily: string) => void;
+}
+
+export default function SongTypographyPanel({ visible, onClose, availableFonts, onSetFontSize, onSetFontFamily }: Props) {
+  const { settings, setSettings } = useSettings();
+  const scheme = useColorScheme();
+  const theme = Colors[scheme ?? 'light'];
+
+  const increase = () => {
+    const newSize = settings.fontSize + 0.1;
+    setSettings({ fontSize: newSize });
+    onSetFontSize?.(newSize);
+  };
+
+  const decrease = () => {
+    const newSize = Math.max(0.6, settings.fontSize - 0.1);
+    setSettings({ fontSize: newSize });
+    onSetFontSize?.(newSize);
+  };
+
+  const changeFamily = (fontFamily: string) => {
+    setSettings({ fontFamily });
+    onSetFontFamily?.(fontFamily);
+  };
+
+  return (
+    <Modal
+      isVisible={visible}
+      onBackdropPress={onClose}
+      style={styles.modal}
+      swipeDirection="down"
+      onSwipeComplete={onClose}
+      backdropOpacity={0.3}
+    >
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={styles.row}>
+          <TouchableOpacity onPress={decrease}>
+            <MaterialIcons name="text-fields" size={24} color={theme.text} style={{ transform: [{ scaleY: 0.8 }] }} />
+          </TouchableOpacity>
+          <Text style={[styles.value, { color: theme.text }]}>{(settings.fontSize * 100).toFixed(0)}%</Text>
+          <TouchableOpacity onPress={increase}>
+            <MaterialIcons name="text-fields" size={32} color={theme.text} />
+          </TouchableOpacity>
+        </View>
+        {availableFonts.map(font => (
+          <TouchableOpacity key={font.cssValue} style={styles.fontOption} onPress={() => changeFamily(font.cssValue)}>
+            <Text style={[styles.fontOptionText, { color: theme.text, fontFamily: font.cssValue }]}>{font.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: { justifyContent: 'flex-end', margin: 0 },
+  container: {
+    padding: 20,
+    paddingBottom: 40,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  value: { fontWeight: 'bold' },
+  fontOption: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  fontOptionText: {
+    fontSize: 16,
+  },
+});

--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -21,7 +21,7 @@ const defaultSettings: SongSettings = {
   chordsVisible: true,
   fontSize: 1.0, // 1.0em
   fontFamily: "'Roboto Mono', 'Courier New', monospace", // Default font
-  notation: 'EN',
+  notation: 'ES',
 };
 
 // Storage key


### PR DESCRIPTION
## Summary
- redesign song controls to use yellow action buttons and bottom panels
- add `SongTypographyPanel` component for font options
- default notation is now ES

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68546392a0a48326824bcde5624dd653