### PR TITLE
Añade grupos de Alojamiento

### DIFF
--- a/mcm-app/assets/jubileo-grupos.json
+++ b/mcm-app/assets/jubileo-grupos.json
@@ -439,7 +439,21 @@
         "Luis Nieto",
         "Silvia Salazar"
       ],
-      "subtitulo": "Incluye parada intermedia"
+    "subtitulo": "Incluye parada intermedia"
+    }
+  ],
+  "Alojamiento": [
+    {
+      "nombre": "Casa San Marcos",
+      "subtitulo": "Habitaciones compartidas",
+      "miembros": ["Ana", "Luis", "Marta"],
+      "mapa": "https://maps.google.com/?q=Casa+San+Marcos"
+    },
+    {
+      "nombre": "Hostal El Camino",
+      "subtitulo": "Plazas limitadas",
+      "miembros": ["Pepe", "Carlos"],
+      "mapa": "https://maps.google.com/?q=Hostal+El+Camino"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- soporte para grupos de tipo **Alojamiento** con enlace a Google Maps
- inclusión automática de categorías desconocidas
- actualiza JSON de ejemplo con datos de alojamiento

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d1b25bc48832695410da6a7d34447