### PR TITLE
Enhance PWA manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Expo es un framework de código abierto para construir aplicaciones universales 
     * [iPhone físico (TestFlight)](#5️⃣-iphone-físico-testflight-)
     * [Modo “Development Build”]($6️⃣-modo-development-build-universo-paralelo-)
 * [Mini-post-it de comandos](#-mini-post-it-de-comandos)
+* [Instalar como app en tu móvil](#instalar-como-app-en-tu-móvil)
 
 ---
 
@@ -194,6 +195,12 @@ Esto iniciará el servidor de desarrollo, y podrás abrir la app de Development 
 
 ### Modo pantalla completa para canciones
 Desde la vista de detalle puedes pulsar el nuevo icono de *pantalla completa* para abrir la canción en modo presentación. El texto se muestra con una fuente grande y puedes activar o pausar el desplazamiento automático con el botón de reproducción.
+
+---
+
+### Instalar como app en tu móvil
+
+Cuando visites la versión web desde Safari o Chrome en tu teléfono, verás un mensaje animado invitándote a añadir la app a la pantalla de inicio. Pulsa el icono de compartir y selecciona **Añadir a pantalla de inicio**. Tendrás un acceso directo con icono propio y la aplicación se abrirá a pantalla completa.
 
 ---
 

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -48,6 +48,7 @@
       "manifest": {
         "name": "mcm-app",
         "short_name": "MCM",
+        "description": "Cancionero y utilidades del Movimiento de Cursillos de Cristiandad",
         "start_url": ".",
         "display": "standalone",
         "background_color": "#ffffff",
@@ -77,9 +78,7 @@
         }
       ],
       "expo-asset",
-      [
-        "expo-build-properties"
-      ]
+      ["expo-build-properties"]
     ],
     "experiments": {
       "typedRoutes": true

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -48,7 +48,7 @@
       "manifest": {
         "name": "mcm-app",
         "short_name": "MCM",
-        "description": "Cancionero y utilidades del Movimiento de Cursillos de Cristiandad",
+        "description": "Aplicación móvil de MCM España para seguimiento de actividades, cantoral y mucho más",
         "start_url": ".",
         "display": "standalone",
         "background_color": "#ffffff",

--- a/mcm-app/components/AddToHomeBanner.tsx
+++ b/mcm-app/components/AddToHomeBanner.tsx
@@ -12,6 +12,7 @@ import { IconSymbol } from './ui/IconSymbol';
 
 export default function AddToHomeScreenPrompt() {
   const [visible, setVisible] = useState(false);
+  const [installEvent, setInstallEvent] = useState<any>(null);
   const scheme = useColorScheme() || 'light';
 
   useEffect(() => {
@@ -22,29 +23,81 @@ export default function AddToHomeScreenPrompt() {
     const inStandalone =
       (window.navigator as any).standalone === true ||
       window.matchMedia('(display-mode: standalone)').matches;
+    const dismissed = window.localStorage.getItem('addToHomeDismissed');
 
-    if (isIOS && isSafari && !inStandalone) {
+    const promptHandler = (e: any) => {
+      e.preventDefault();
+      setInstallEvent(e);
+      if (!dismissed) setVisible(true);
+    };
+
+    if (isIOS && isSafari && !inStandalone && !dismissed) {
       setVisible(true);
+    } else {
+      window.addEventListener('beforeinstallprompt', promptHandler);
     }
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', promptHandler);
+    };
   }, []);
 
   if (!visible) return null;
   const theme = Colors[scheme];
 
+  const handleInstall = () => {
+    if (installEvent) {
+      installEvent.prompt();
+      installEvent.userChoice.finally(() => {
+        setInstallEvent(null);
+        window.localStorage.setItem('addToHomeDismissed', 'true');
+        setVisible(false);
+      });
+    } else {
+      window.localStorage.setItem('addToHomeDismissed', 'true');
+      setVisible(false);
+    }
+  };
+
+  const handleClose = () => {
+    window.localStorage.setItem('addToHomeDismissed', 'true');
+    setVisible(false);
+  };
+
+  const isAndroidPrompt = !!installEvent;
+
   return (
     <View style={styles.overlay} pointerEvents="box-none">
       <View style={[styles.container, { backgroundColor: theme.background }]}>
-        <Text style={[styles.text, { color: theme.text }]}>
-          <IconSymbol name="square.and.arrow.up" color={theme.text} /> Añade
-          esta app a tu pantalla de inicio
-        </Text>
-        <Text style={[styles.subtext, { color: theme.text }]}>
-          Pulsa Compartir y luego Añadir a pantalla de inicio
-        </Text>
-        <TouchableOpacity
-          onPress={() => setVisible(false)}
-          style={styles.close}
-        >
+        {isAndroidPrompt ? (
+          <>
+            <Text style={[styles.text, { color: theme.text }]}>
+              Añade esta app para un acceso directo.
+            </Text>
+            <TouchableOpacity
+              onPress={handleInstall}
+              style={styles.installButton}
+            >
+              <Text style={{ color: theme.text, fontWeight: 'bold' }}>
+                Instalar
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <>
+            <Text style={[styles.text, { color: theme.text }]}>
+              <IconSymbol name="square.and.arrow.up" color={theme.text} /> Añade
+              esta app a tu pantalla de inicio
+            </Text>
+            <Text style={[styles.subtext, { color: theme.text }]}>
+              Pulsa Compartir y luego Añadir a pantalla de inicio
+            </Text>
+            <View
+              style={[styles.arrowDown, { borderTopColor: theme.background }]}
+            />
+          </>
+        )}
+        <TouchableOpacity onPress={handleClose} style={styles.close}>
           <IconSymbol name="close" color={theme.text} size={20} />
         </TouchableOpacity>
       </View>
@@ -85,5 +138,26 @@ const styles = StyleSheet.create({
     top: 4,
     right: 4,
     padding: 4,
+  },
+  installButton: {
+    marginTop: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#ccc',
+  },
+  arrowDown: {
+    position: 'absolute',
+    bottom: -10,
+    left: '50%',
+    marginLeft: -10,
+    width: 0,
+    height: 0,
+    borderLeftWidth: 10,
+    borderRightWidth: 10,
+    borderTopWidth: 10,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
   },
 });


### PR DESCRIPTION
## Summary
- document install instructions
- add PWA icons for add-to-home screen
- show AddToHomeBanner on Android and iOS
- add description to web manifest
- remove conflicting home screen icons

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68823d01075883269a8571bfdb56e001