### PR TITLE
Add search to jubileo groups

### DIFF
--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -1,6 +1,11 @@
-import React, { useState } from 'react';
-import { ScrollView, StyleSheet, View, TouchableOpacity } from 'react-native';
-import { List, IconButton, Text } from 'react-native-paper';
+import React, { useState, useMemo } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  TouchableOpacity,
+} from 'react-native';
+import { List, IconButton, Text, Searchbar } from 'react-native-paper';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
@@ -27,14 +32,112 @@ export default function GruposScreen() {
   ];
   const [categoria, setCategoria] = useState<string | null>(null);
   const [grupo, setGrupo] = useState<Grupo | null>(null);
+  const [showSearch, setShowSearch] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const searchResults = useMemo(() => {
+    if (!data || search.trim().length < 3) return [];
+    const q = search.trim().toLowerCase();
+    const res: { categoria: string; grupo: Grupo; matches: string[] }[] = [];
+    Object.entries(data).forEach(([cat, grupos]) => {
+      grupos.forEach((g) => {
+        const matches: string[] = [];
+        if (g.nombre.toLowerCase().includes(q)) {
+          matches.push('__match_name__');
+        }
+        if (g.responsable && g.responsable.toLowerCase().includes(q)) {
+          matches.push(g.responsable);
+        }
+        g.miembros.forEach((m) => {
+          if (m.toLowerCase().includes(q)) {
+            matches.push(m);
+          }
+        });
+        if (matches.length > 0) {
+          res.push({ categoria: cat, grupo: g, matches });
+        }
+      });
+    });
+    return res;
+  }, [search, data]);
 
   if (categoria && (loading || !data)) {
     return <ProgressWithMessage message="Cargando grupos..." />;
   }
 
-  if (!categoria) {
+  if (showSearch) {
+    const grouped: Record<string, { grupo: Grupo; matches: string[] }[]> = {};
+    searchResults.forEach((r) => {
+      if (!grouped[r.categoria]) grouped[r.categoria] = [];
+      grouped[r.categoria].push({ grupo: r.grupo, matches: r.matches });
+    });
+    return (
+      <ScrollView style={styles.container}>
+        <View style={styles.backWrapper}>
+          <IconButton
+            icon="arrow-left"
+            size={24}
+            onPress={() => {
+              setShowSearch(false);
+              setSearch('');
+            }}
+          />
+        </View>
+        <Searchbar
+          placeholder="Buscar grupo o persona"
+          placeholderTextColor="#8A8A8D"
+          iconColor="#8A8A8D"
+          onChangeText={setSearch}
+          value={search}
+          style={styles.searchbar}
+          inputStyle={styles.searchbarInput}
+          autoFocus
+        />
+        {search.trim().length < 3 ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.hintText}>Escribe al menos 3 caracteres</Text>
+          </View>
+        ) : searchResults.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>No se han encontrado resultados</Text>
+          </View>
+        ) : (
+          Object.entries(grouped).map(([cat, grupos]) => (
+            <View key={cat}>
+              <List.Subheader style={styles.sectionHeader}>{cat}</List.Subheader>
+              {grupos.map(({ grupo: g, matches }, idx) => (
+                <View key={idx}>
+                  <List.Item
+                    title={g.nombre}
+                    description={g.subtitulo}
+                    onPress={() => {
+                      setCategoria(cat);
+                      setGrupo(g);
+                      setShowSearch(false);
+                      setSearch('');
+                    }}
+                    titleStyle={styles.groupListTitle}
+                  />
+                  {matches
+                    .filter((m) => m !== '__match_name__')
+                    .map((m, j) => (
+                      <List.Item key={j} title={m} style={styles.matchItem} />
+                    ))}
+                </View>
+              ))}
+            </View>
+          ))
+        )}
+      </ScrollView>
+    );
+  }
+
+  if (!categoria && !showSearch) {
     return (
       <ScrollView style={styles.container} contentContainerStyle={styles.catList}>
+        <View style={styles.searchButtonWrapper}>
+          <IconButton icon="magnify" size={24} onPress={() => setShowSearch(true)} />
+        </View>
         {categorias.map((c) => (
           <TouchableOpacity
             key={c.name}
@@ -112,5 +215,41 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
   sectionHeader: { fontSize: 16, fontWeight: 'bold', color: theme.text },
   groupContainer: { paddingHorizontal: 16 },
   groupTitle: { fontSize: 22, fontWeight: 'bold', marginVertical: 8, color: theme.text },
+  searchbar: {
+    marginHorizontal: 16,
+    marginVertical: 12,
+    borderRadius: 20,
+    backgroundColor: scheme === 'dark' ? '#2C2C2E' : '#fff',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    height: 44,
+    borderWidth: 1,
+    borderColor: scheme === 'dark' ? '#444' : '#E0E0E0',
+  },
+  searchbarInput: {
+    fontSize: 16,
+    paddingLeft: 0,
+    paddingTop: 0,
+    textAlignVertical: 'center',
+    color: scheme === 'dark' ? Colors.dark.text : Colors.light.text,
+  },
+  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  emptyText: {
+    fontSize: 16,
+    color: scheme === 'dark' ? '#CCCCCC' : '#666',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  hintText: {
+    fontSize: 14,
+    color: scheme === 'dark' ? '#AAAAAA' : '#888',
+    fontStyle: 'italic',
+    textAlign: 'center',
+  },
+  searchButtonWrapper: { alignItems: 'flex-end', padding: 8 },
+  matchItem: { paddingLeft: 32 },
 });
 };


### PR DESCRIPTION
## Summary
- add search bar to `GruposScreen`
- list results grouped by category
- allow searching by group name, responsible or member names
- require at least 3 characters

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68546b172f948326ae16ae364d476590