### PR TITLE
Adjust songbook layout for web/mobile

### DIFF
--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
 import { useFeatureFlags } from '@/contexts/FeatureFlagsContext';
+import { Platform } from 'react-native';
 
 export default function TabsLayout() {
   const scheme = useColorScheme(); //
@@ -21,12 +22,14 @@ export default function TabsLayout() {
       <Tabs
         initialRouteName={featureFlags.defaultTab}
         screenOptions={{
-          headerShown: true, // Default to showing headers
-          headerTintColor: '#fff', // Default text/icon color for headers
+          headerShown: true,
+          headerTintColor: '#fff',
           headerTitleStyle: {
             fontWeight: 'bold',
+            fontSize: 18,
           },
-          headerTitleAlign: 'center', // Center the title
+          headerTitleAlign: 'center',
+          headerStatusBarHeight: Platform.OS === 'web' ? 0 : undefined,
           tabBarActiveTintColor: Colors[scheme ?? 'light'].tint,
           tabBarInactiveTintColor: Colors[scheme ?? 'light'].icon,
           tabBarStyle: {

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -1,4 +1,5 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Platform } from 'react-native';
 
 // Importar pantallas
 import CategoriesScreen from '../screens/CategoriesScreen';
@@ -67,7 +68,9 @@ export default function CancioneroTab() {
             headerTintColor: '#fff',
             headerTitleStyle: {
               fontWeight: 'bold',
+              fontSize: 18,
             },
+            headerStatusBarHeight: Platform.OS === 'web' ? 0 : undefined,
           }}
         >
           <Stack.Screen

--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Platform } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { MaterialIcons } from '@expo/vector-icons';
 
@@ -44,8 +44,9 @@ export default function JubileoTab() {
           headerBackTitle: 'Atrás',
           headerStyle: { backgroundColor: '#A3BD31' },
           headerTintColor: '#fff',
-          headerTitleStyle: { fontWeight: 'bold' },
+          headerTitleStyle: { fontWeight: 'bold', fontSize: 18 },
           headerTitleAlign: 'center',
+          headerStatusBarHeight: Platform.OS === 'web' ? 0 : undefined,
           headerRight: () => (
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
               <TouchableOpacity

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -13,6 +13,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'; *
 import React, { useState, useEffect, useMemo } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { View, StyleSheet } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import {
   ThemeProvider as NavThemeProvider,
   DarkTheme,
@@ -155,13 +156,15 @@ function InnerLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <PaperProvider theme={paperTheme}>
-        <NavThemeProvider value={navigationTheme}>
-          <Slot />
-          <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-          <AddToHomeBanner />
-        </NavThemeProvider>
-      </PaperProvider>
+      <SafeAreaProvider>
+        <PaperProvider theme={paperTheme}>
+          <NavThemeProvider value={navigationTheme}>
+            <Slot />
+            <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+            <AddToHomeBanner />
+          </NavThemeProvider>
+        </PaperProvider>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     overflowY: 'auto',
-    padding: 16,
+    padding: 8,
     boxSizing: 'border-box',
   },
   scrollButton: {
@@ -165,6 +165,7 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 30,
     opacity: 0.7,
+    zIndex: 2,
   },
   sliderWrapper: {
     position: 'absolute',
@@ -174,6 +175,7 @@ const styles = StyleSheet.create({
     height: 40,
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 2,
   },
   slider: {
     width: '100%',

--- a/mcm-app/components/SongDisplay.tsx
+++ b/mcm-app/components/SongDisplay.tsx
@@ -23,13 +23,14 @@ const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
         <div
           style={{
             width: '100%',
-            maxWidth: '800px',
-            margin: '0 auto',
-            padding: '16px 24px',
+            maxWidth: '100%',
+            margin: 0,
+            padding: '8px 12px',
             backgroundColor: 'white',
             boxSizing: 'border-box',
             minHeight: '100%',
             boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+            overflowY: 'auto',
           }}
           dangerouslySetInnerHTML={{ __html: songHtml }}
         />
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
   webViewContainer: {
     flex: 1,
     backgroundColor: '#f5f5f5',
-    ...(Platform.OS === 'web' ? { paddingVertical: 16 } : {}),
+    ...(Platform.OS === 'web' ? { paddingVertical: 8 } : {}),
   },
   loadingContainer: {
     justifyContent: 'center',


### PR DESCRIPTION
## Summary
- wrap app with SafeAreaProvider to improve notch handling
- tweak SongDisplay styles to reduce margins and enable scrolling
- improve fullscreen scroll controls z-order
- reduce header height on web

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68823e2bbfc08326bed862e29e7909f8