### PR TITLE
feat: redesign home screen

### DIFF
--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, ComponentProps, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, ViewStyle, TextStyle } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, ViewStyle, TextStyle, useWindowDimensions } from 'react-native';
 import { Link, LinkProps } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -22,7 +22,7 @@ const navigationItems: NavigationItem[] = [
   { href: '/fotos', label: 'Fotos', icon: 'photo-library', backgroundColor: colors.accent, color: colors.black },
   { href: '/calendario', label: 'Calendario', icon: 'event', backgroundColor: colors.info, color: colors.black },
   { href: '/comunica', label: 'Comunica', icon: 'chat', backgroundColor: colors.success, color: colors.black },
-  { href: '/jubileo', label: 'Jubileo', icon: 'party-mode', backgroundColor: colors.warning, color: colors.black },
+  { href: '/jubileo', label: 'Jubileo', icon: 'celebration', backgroundColor: colors.warning, color: colors.black },
   { label: 'Y mas cosas....', icon: 'hourglass-empty', backgroundColor: colors.danger, color: colors.black },
 ];
 
@@ -63,10 +63,24 @@ function SettingsButton({ color, onPress }: IconButtonProps & { onPress: () => v
   );
 }
 
+function DecorationCircles() {
+  return (
+    <>
+      <View style={[styles.circle, styles.circleSmall]} />
+      <View style={[styles.circle, styles.circleLarge]} />
+    </>
+  );
+}
+
 export default function Home() {
   const navigation = useNavigation();
   const scheme = useColorScheme();
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const { width, height } = useWindowDimensions();
+  const containerPadding = spacing.md;
+  const gap = spacing.md;
+  const itemWidth = (width - containerPadding * 2 - gap) / 2;
+  const itemHeight = Math.min(160, (height - containerPadding * 2 - gap * 3) / 3);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -89,10 +103,13 @@ export default function Home() {
       keyExtractor={(_, index) => index.toString()}
       numColumns={2}
       columnWrapperStyle={styles.row}
-      contentContainerStyle={styles.container}
+      contentContainerStyle={[styles.container, { padding: containerPadding }]}
       renderItem={({ item }) => {
         const content = (
-          <View style={[styles.item, { backgroundColor: item.backgroundColor }]}> 
+          <View
+            style={[styles.item, { backgroundColor: item.backgroundColor, width: itemWidth, height: itemHeight }]}
+          >
+            <DecorationCircles />
             <MaterialIcons name={item.icon} size={48} color={item.color} style={styles.icon} />
             <Text style={[styles.label, { color: item.color }]}>{item.label}</Text>
           </View>
@@ -118,22 +135,24 @@ interface Styles {
   icon: TextStyle;
   label: TextStyle;
   headerButtons: ViewStyle;
+  circle: ViewStyle;
+  circleSmall: ViewStyle;
+  circleLarge: ViewStyle;
 }
 
 const styles = StyleSheet.create<Styles>({
   container: {
-    padding: spacing.lg,
+    padding: spacing.md,
   },
   row: {
     justifyContent: 'space-between',
-    marginBottom: spacing.lg,
+    marginBottom: spacing.md,
   },
   itemWrapper: {
     flex: 1,
     marginHorizontal: spacing.sm / 2,
   },
   item: {
-    aspectRatio: 1,
     borderRadius: 16,
     justifyContent: 'center',
     alignItems: 'center',
@@ -150,5 +169,24 @@ const styles = StyleSheet.create<Styles>({
   headerButtons: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  circle: {
+    position: 'absolute',
+    opacity: 0.2,
+    backgroundColor: '#ffffff',
+  },
+  circleSmall: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    top: 8,
+    left: 8,
+  },
+  circleLarge: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    bottom: 8,
+    right: 8,
   },
 });


### PR DESCRIPTION
## Summary
- rework main home screen layout
- add circle decorations and dynamic sizing
- update jubileo icon to a party icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68547fc080508326be3ead14fdf71c2f