### PR TITLE
Fix system dark mode handling

### DIFF
--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -27,7 +27,13 @@ export default function SettingsPanel({ visible, onClose }: Props) {
   };
 
   const toggleTheme = () => {
-    setSettings({ theme: settings.theme === 'light' ? 'dark' : 'light' });
+    const nextTheme =
+      settings.theme === 'light'
+        ? 'dark'
+        : settings.theme === 'dark'
+        ? 'system'
+        : 'light';
+    setSettings({ theme: nextTheme });
   };
 
   return (
@@ -51,7 +57,13 @@ export default function SettingsPanel({ visible, onClose }: Props) {
         </View>
         <TouchableOpacity style={styles.themeToggle} onPress={toggleTheme}>
           <MaterialIcons
-            name={settings.theme === 'light' ? 'dark-mode' : 'light-mode'}
+            name={
+              settings.theme === 'light'
+                ? 'dark-mode'
+                : settings.theme === 'dark'
+                ? 'brightness-auto'
+                : 'light-mode'
+            }
             size={28}
             color={theme.text}
           />

--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import Modal from 'react-native-modal';
 import { MaterialIcons } from '@expo/vector-icons';
 import useFontScale from '@/hooks/useFontScale';
-import { useAppSettings } from '@/contexts/AppSettingsContext';
+import { useAppSettings, ThemeScheme } from '@/contexts/AppSettingsContext';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
@@ -26,14 +26,8 @@ export default function SettingsPanel({ visible, onClose }: Props) {
     setSettings({ fontScale: Math.max(1, settings.fontScale - 0.1) });
   };
 
-  const toggleTheme = () => {
-    const nextTheme =
-      settings.theme === 'light'
-        ? 'dark'
-        : settings.theme === 'dark'
-        ? 'system'
-        : 'light';
-    setSettings({ theme: nextTheme });
+  const setTheme = (theme: ThemeScheme) => {
+    setSettings({ theme });
   };
 
   return (
@@ -55,19 +49,35 @@ export default function SettingsPanel({ visible, onClose }: Props) {
             <MaterialIcons name="text-fields" size={32} color={theme.text} />
           </TouchableOpacity>
         </View>
-        <TouchableOpacity style={styles.themeToggle} onPress={toggleTheme}>
-          <MaterialIcons
-            name={
-              settings.theme === 'light'
-                ? 'dark-mode'
-                : settings.theme === 'dark'
-                ? 'brightness-auto'
-                : 'light-mode'
-            }
-            size={28}
-            color={theme.text}
-          />
-        </TouchableOpacity>
+        <View style={styles.themeToggleRow}>
+          <TouchableOpacity
+            onPress={() => setTheme('light')}
+            style={[
+              styles.themeButton,
+              settings.theme === 'light' && styles.themeSelected,
+            ]}
+          >
+            <MaterialIcons name="light-mode" size={28} color={theme.text} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => setTheme('dark')}
+            style={[
+              styles.themeButton,
+              settings.theme === 'dark' && styles.themeSelected,
+            ]}
+          >
+            <MaterialIcons name="dark-mode" size={28} color={theme.text} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => setTheme('system')}
+            style={[
+              styles.themeButton,
+              settings.theme === 'system' && styles.themeSelected,
+            ]}
+          >
+            <MaterialIcons name="brightness-auto" size={28} color={theme.text} />
+          </TouchableOpacity>
+        </View>
       </View>
     </Modal>
   );
@@ -89,8 +99,16 @@ const styles = StyleSheet.create({
   value: {
     fontWeight: 'bold',
   },
-  themeToggle: {
+  themeToggleRow: {
     marginTop: 20,
-    alignSelf: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+  },
+  themeButton: {
+    opacity: 0.6,
+  },
+  themeSelected: {
+    opacity: 1,
   },
 });

--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -1,8 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Appearance } from 'react-native';
 
-export type ThemeScheme = 'light' | 'dark';
+export type ThemeScheme = 'light' | 'dark' | 'system';
 
 interface AppSettings {
   fontScale: number;
@@ -17,7 +16,7 @@ interface AppSettingsContextType {
 
 const defaultSettings: AppSettings = {
   fontScale: 1,
-  theme: Appearance.getColorScheme() === 'dark' ? 'dark' : 'light',
+  theme: 'system',
 };
 
 const STORAGE_KEY = '@app_settings';

--- a/mcm-app/hooks/useColorScheme.ts
+++ b/mcm-app/hooks/useColorScheme.ts
@@ -1,13 +1,24 @@
-import { useColorScheme as useRNColorScheme } from 'react-native';
+import { Appearance, ColorSchemeName } from 'react-native';
 import { useAppSettings } from '@/contexts/AppSettingsContext';
+import { useEffect, useState } from 'react';
 
 export function useColorScheme(): 'light' | 'dark' {
   const { settings } = useAppSettings();
-  const scheme = useRNColorScheme();
-  const deviceScheme = scheme === 'dark' ? 'dark' : 'light';
+  const [deviceScheme, setDeviceScheme] = useState<'light' | 'dark'>(
+    Appearance.getColorScheme() === 'dark' ? 'dark' : 'light'
+  );
+
+  useEffect(() => {
+    const listener = ({ colorScheme }: { colorScheme: ColorSchemeName }) => {
+      setDeviceScheme(colorScheme === 'dark' ? 'dark' : 'light');
+    };
+    const subscription = Appearance.addChangeListener(listener);
+    return () => subscription.remove();
+  }, []);
 
   if (settings.theme === 'system') {
     return deviceScheme;
   }
+
   return settings.theme;
 }

--- a/mcm-app/hooks/useColorScheme.ts
+++ b/mcm-app/hooks/useColorScheme.ts
@@ -5,5 +5,9 @@ export function useColorScheme(): 'light' | 'dark' {
   const { settings } = useAppSettings();
   const scheme = useRNColorScheme();
   const deviceScheme = scheme === 'dark' ? 'dark' : 'light';
-  return settings.theme || deviceScheme;
+
+  if (settings.theme === 'system') {
+    return deviceScheme;
+  }
+  return settings.theme;
 }


### PR DESCRIPTION
## Summary
- support `system` theme to sync with OS
- cycle theme between light, dark and system in settings panel

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Cannot find module './comunica.module.css', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685463fda41483268cc6e91fbecbe675