### PR TITLE
Add PWA enhancements for mobile web

### DIFF
--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -28,7 +28,39 @@
     "web": {
       "bundler": "metro",
       "output": "static",
-      "favicon": "./assets/images/favicon.png"
+      "favicon": "./assets/images/favicon.png",
+      "meta": {
+        "apple": {
+          "mobileWebAppCapable": "yes",
+          "statusBarStyle": "default",
+          "title": "mcm-app",
+          "icons": {
+            "120": "./assets/images/icon.png",
+            "152": "./assets/images/icon.png",
+            "180": "./assets/images/icon.png"
+          }
+        }
+      },
+      "manifest": {
+        "name": "MCM App",
+        "short_name": "MCMApp",
+        "start_url": ".",
+        "display": "standalone",
+        "background_color": "#ffffff",
+        "theme_color": "#253883",
+        "icons": [
+          {
+            "src": "./assets/images/icon.png",
+            "sizes": "192x192",
+            "type": "image/png"
+          },
+          {
+            "src": "./assets/images/icon.png",
+            "sizes": "512x512",
+            "type": "image/png"
+          }
+        ]
+      }
     },
     "plugins": [
       "expo-router",

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -24,6 +24,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { AppSettingsProvider } from '@/contexts/AppSettingsContext';
 import { FeatureFlagsProvider } from '@/contexts/FeatureFlagsContext';
 import { HelloWave } from '@/components/HelloWave'; // Import HelloWave
+import AddToHomeScreenPrompt from '@/components/AddToHomeScreenPrompt';
 import {
   Provider as PaperProvider,
   MD3LightTheme,
@@ -157,6 +158,7 @@ function InnerLayout() {
       <PaperProvider theme={paperTheme}>
         <NavThemeProvider value={navigationTheme}>
           <Slot />
+          <AddToHomeScreenPrompt />
           <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
         </NavThemeProvider>
       </PaperProvider>

--- a/mcm-app/components/AddToHomeScreenPrompt.tsx
+++ b/mcm-app/components/AddToHomeScreenPrompt.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { Platform, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { IconSymbol } from './ui/IconSymbol';
+
+export default function AddToHomeScreenPrompt() {
+  const [visible, setVisible] = useState(false);
+  const scheme = useColorScheme() || 'light';
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const ua = window.navigator.userAgent;
+    const isIOS = /iPhone|iPad|iPod/i.test(ua);
+    const isSafari = /Safari/i.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+    const inStandalone =
+      (window.navigator as any).standalone === true ||
+      window.matchMedia('(display-mode: standalone)').matches;
+
+    if (isIOS && isSafari && !inStandalone) {
+      setVisible(true);
+    }
+  }, []);
+
+  if (!visible) return null;
+  const theme = Colors[scheme];
+
+  return (
+    <View style={styles.overlay} pointerEvents="box-none">
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <Text style={[styles.text, { color: theme.text }]}> 
+          <IconSymbol name="square.and.arrow.up" color={theme.text} /> Añade esta app a tu pantalla de inicio
+        </Text>
+        <Text style={[styles.subtext, { color: theme.text }]}>Pulsa Compartir y luego "Añadir a pantalla de inicio"</Text>
+        <TouchableOpacity onPress={() => setVisible(false)} style={styles.close}>
+          <IconSymbol name="close" color={theme.text} size={20} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    bottom: 20,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 1000,
+  },
+  container: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    flexDirection: 'column',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  text: {
+    fontSize: 14,
+    marginBottom: 4,
+  },
+  subtext: {
+    fontSize: 12,
+  },
+  close: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    padding: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- set up a web manifest and Apple meta tags in `app.json`
- display an overlay prompting iOS Safari users to install the app
- inject the new `AddToHomeScreenPrompt` component in the root layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881566e8a048326a106c22022ff6dca