### PR TITLE
Fix lint warnings

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -4,7 +4,7 @@ import { MaterialIcons } from '@expo/vector-icons'; // Asegúrate de tenerlo imp
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import colors, { Colors } from '@/constants/colors'; //
+import { Colors } from '@/constants/colors';
 
 export default function TabsLayout() {
   const scheme = useColorScheme(); //

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -1,4 +1,4 @@
-import { createNativeStackNavigator, NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 // Importar pantallas
 import CategoriesScreen from '../screens/CategoriesScreen';

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -1,6 +1,6 @@
 // app/(tabs)/fotos.tsx
 import React, { useState, useEffect } from 'react';
-import { View, FlatList, StyleSheet, Linking, useWindowDimensions, ViewStyle, TextStyle, Alert } from 'react-native';
+import { View, FlatList, StyleSheet, Linking, useWindowDimensions, ViewStyle, Alert } from 'react-native';
 import { Button, ActivityIndicator } from 'react-native-paper';
 import AlbumCard from '@/components/AlbumCard';
 import ProgressWithMessage from '@/components/ProgressWithMessage';

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -3,7 +3,6 @@ import { View, Text, StyleSheet, FlatList, TouchableOpacity, ViewStyle, TextStyl
 import { Link, LinkProps } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { Badge } from 'react-native-paper';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -11,7 +11,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'; *
  const NOTIFICATIONS_STORAGE_KEY = 'bf78779e-4d63-444f-a72e-ce5e0fb2bf80';  */
 
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { View, StyleSheet } from 'react-native';
 import { ThemeProvider as NavThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
@@ -20,9 +20,8 @@ import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { AppSettingsProvider } from '@/contexts/AppSettingsContext';
 import { HelloWave } from '@/components/HelloWave'; // Import HelloWave
-import { Provider as PaperProvider, MD3LightTheme, MD3DarkTheme, adaptNavigationTheme } from 'react-native-paper';
+import { Provider as PaperProvider, MD3LightTheme, MD3DarkTheme } from 'react-native-paper';
 import colors from '@/constants/colors';
-import { useMemo } from 'react';
 
 
 

--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -3,8 +3,10 @@ import { ScrollView, StyleSheet, View, Linking } from 'react-native';
 import { List, IconButton, Avatar } from 'react-native-paper';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
-import colors, { Colors } from '@/constants/colors';
+import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+
+const PALETTE = ['#FF8A65', '#4FC3F7', '#81C784', '#BA68C8', '#FFD54F', '#9FA8DA'];
 
 interface Contacto {
   nombre: string;
@@ -18,9 +20,8 @@ export default function ContactosScreen() {
   const { data: contacts, loading } = useFirebaseData<Contacto[]>('jubileo/contactos', 'jubileo_contactos');
   const data = contacts as Contacto[] | undefined;
 
-  const palette = ['#FF8A65', '#4FC3F7', '#81C784', '#BA68C8', '#FFD54F', '#9FA8DA'];
   const colorsForContacts = React.useMemo(
-    () => (data || []).map(() => palette[Math.floor(Math.random() * palette.length)]),
+    () => (data || []).map(() => PALETTE[Math.floor(Math.random() * PALETTE.length)]),
     [data]
   );
 

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { View, StyleSheet, Text, TouchableOpacity, ViewStyle, TextStyle, useWindowDimensions, ScrollView } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import colors, { Colors } from '@/constants/colors';
+import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import typography from '@/constants/typography';

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet, ScrollView, TouchableOpacity, Platform, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, ScrollView, Platform, ActivityIndicator } from 'react-native';
 import { Card, Text, FAB, Portal, Modal, TextInput, Switch, Button, Chip } from 'react-native-paper';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import colors, { Colors } from '@/constants/colors';
 import spacing from '@/constants/spacing';
@@ -27,7 +27,7 @@ export default function ReflexionesScreen() {
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
 
-  const { data: dataRef, loading } = useFirebaseData<Reflexion[]>('jubileo/compartiendo', 'jubileo_compartiendo');
+  const { data: dataRef } = useFirebaseData<Reflexion[]>('jubileo/compartiendo', 'jubileo_compartiendo');
   const { data: gruposData } = useFirebaseData<Record<string, Grupo[]>>('jubileo/grupos', 'jubileo_grupos');
 
   const grupos = gruposData?.['Conso+'] ?? [];
@@ -55,7 +55,6 @@ export default function ReflexionesScreen() {
 
   const showDatePicker = () => {
     if (Platform.OS === 'android') {
-      const { DateTimePickerAndroid } = require('@react-native-community/datetimepicker');
       DateTimePickerAndroid.open({
         value: fecha,
         mode: 'date',

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -10,7 +10,6 @@ import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSelectedSongs } from '../../contexts/SelectedSongsContext'; // Import context hook
 import { IconSymbol } from '../../components/ui/IconSymbol'; // Import IconSymbol
 import { useSettings } from '../../contexts/SettingsContext'; // <<<--- ADD THIS IMPORT
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 const availableFonts = [
   { name: 'Monoespaciada', cssValue: "'Roboto Mono', 'Courier New', monospace" },
@@ -77,10 +76,11 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
   });
 
   // Effect for setting header button
+  const isSelected = isSongSelected(filename);
   useLayoutEffect(() => {
     if (!filename) return; // Don't set header if filename is not available
 
-    const currentlySelected = isSongSelected(filename);
+    const currentlySelected = isSelected;
     
     // Configuración del botón derecho
     const headerRight = () => (
@@ -124,7 +124,7 @@ export default function SongDetailScreen({ route, navigation }: SongDetailScreen
       
       return () => clearTimeout(timer);
     }
-  }, [navigation, filename, isSongSelected(filename), addSong, removeSong]);
+  }, [navigation, filename, isSelected, addSong, removeSong]);
 
   // Effect for loading the ChordPro file content
   useEffect(() => {

--- a/mcm-app/components/AlbumCard.tsx
+++ b/mcm-app/components/AlbumCard.tsx
@@ -19,7 +19,6 @@ interface AlbumCardProps {
 const AlbumCard: React.FC<AlbumCardProps> = ({ album, onPress }) => {
   const { width } = useWindowDimensions();
   const activeStyles = styles(width);
-  const { location, date } = album; // Directly use from album prop
   return (
     <TouchableOpacity style={activeStyles.card} onPress={onPress} activeOpacity={0.8}>
       <View style={activeStyles.cardContent}>

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -4,7 +4,6 @@ import { Swipeable } from 'react-native-gesture-handler';
 import { useSelectedSongs } from '../contexts/SelectedSongsContext'; // Corrected path
 import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { Colors } from '@/constants/colors';
 import { useSettings } from '../contexts/SettingsContext';
 import { convertChord } from '../utils/chordNotation';
 

--- a/mcm-app/components/ThemedText.tsx
+++ b/mcm-app/components/ThemedText.tsx
@@ -1,6 +1,5 @@
 import { StyleSheet, Text, type TextProps, type TextStyle } from 'react-native';
-import typography, { type Typography } from '@/constants/typography';
-import { Colors } from '@/constants/colors';
+import typography from '@/constants/typography';
 import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedTextProps = TextProps & {

--- a/mcm-app/components/ui/IconSymbol.tsx
+++ b/mcm-app/components/ui/IconSymbol.tsx
@@ -1,8 +1,7 @@
 // Fallback for using MaterialIcons on Android and web.
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
-import { ComponentProps } from 'react';
+import { SymbolWeight } from 'expo-symbols';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
 // Define a more specific type for our icon mapping


### PR DESCRIPTION
## Summary
- clean unused imports across various screens and components
- memoize palette constant and remove redundant dependencies
- consolidate React imports in root layout
- drop duplicate React import
- adjust hook dependencies in song detail screen
- fix TypeScript lint warnings

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68547978942c83269256590453c144af