### PR TITLE
Update Jubileo menu colors and add settings button

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -68,7 +68,7 @@ export default function TabsLayout() {
             tabBarIcon: ({ color, size }) => (
               <MaterialIcons name="calendar-today" color={color} size={size} />
             ),
-            headerStyle: { backgroundColor: '#9D1E74' }, // Morado Jubileo
+            headerStyle: { backgroundColor: '#31AADF' }, // Color info
           }}
         />
 
@@ -89,7 +89,7 @@ export default function TabsLayout() {
             tabBarIcon: ({ color, size }) => (
               <MaterialIcons name="public" color={color} size={size} />
             ),
-            headerStyle: { backgroundColor: '#31AADF' }, // Info color
+            headerStyle: { backgroundColor: '#9D1E74dd' }, // Moradito
           }}
         />
       </Tabs>

--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -68,7 +68,7 @@ export default function TabsLayout() {
             tabBarIcon: ({ color, size }) => (
               <MaterialIcons name="calendar-today" color={color} size={size} />
             ),
-            headerStyle: { backgroundColor: '#A3BD31' }, // Éxito / Confirmación color
+            headerStyle: { backgroundColor: '#9D1E74' }, // Morado Jubileo
           }}
         />
 

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -52,14 +52,14 @@ const navigationItems: NavigationItem[] = [
     href: '/comunica',
     label: 'Comunica',
     icon: 'chat',
-    backgroundColor: colors.success,
+    backgroundColor: colors.info,
     color: colors.black,
   },
   {
     href: '/jubileo',
     label: 'Jubileo',
     icon: 'celebration',
-    backgroundColor: colors.warning,
+    backgroundColor: colors.success,
     color: colors.black,
   },
   {

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -28,10 +28,24 @@ interface NavigationItem {
 
 const navigationItems: NavigationItem[] = [
   {
+    href: '/jubileo',
+    label: 'Jubileo',
+    icon: 'celebration',
+    backgroundColor: colors.success,
+    color: colors.black,
+  },
+  {
     href: '/cancionero',
     label: 'Cantoral',
     icon: 'library-music',
     backgroundColor: colors.warning,
+    color: colors.black,
+  },
+  {
+    href: '/calendario',
+    label: 'Calendario',
+    icon: 'event',
+    backgroundColor: colors.info, // Morado Jubileo
     color: colors.black,
   },
   {
@@ -42,30 +56,16 @@ const navigationItems: NavigationItem[] = [
     color: colors.black,
   },
   {
-    href: '/calendario',
-    label: 'Calendario',
-    icon: 'event',
-    backgroundColor: colors.info,
-    color: colors.black,
-  },
-  {
     href: '/comunica',
     label: 'Comunica',
     icon: 'chat',
-    backgroundColor: colors.info,
+    backgroundColor: '#9D1E74dd',
     color: colors.black,
   },
   {
-    href: '/jubileo',
-    label: 'Jubileo',
-    icon: 'celebration',
-    backgroundColor: colors.success,
-    color: colors.black,
-  },
-  {
-    label: 'Y mas cosas....',
+    label: 'Próximamente...',
     icon: 'hourglass-empty',
-    backgroundColor: colors.danger,
+    backgroundColor: '#2e2e2e ',
     color: colors.black,
   },
 ];

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { View } from 'react-native';
+import { View, TouchableOpacity } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { MaterialIcons } from '@expo/vector-icons';
 
 import JubileoHomeScreen from '../screens/JubileoHomeScreen';
 import HorarioScreen from '../screens/HorarioScreen';
@@ -11,7 +12,6 @@ import ProfundizaScreen from '../screens/ProfundizaScreen';
 import GruposScreen from '../screens/GruposScreen';
 import ContactosScreen from '../screens/ContactosScreen';
 import ReflexionesScreen from '../screens/ReflexionesScreen';
-import { IconButton } from 'react-native-paper';
 import SettingsPanel from '@/components/SettingsPanel';
 
 export type JubileoStackParamList = {
@@ -43,20 +43,19 @@ export default function JubileoTab() {
         headerTitleAlign: 'center',
         headerRight: () => (
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <IconButton
-              icon="settings"
-              size={24}
-              iconColor="#fff"
-              style={{ marginRight: 4 }}
+            <TouchableOpacity
               onPress={() => setSettingsVisible(true)}
-            />
+              style={{ padding: 8, marginRight: 4 }}
+            >
+              <MaterialIcons name="settings" size={24} color="#fff" />
+            </TouchableOpacity>
             {route.name !== 'Reflexiones' && (
-              <IconButton
-                icon="forum"
-                size={24}
-                iconColor="#fff"
+              <TouchableOpacity
                 onPress={() => navigation.navigate('Reflexiones')}
-              />
+                style={{ padding: 8 }}
+              >
+                <MaterialIcons name="forum" size={24} color="#fff" />
+              </TouchableOpacity>
             )}
           </View>
         ),

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import JubileoHomeScreen from '../screens/JubileoHomeScreen';
@@ -10,6 +12,7 @@ import GruposScreen from '../screens/GruposScreen';
 import ContactosScreen from '../screens/ContactosScreen';
 import ReflexionesScreen from '../screens/ReflexionesScreen';
 import { IconButton } from 'react-native-paper';
+import SettingsPanel from '@/components/SettingsPanel';
 
 export type JubileoStackParamList = {
   Home: undefined;
@@ -26,24 +29,37 @@ export type JubileoStackParamList = {
 const Stack = createNativeStackNavigator<JubileoStackParamList>();
 
 export default function JubileoTab() {
+  const [settingsVisible, setSettingsVisible] = useState(false);
   return (
-    <Stack.Navigator
+    <>
+      <SettingsPanel visible={settingsVisible} onClose={() => setSettingsVisible(false)} />
+      <Stack.Navigator
       initialRouteName="Home"
       screenOptions={({ navigation, route }) => ({
         headerBackTitle: 'Atrás',
-        headerStyle: { backgroundColor: '#9D1E74' },
+        headerStyle: { backgroundColor: '#A3BD31' },
         headerTintColor: '#fff',
         headerTitleStyle: { fontWeight: 'bold' },
         headerTitleAlign: 'center',
-        headerRight: () =>
-          route.name !== 'Reflexiones' ? (
+        headerRight: () => (
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <IconButton
-              icon="forum"
+              icon="settings"
               size={24}
               iconColor="#fff"
-              onPress={() => navigation.navigate('Reflexiones')}
+              style={{ marginRight: 4 }}
+              onPress={() => setSettingsVisible(true)}
             />
-          ) : null,
+            {route.name !== 'Reflexiones' && (
+              <IconButton
+                icon="forum"
+                size={24}
+                iconColor="#fff"
+                onPress={() => navigation.navigate('Reflexiones')}
+              />
+            )}
+          </View>
+        ),
       })}
     >
       <Stack.Screen
@@ -95,5 +111,6 @@ export default function JubileoTab() {
         }}
       />
     </Stack.Navigator>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add settings menu button to all Jubileo screens
- switch Jubileo header color to green and Calendar to purple
- adjust home screen button colors to match sections

## Testing
- `npm test`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687d1cb14ff8832689d01a4776d9ae4b