### PR TITLE
Update Firebase docs and add Apple sign-in flag

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -13,11 +13,11 @@ Esta guía resume los pasos necesarios para habilitar la autenticación con Goog
    {
      "email": "usuario@example.com",
      "displayName": "Nombre Apellido",
-     "location": "MCM Castellon",
+     "profile": "MCM Castellon",
      "admin": false
    }
    ```
-5. En **Remote Config** crea un parámetro llamado `locations` con valor por defecto:
+5. En **Remote Config** crea un parámetro llamado `profiles` con valor por defecto:
    ```json
    ["MCM Castellon","MCM nacional","MCM Villacañas","MCM Madrid"]
    ```
@@ -35,13 +35,16 @@ EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=...
 EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=...
 EXPO_PUBLIC_FIREBASE_APP_ID=...
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=... # Client ID del inicio de sesión con Google
+EXPO_PUBLIC_ENABLE_APPLE_SIGNIN=false
+EXPO_PUBLIC_APPLE_SERVICE_ID=
+EXPO_PUBLIC_APPLE_REDIRECT_URI=
 ```
 
 Al arrancar la aplicación (`npm start` desde `mcm-app`) Expo cargará estas variables.
 
 ## 3. Comportamiento de la App
 - Desde la pantalla principal se puede abrir el panel de ajustes.
-- Si no hay sesión iniciada aparecerán los botones para iniciar sesión con Google o Apple (este último aún no funcional).
-- Tras iniciar sesión se mostrará el nombre del usuario, sus iniciales y un selector de localidad basado en Remote Config.
+- Si no hay sesión iniciada aparecerán los botones para iniciar sesión con Google y, si lo habilitas, con Apple.
+- Tras iniciar sesión se mostrará el nombre del usuario, sus iniciales y un selector de perfil basado en Remote Config.
 - El usuario puede cerrar la sesión desde este mismo panel.
 

--- a/README.md
+++ b/README.md
@@ -222,16 +222,22 @@ Update web 2 .................. npx eas deploy --prod
 Puedes definir algunas variables para ajustar ciertas funciones de la app. Expo cargará automáticamente las variables que empiecen por `EXPO_PUBLIC_` desde los archivos `.env`.
 
 - `EXPO_PUBLIC_CORS_PROXY_URL`: URL base de un proxy para evitar problemas de CORS al descargar calendarios `.ics`. Un ejemplo es `https://corsproxy.io/?`. Si no se define, se intentará acceder a las URLs directamente.
+- `EXPO_PUBLIC_ENABLE_APPLE_SIGNIN`: Ponlo a `true` si quieres mostrar el botón de inicio con Apple.
+- `EXPO_PUBLIC_APPLE_SERVICE_ID` y `EXPO_PUBLIC_APPLE_REDIRECT_URI`: datos de tu identificador de servicio de Apple para el inicio de sesión.
 
 ### Configuración de Firebase
 
-1. Crea un proyecto en [Firebase](https://console.firebase.google.com/) y habilita **Realtime Database**.
+1. Crea un proyecto en [Firebase](https://console.firebase.google.com/).
+   - Activa **Authentication** y habilita el proveedor de Google. Si dispones de cuenta de Apple Developer puedes habilitar también el inicio con Apple.
+   - Habilita **Realtime Database** en modo producción.
 2. Dentro de la base de datos crea estos nodos:
    - `songs`
    - `albums`
    - `jubileo` con las subclaves `horario`, `materiales`, `visitas`, `profundiza`, `grupos` y `contactos`.
+   - `users` para almacenar los perfiles de usuario (campos `profile` y `admin`).
    Cada nodo debe contener dos campos: `updatedAt` (timestamp) y `data` (con el contenido del JSON correspondiente).
-3. Genera las credenciales web de Firebase y cópialas en un archivo `.env.local` siguiendo el formato de `.env.example` en la carpeta `mcm-app`.
+3. En **Remote Config** crea el parámetro `profiles` con un valor por defecto similar a `["MCM Castellon","MCM nacional"]` para actualizar la lista sin publicar nuevas versiones.
+4. Genera las credenciales web de Firebase y cópialas en un archivo `.env.local` siguiendo el formato de `.env.example` en la carpeta `mcm-app`.
    Asegúrate de que todas las variables empiecen con `EXPO_PUBLIC_`.
-4. El archivo `.env.local` se encuentra en `.gitignore`, por lo que tus claves no se subirán al repositorio.
-5. Al arrancar la app (`npm start`) Expo cargará automáticamente dichas variables de entorno.
+5. El archivo `.env.local` se encuentra en `.gitignore`, por lo que tus claves no se subirán al repositorio.
+6. Al arrancar la app (`npm start`) Expo cargará automáticamente dichas variables de entorno.

--- a/mcm-app/.env.example
+++ b/mcm-app/.env.example
@@ -13,5 +13,10 @@ EXPO_PUBLIC_FIREBASE_APP_ID=your_app_id
 # OAuth client used for Google sign in
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=your_google_client_id
 
+# Apple sign in (opcional)
+EXPO_PUBLIC_ENABLE_APPLE_SIGNIN=false
+EXPO_PUBLIC_APPLE_SERVICE_ID=
+EXPO_PUBLIC_APPLE_REDIRECT_URI=
+
 # Optional proxy used when fetching calendar files
 EXPO_PUBLIC_CORS_PROXY_URL=

--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import Modal from 'react-native-modal';
 import { MaterialIcons } from '@expo/vector-icons';
 import useFontScale from '@/hooks/useFontScale';
@@ -7,7 +7,7 @@ import { useAppSettings, ThemeScheme } from '@/contexts/AppSettingsContext';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useAuth } from '@/contexts/AuthContext';
-import useLocations from '@/hooks/useLocations';
+import useProfiles from '@/hooks/useProfiles';
 import { Picker } from '@react-native-picker/picker';
 
 interface Props {
@@ -20,12 +20,13 @@ export default function SettingsPanel({ visible, onClose }: Props) {
   const scheme = useColorScheme();
   const theme = Colors[scheme];
   const fontScale = useFontScale();
-  const { user, profile, signInWithGoogle, signOutUser, setLocation } = useAuth();
-  const locations = useLocations();
-  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
+  const { user, profile, signInWithGoogle, signInWithApple, signOutUser, setProfile } = useAuth();
+  const enableApple = process.env.EXPO_PUBLIC_ENABLE_APPLE_SIGNIN === 'true';
+  const profiles = useProfiles();
+  const [selectedProfile, setSelectedProfile] = useState<string | null>(null);
 
   useEffect(() => {
-    setSelectedLocation(profile?.location ?? null);
+    setSelectedProfile(profile?.profile ?? null);
   }, [profile]);
 
   const increase = () => {
@@ -70,14 +71,14 @@ export default function SettingsPanel({ visible, onClose }: Props) {
               </TouchableOpacity>
             </View>
             <View style={{ marginVertical: 10 }}>
-              <Text style={{ color: theme.text, marginBottom: 4 }}>Localidad</Text>
+              <Text style={{ color: theme.text, marginBottom: 4 }}>Perfil</Text>
               <Picker
-                selectedValue={selectedLocation ?? undefined}
-                onValueChange={(v) => { setSelectedLocation(v); setLocation(v); }}
+                selectedValue={selectedProfile ?? undefined}
+                onValueChange={(v) => { setSelectedProfile(v); setProfile(v); }}
                 style={{ color: theme.text }}
               >
-                {locations.map(loc => (
-                  <Picker.Item label={loc} value={loc} key={loc} />
+                {profiles.map(p => (
+                  <Picker.Item label={p} value={p} key={p} />
                 ))}
               </Picker>
             </View>
@@ -88,10 +89,12 @@ export default function SettingsPanel({ visible, onClose }: Props) {
               <MaterialIcons name="login" size={24} color={theme.text} />
               <Text style={[styles.loginText, { color: theme.text }]}>Iniciar sesión con Google</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.loginButton} disabled>
-              <MaterialIcons name="apple" size={24} color={theme.text} />
-              <Text style={[styles.loginText, { color: theme.text }]}>Iniciar sesión con Apple</Text>
-            </TouchableOpacity>
+            {enableApple && Platform.OS !== 'android' && (
+              <TouchableOpacity style={styles.loginButton} onPress={signInWithApple}>
+                <MaterialIcons name="apple" size={24} color={theme.text} />
+                <Text style={[styles.loginText, { color: theme.text }]}>Iniciar sesión con Apple</Text>
+              </TouchableOpacity>
+            )}
           </View>
         )}
         <View style={styles.row}>

--- a/mcm-app/contexts/AuthContext.tsx
+++ b/mcm-app/contexts/AuthContext.tsx
@@ -1,14 +1,17 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { getAuth, onAuthStateChanged, signOut, signInWithCredential, GoogleAuthProvider, User } from 'firebase/auth';
+import { getAuth, onAuthStateChanged, signOut, signInWithCredential, GoogleAuthProvider, OAuthProvider, User } from 'firebase/auth';
 import { getDatabase, ref, get, set, update } from 'firebase/database';
 import * as Google from 'expo-auth-session/providers/google';
+import * as Apple from 'expo-auth-session/providers/apple';
+import * as AppleAuthentication from 'expo-apple-authentication';
+import { Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import { getFirebaseApp } from '@/hooks/firebaseApp';
 
 WebBrowser.maybeCompleteAuthSession();
 
 interface UserProfile {
-  location: string | null;
+  profile: string | null;
   admin: boolean;
 }
 
@@ -16,8 +19,9 @@ interface AuthContextType {
   user: User | null;
   profile: UserProfile | null;
   signInWithGoogle: () => void;
+  signInWithApple: () => void;
   signOutUser: () => void;
-  setLocation: (loc: string) => Promise<void>;
+  setProfile: (p: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -32,6 +36,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     clientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
   });
 
+  const enableApple = process.env.EXPO_PUBLIC_ENABLE_APPLE_SIGNIN === 'true';
+  const [appleRequest, appleResponse, promptAppleAsync] = Apple.useAuthRequest({
+    clientId: process.env.EXPO_PUBLIC_APPLE_SERVICE_ID ?? '',
+    redirectUri: process.env.EXPO_PUBLIC_APPLE_REDIRECT_URI,
+    scopes: ['name', 'email'],
+  });
+
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (u) => {
       setUser(u);
@@ -40,7 +51,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         if (snap.exists()) {
           setProfile(snap.val());
         } else {
-          const data: UserProfile = { location: null, admin: false };
+          const data: UserProfile = { profile: null, admin: false };
           await set(ref(db, `users/${u.uid}`), {
             email: u.email,
             displayName: u.displayName,
@@ -63,20 +74,54 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [response]);
 
+  useEffect(() => {
+    if (appleResponse?.type === 'success') {
+      const { id_token } = appleResponse.params as any;
+      if (id_token) {
+        const provider = new OAuthProvider('apple.com');
+        const credential = provider.credential({ idToken: id_token });
+        signInWithCredential(auth, credential).catch(console.error);
+      }
+    }
+  }, [appleResponse]);
+
   const signInWithGoogle = () => {
     promptAsync().catch(console.error);
   };
 
+  const signInWithApple = async () => {
+    if (!enableApple) return;
+    if (Platform.OS === 'ios') {
+      try {
+        const result = await AppleAuthentication.signInAsync({
+          requestedScopes: [
+            AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+            AppleAuthentication.AppleAuthenticationScope.EMAIL,
+          ],
+        });
+        if (result.identityToken) {
+          const provider = new OAuthProvider('apple.com');
+          const cred = provider.credential({ idToken: result.identityToken });
+          signInWithCredential(auth, cred).catch(console.error);
+        }
+      } catch (e: any) {
+        if (e.code !== 'ERR_CANCELED') console.error(e);
+      }
+    } else {
+      promptAppleAsync().catch(console.error);
+    }
+  };
+
   const signOutUser = () => signOut(auth);
 
-  const setLocation = async (loc: string) => {
+  const setProfileValue = async (pVal: string) => {
     if (!user) return;
-    await update(ref(db, `users/${user.uid}`), { location: loc });
-    setProfile((p) => (p ? { ...p, location: loc } : p));
+    await update(ref(db, `users/${user.uid}`), { profile: pVal });
+    setProfile((p) => (p ? { ...p, profile: pVal } : p));
   };
 
   return (
-    <AuthContext.Provider value={{ user, profile, signInWithGoogle, signOutUser, setLocation }}>
+    <AuthContext.Provider value={{ user, profile, signInWithGoogle, signInWithApple, signOutUser, setProfile: setProfileValue }}>
       {children}
     </AuthContext.Provider>
   );

--- a/mcm-app/hooks/useProfiles.ts
+++ b/mcm-app/hooks/useProfiles.ts
@@ -2,26 +2,26 @@ import { useEffect, useState } from 'react';
 import { getRemoteConfig, fetchAndActivate, getValue } from 'firebase/remote-config';
 import { getFirebaseApp } from './firebaseApp';
 
-const DEFAULT_LOCATIONS = [
+const DEFAULT_PROFILES = [
   'MCM Castellon',
   'MCM nacional',
   'MCM Villacañas',
   'MCM Madrid',
 ];
 
-export default function useLocations() {
-  const [locations, setLocations] = useState<string[]>(DEFAULT_LOCATIONS);
+export default function useProfiles() {
+  const [profiles, setProfiles] = useState<string[]>(DEFAULT_PROFILES);
 
   useEffect(() => {
     const rc = getRemoteConfig(getFirebaseApp());
     rc.settings = { minimumFetchIntervalMillis: 3600000 };
-    rc.defaultConfig = { locations: JSON.stringify(DEFAULT_LOCATIONS) } as any;
+    rc.defaultConfig = { profiles: JSON.stringify(DEFAULT_PROFILES) } as any;
     fetchAndActivate(rc)
       .then(() => {
-        const val = getValue(rc, 'locations').asString();
+        const val = getValue(rc, 'profiles').asString();
         try {
           const parsed = JSON.parse(val);
-          if (Array.isArray(parsed)) setLocations(parsed);
+          if (Array.isArray(parsed)) setProfiles(parsed);
         } catch {
           // ignore
         }
@@ -29,5 +29,5 @@ export default function useLocations() {
       .catch(() => {});
   }, []);
 
-  return locations;
+  return profiles;
 }


### PR DESCRIPTION
## Summary
- document Google/Apple auth setup and new `profiles` parameter
- rename `useLocations` to `useProfiles`
- update settings panel with optional Apple login
- implement Apple sign-in logic and profile handling
- document new environment variables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68565d784d988326aa68b011fcd57b6b