### PR TITLE
Improve offline banner and playlist import

### DIFF
--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -4,6 +4,7 @@ import { View, FlatList, StyleSheet, Linking, useWindowDimensions, ViewStyle, Al
 import { Button, ActivityIndicator } from 'react-native-paper';
 import AlbumCard from '@/components/AlbumCard';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
+import OfflineBanner from '@/components/OfflineBanner';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { Colors as ThemeColors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -32,7 +33,7 @@ export default function FotosScreen() {
   const { width } = useWindowDimensions();
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
-  const { data: allAlbumsData, loading } = useFirebaseData<Album[]>('albums', 'albums');
+  const { data: allAlbumsData, loading, offline } = useFirebaseData<Album[]>('albums', 'albums');
   const [displayedAlbums, setDisplayedAlbums] = useState<Album[]>([]);
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [allAlbumsLoaded, setAllAlbumsLoaded] = useState<boolean>(false);
@@ -111,6 +112,7 @@ export default function FotosScreen() {
 
   return (
     <View style={styles.container}>
+      {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
       <FlatList
         data={displayedAlbums}
         renderItem={({ item }) => (

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -2,6 +2,7 @@ import { FlatList, TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useLayoutEffect, useMemo } from 'react';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
+import OfflineBanner from '@/components/OfflineBanner';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
@@ -70,9 +71,7 @@ export default function CategoriesScreen({
       data={displayCategories}
       keyExtractor={(item) => item.id}
       ListHeaderComponent={offline ? (
-        <Text style={{ textAlign: 'center', marginVertical: 8 }}>
-          Mostrando datos sin conexión
-        </Text>
+        <OfflineBanner text="Mostrando datos sin conexión" />
       ) : null}
       renderItem={({ item }) => (
         <TouchableOpacity

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -10,6 +10,7 @@ import typography from '@/constants/typography';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
+import OfflineBanner from '@/components/OfflineBanner';
 
 interface NavigationItem {
   label: string;
@@ -58,9 +59,7 @@ export default function JubileoHomeScreen() {
         showsVerticalScrollIndicator={false}
       >
         {offline && (
-          <Text style={{ textAlign: 'center', marginBottom: 8 }}>
-            Modo sin conexión
-          </Text>
+          <OfflineBanner text="Mostrando datos sin conexión" />
         )}
         <View style={[styles.gridContainer, { padding: containerPadding, backgroundColor: Colors[scheme].background }]}>
           {navigationItems.map((item, idx) => (

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -37,7 +37,7 @@ interface CategorizedSongs {
 type SelectedSongsScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'SongDetail'>;
 
 const SelectedSongsScreen: React.FC = () => {
-  const { selectedSongs, clearSelection } = useSelectedSongs();
+  const { selectedSongs, clearSelection, addSong } = useSelectedSongs();
   const navigation = useNavigation<SelectedSongsScreenNavigationProp>();
   const scheme = useColorScheme() || 'light'; // Default to light theme if undefined
   const styles = useMemo(() => createStyles(scheme), [scheme]);
@@ -171,7 +171,11 @@ const SelectedSongsScreen: React.FC = () => {
 
   const handleShareFile = useCallback(async () => {
     try {
-      const path = FileSystem.cacheDirectory + 'playlist.mcm.json';
+      const monthNames = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+      const now = new Date();
+      const dateStr = `${now.getDate()}-${monthNames[now.getMonth()]}`;
+      const fileName = `Playlist ${dateStr}.mcmsongs`;
+      const path = FileSystem.cacheDirectory + fileName;
       await FileSystem.writeAsStringAsync(path, JSON.stringify(selectedSongs), {
         encoding: FileSystem.EncodingType.UTF8,
       });
@@ -186,7 +190,7 @@ const SelectedSongsScreen: React.FC = () => {
 
   const handleImportFile = useCallback(async () => {
     try {
-      const res = await DocumentPicker.getDocumentAsync({ type: 'application/json' });
+      const res = await DocumentPicker.getDocumentAsync({ type: '*/*' });
       if (res.canceled || !res.assets || res.assets.length === 0) return;
       const file = res.assets[0];
       const content = await FileSystem.readAsStringAsync(file.uri, {
@@ -201,7 +205,7 @@ const SelectedSongsScreen: React.FC = () => {
     } catch (err) {
       console.error('Error importing playlist', err);
     }
-  }, []);
+  }, [addSong]);
 
   const handleSongPress = (song: Song) => {
     if (!allSongsData) return;
@@ -282,6 +286,10 @@ const SelectedSongsScreen: React.FC = () => {
         <IconSymbol name="music.note.list" size={60} color="#cccccc" />
         <Text style={styles.emptyText}>Todavía no has seleccionado canciones</Text>
         <Text style={styles.swipeHint}>Desliza una canción hacia la izquierda para seleccionarla</Text>
+        <TouchableOpacity onPress={handleImportFile} style={[styles.shareButton, { marginTop: 20 }]}> 
+          <IconSymbol name="tray.and.arrow.down" size={20} color="#007AFF" />
+          <Text style={styles.shareButtonText}>Importar</Text>
+        </TouchableOpacity>
       </View>
     );
   }

--- a/mcm-app/components/OfflineBanner.tsx
+++ b/mcm-app/components/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export default function OfflineBanner({ text = 'Mostrando datos sin conexión' }: { text?: string }) {
+  const scheme = useColorScheme() || 'light';
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+}
+
+const createStyles = (scheme: 'light' | 'dark') => {
+  const isDark = scheme === 'dark';
+  return StyleSheet.create({
+    container: {
+      backgroundColor: isDark ? '#444' : '#e0e0e0',
+      paddingVertical: 6,
+      paddingHorizontal: 10,
+    },
+    text: {
+      color: isDark ? Colors.dark.text : Colors.light.text,
+      textAlign: 'center',
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- show a consistent offline banner across cantoral, jubileo and photos
- allow importing playlists even with no songs selected
- export playlists with `.mcmsongs` extension and Spanish date in the name

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861b614d14c8326895066bf60befa8e