### PR TITLE
Add apps list to Jubileo

### DIFF
--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -9,6 +9,7 @@ import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
 import ContactosScreen from '../screens/ContactosScreen';
 import ReflexionesScreen from '../screens/ReflexionesScreen';
+import AppsScreen from '../screens/AppsScreen';
 import { IconButton } from 'react-native-paper';
 
 export type JubileoStackParamList = {
@@ -20,6 +21,7 @@ export type JubileoStackParamList = {
   Profundiza: undefined;
   Grupos: undefined;
   Contactos: undefined;
+  Apps: undefined;
   Reflexiones: undefined;
 };
 
@@ -85,6 +87,11 @@ export default function JubileoTab() {
         name="Contactos"
         component={ContactosScreen}
         options={{ title: 'Contactos' }}
+      />
+      <Stack.Screen
+        name="Apps"
+        component={AppsScreen}
+        options={{ title: 'Apps' }}
       />
       <Stack.Screen
         name="Reflexiones"

--- a/mcm-app/app/screens/AppsScreen.tsx
+++ b/mcm-app/app/screens/AppsScreen.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  Image,
+  TouchableOpacity,
+  Linking,
+  Platform,
+} from 'react-native';
+import {
+  List,
+  IconButton,
+  Portal,
+  Modal,
+  Text,
+  Chip,
+} from 'react-native-paper';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { useFirebaseData } from '@/hooks/useFirebaseData';
+import ProgressWithMessage from '@/components/ProgressWithMessage';
+
+interface AppInfo {
+  orden: number;
+  nombre: string;
+  descripcion: string;
+  tipo: string;
+  icono: string;
+  iosLink: string;
+  androidLink: string;
+  iosScheme?: string;
+  androidScheme?: string;
+}
+
+export default function AppsScreen() {
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const { data: appsData, loading } = useFirebaseData<AppInfo[]>(
+    'jubileo/apps',
+    'jubileo_apps',
+  );
+  const [selected, setSelected] = useState<AppInfo | null>(null);
+
+  const openApp = async (app: AppInfo) => {
+    const schemeUrl = Platform.OS === 'ios' ? app.iosScheme : app.androidScheme;
+    if (schemeUrl) {
+      const can = await Linking.canOpenURL(schemeUrl);
+      if (can) {
+        Linking.openURL(schemeUrl);
+        return;
+      }
+    }
+    const storeUrl = Platform.OS === 'ios' ? app.iosLink : app.androidLink;
+    if (storeUrl) Linking.openURL(storeUrl);
+  };
+
+  if (loading || !appsData) {
+    return <ProgressWithMessage message="Cargando aplicaciones..." />;
+  }
+
+  const apps = [...appsData].sort((a, b) => a.orden - b.orden);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView>
+        <List.Section>
+          {apps.map((app, idx) => (
+            <List.Item
+              key={idx}
+              title={app.nombre}
+              description={app.descripcion}
+              left={() => (
+                <TouchableOpacity onPress={() => openApp(app)}>
+                  <Image source={{ uri: app.icono }} style={styles.icon} />
+                </TouchableOpacity>
+              )}
+              right={() => (
+                <IconButton icon="plus" onPress={() => setSelected(app)} />
+              )}
+              titleStyle={styles.title}
+            />
+          ))}
+        </List.Section>
+      </ScrollView>
+      <Portal>
+        <Modal
+          visible={!!selected}
+          onDismiss={() => setSelected(null)}
+          contentContainerStyle={styles.modal}
+        >
+          {selected && (
+            <View>
+              <Text style={styles.modalTitle}>{selected.nombre}</Text>
+              <Text style={styles.modalDesc}>{selected.descripcion}</Text>
+              <View style={styles.chipRow}>
+                <Chip
+                  icon={
+                    selected.tipo.toLowerCase() === 'necesaria'
+                      ? 'star'
+                      : 'information'
+                  }
+                  style={styles.chip}
+                >
+                  {selected.tipo}
+                </Chip>
+              </View>
+              <View style={styles.downloadRow}>
+                <IconButton
+                  icon="apple"
+                  size={28}
+                  onPress={() => Linking.openURL(selected.iosLink)}
+                />
+                <IconButton
+                  icon="android"
+                  size={28}
+                  onPress={() => Linking.openURL(selected.androidLink)}
+                />
+              </View>
+            </View>
+          )}
+        </Modal>
+      </Portal>
+    </View>
+  );
+}
+
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.background },
+    icon: { width: 40, height: 40, borderRadius: 8, marginRight: 8 },
+    title: { fontWeight: 'bold', color: theme.text },
+    modal: {
+      backgroundColor: theme.background,
+      padding: 20,
+      margin: 20,
+      borderRadius: 8,
+    },
+    modalTitle: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      textAlign: 'center',
+      marginBottom: 8,
+      color: theme.text,
+    },
+    modalDesc: {
+      fontSize: 16,
+      textAlign: 'center',
+      marginBottom: 12,
+      color: theme.text,
+    },
+    chipRow: { alignItems: 'center', marginBottom: 12 },
+    chip: { alignSelf: 'center' },
+    downloadRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      marginTop: 8,
+    },
+  });
+};

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -60,6 +60,12 @@ const navigationItems: NavigationItem[] = [
     target: 'Contactos',
     backgroundColor: '#9FA8DA',
   },
+  {
+    label: 'Apps',
+    icon: '📲',
+    target: 'Apps',
+    backgroundColor: '#FFB74D',
+  },
 ];
 
 export default function JubileoHomeScreen() {
@@ -82,7 +88,8 @@ export default function JubileoHomeScreen() {
     'jubileo/contactos',
     'jubileo_contactos',
   );
-  const isLoading = lh || lm || lv || lp || lg || lc;
+  const { loading: la } = useFirebaseData('jubileo/apps', 'jubileo_apps');
+  const isLoading = lh || lm || lv || lp || lg || lc || la;
   const { width, height } = useWindowDimensions();
   const containerPadding = spacing.md;
   const gap = spacing.md;
@@ -105,10 +112,16 @@ export default function JubileoHomeScreen() {
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
       >
-        {offline && (
-          <OfflineBanner text="Mostrando datos sin conexión" />
-        )}
-        <View style={[styles.gridContainer, { padding: containerPadding, backgroundColor: Colors[scheme].background }]}>
+        {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
+        <View
+          style={[
+            styles.gridContainer,
+            {
+              padding: containerPadding,
+              backgroundColor: Colors[scheme].background,
+            },
+          ]}
+        >
           {navigationItems.map((item, idx) => (
             <View key={idx} style={styles.itemWrapper}>
               <TouchableOpacity

--- a/mcm-app/assets/jubileo-apps.json
+++ b/mcm-app/assets/jubileo-apps.json
@@ -1,0 +1,57 @@
+[
+  {
+    "orden": 1,
+    "nombre": "WhatsApp",
+    "descripcion": "Mensajería instantánea y llamadas gratuitas",
+    "tipo": "Necesaria",
+    "icono": "https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg",
+    "iosLink": "https://apps.apple.com/app/whatsapp-messenger/id310633997",
+    "androidLink": "https://play.google.com/store/apps/details?id=com.whatsapp",
+    "iosScheme": "whatsapp://",
+    "androidScheme": "whatsapp://"
+  },
+  {
+    "orden": 2,
+    "nombre": "Google Maps",
+    "descripcion": "Navegación GPS y mapas sin conexión",
+    "tipo": "Necesaria",
+    "icono": "https://upload.wikimedia.org/wikipedia/commons/9/99/Google_Maps_Logo.svg",
+    "iosLink": "https://apps.apple.com/app/google-maps/id585027354",
+    "androidLink": "https://play.google.com/store/apps/details?id=com.google.android.apps.maps",
+    "iosScheme": "comgooglemaps://",
+    "androidScheme": "geo:0,0?q="
+  },
+  {
+    "orden": 3,
+    "nombre": "Spotify",
+    "descripcion": "Escucha y descubre música de todo el mundo",
+    "tipo": "Opcional",
+    "icono": "https://upload.wikimedia.org/wikipedia/commons/2/26/Spotify_logo_with_text.svg",
+    "iosLink": "https://apps.apple.com/app/spotify-music/id324684580",
+    "androidLink": "https://play.google.com/store/apps/details?id=com.spotify.music",
+    "iosScheme": "spotify://",
+    "androidScheme": "spotify://"
+  },
+  {
+    "orden": 4,
+    "nombre": "YouVersion",
+    "descripcion": "La Biblia en múltiples idiomas y planes",
+    "tipo": "Opcional",
+    "icono": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/YouVersion.svg/512px-YouVersion.svg.png",
+    "iosLink": "https://apps.apple.com/app/bible/id282935706",
+    "androidLink": "https://play.google.com/store/apps/details?id=com.sirma.mobile.bible.android",
+    "iosScheme": "youversion://",
+    "androidScheme": "youversion://"
+  },
+  {
+    "orden": 5,
+    "nombre": "Slack",
+    "descripcion": "Comunicación en equipo y colaboración",
+    "tipo": "Opcional",
+    "icono": "https://upload.wikimedia.org/wikipedia/commons/7/76/Slack_Icon.png",
+    "iosLink": "https://apps.apple.com/app/slack/id618783545",
+    "androidLink": "https://play.google.com/store/apps/details?id=com.Slack",
+    "iosScheme": "slack://",
+    "androidScheme": "slack://"
+  }
+]


### PR DESCRIPTION
## Summary
- provide sample `jubileo-apps.json` structure
- add new `AppsScreen` to display and launch recommended apps
- include Apps in Jubileo stack and home grid

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b868d1c2083268a2d4233a887b67f