### PR TITLE
Add Comida section with web viewer

### DIFF
--- a/mcm-app/app/(tabs)/jubileo.tsx
+++ b/mcm-app/app/(tabs)/jubileo.tsx
@@ -13,6 +13,8 @@ import GruposScreen from '../screens/GruposScreen';
 import ContactosScreen from '../screens/ContactosScreen';
 import ReflexionesScreen from '../screens/ReflexionesScreen';
 import AppsScreen from '../screens/AppsScreen';
+import ComidaScreen from '../screens/ComidaScreen';
+import ComidaWebScreen from '../screens/ComidaWebScreen';
 import SettingsPanel from '@/components/SettingsPanel';
 
 export type JubileoStackParamList = {
@@ -21,6 +23,8 @@ export type JubileoStackParamList = {
   Materiales: { initialDayIndex?: number } | undefined;
   MaterialPages: { actividad: any; fecha: string };
   Visitas: undefined;
+  Comida: undefined;
+  ComidaWeb: { url: string; title: string };
   Profundiza: undefined;
   Grupos: undefined;
   Contactos: undefined;
@@ -86,6 +90,16 @@ export default function JubileoTab() {
           name="MaterialPages"
           component={MaterialPagesScreen}
           options={{ title: 'Material' }}
+        />
+        <Stack.Screen
+          name="Comida"
+          component={ComidaScreen}
+          options={{ title: 'Comida' }}
+        />
+        <Stack.Screen
+          name="ComidaWeb"
+          component={ComidaWebScreen}
+          options={{ title: 'Comida' }}
         />
         <Stack.Screen
           name="Visitas"

--- a/mcm-app/app/screens/ComidaScreen.tsx
+++ b/mcm-app/app/screens/ComidaScreen.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  useWindowDimensions,
+  ScrollView,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Colors } from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import typography from '@/constants/typography';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { JubileoStackParamList } from '../(tabs)/jubileo';
+
+interface Option {
+  label: string;
+  icon: string;
+  url: string;
+}
+
+const OPTIONS: Option[] = [
+  {
+    label: 'Web comidas',
+    icon: '🍽️',
+    url: 'https://app.amicidelpellegrino.it/es',
+  },
+  {
+    label: 'Busca sitios',
+    icon: '🔍',
+    url: 'https://storelocator.amicidelpellegrino.it/?locale=it',
+  },
+  {
+    label: 'Google Maps',
+    icon: '🗺️',
+    url: 'https://www.google.com/maps/d/edit?mid=11qLeGeI5-oD-OS1rh1kMsBSbGKwyP0g&usp=sharing',
+  },
+  {
+    label: 'Food Hub',
+    icon: '🍔',
+    url: 'https://www.iubilaeum2025.va/es/pellegrinaggio/calendario-giubileo/GrandiEventi/Giubileo-dei-Giovani/hub-food.html',
+  },
+];
+
+type Nav = NativeStackNavigationProp<JubileoStackParamList, 'ComidaWeb'>;
+
+export default function ComidaScreen() {
+  const navigation = useNavigation<Nav>();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const { width, height } = useWindowDimensions();
+  const containerPadding = spacing.md;
+  const gap = spacing.md;
+  const itemWidth = (width - containerPadding * 2 - gap) / 2;
+  const itemHeight = Math.min(160, (height - containerPadding * 2 - gap * 3) / 3);
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.gridContainer}>
+          {OPTIONS.map((opt, idx) => (
+            <View key={idx} style={styles.itemWrapper}>
+              <TouchableOpacity
+                style={[styles.item, { width: itemWidth, height: itemHeight }]}
+                onPress={() => navigation.navigate('ComidaWeb', { url: opt.url, title: opt.label })}
+                activeOpacity={0.85}
+              >
+                <Text style={styles.icon}>{opt.icon}</Text>
+                <Text style={styles.label}>{opt.label}</Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const createStyles = (scheme: 'light' | 'dark') => {
+  const theme = Colors[scheme];
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.background },
+    scrollContent: { flexGrow: 1, padding: spacing.md },
+    gridContainer: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+    },
+    itemWrapper: { width: '48%', marginBottom: spacing.md },
+    item: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: 16,
+      backgroundColor: '#FF8A65',
+    },
+    icon: {
+      fontSize: 40,
+      marginBottom: spacing.sm,
+      color: '#fff',
+    },
+    label: {
+      ...(typography.button as any),
+      color: '#fff',
+      fontWeight: 'bold',
+      textAlign: 'center',
+    },
+  });
+};

--- a/mcm-app/app/screens/ComidaWebScreen.tsx
+++ b/mcm-app/app/screens/ComidaWebScreen.tsx
@@ -1,0 +1,129 @@
+import React, { useLayoutEffect, useState } from 'react';
+import { View, StyleSheet, Platform, TouchableOpacity, Linking } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { ActivityIndicator, Portal, Snackbar } from 'react-native-paper';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { JubileoStackParamList } from '../(tabs)/jubileo';
+import spacing from '@/constants/spacing';
+import { Colors as ThemeColors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import iframeStyles from '../(tabsdesactivados)/comunica.module.css';
+
+interface Params {
+  url: string;
+  title: string;
+}
+
+type Route = RouteProp<JubileoStackParamList, 'ComidaWeb'>;
+
+export default function ComidaWebScreen() {
+  const route = useRoute<Route>();
+  const { url, title } = route.params;
+  const navigation = useNavigation();
+  const scheme = useColorScheme();
+  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  const openExternal = () => {
+    if (Platform.OS === 'web') {
+      window.open(url, '_blank');
+    } else {
+      Linking.openURL(url);
+    }
+  };
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title,
+      headerRight: () => (
+        <TouchableOpacity onPress={openExternal} style={{ padding: 8, marginRight: 4 }}>
+          <MaterialIcons name="open-in-new" size={24} color="#fff" />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, url, title]);
+
+  const onLoadEnd = () => setIsLoading(false);
+  const onError = () => {
+    setError('Error al cargar el contenido. Por favor, verifica tu conexión a internet.');
+    setVisible(true);
+    setIsLoading(false);
+  };
+
+  if (Platform.OS === 'web') {
+    return (
+      <View style={styles.containerWeb}>
+        <iframe
+          src={url}
+          title={title}
+          className={iframeStyles.iframe}
+          onError={onError}
+          onLoad={onLoadEnd}
+        />
+        {isLoading && (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color={ThemeColors.light.tint} />
+          </View>
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <WebView
+        source={{ uri: url }}
+        style={styles.webview}
+        startInLoadingState={true}
+        renderLoading={() => (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color={ThemeColors.light.tint} />
+          </View>
+        )}
+        onLoadEnd={onLoadEnd}
+        onError={onError}
+      />
+      <Portal>
+        <Snackbar
+          visible={visible}
+          onDismiss={() => setVisible(false)}
+          action={{ label: 'Cerrar', onPress: () => setVisible(false) }}
+          duration={Snackbar.DURATION_MEDIUM}
+          style={{ backgroundColor: '#f44336' }}
+        >
+          {error}
+        </Snackbar>
+      </Portal>
+    </View>
+  );
+}
+
+const createStyles = (scheme: 'light' | 'dark') => {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      margin: spacing.sm,
+      position: 'relative',
+    },
+    webview: {
+      flex: 1,
+      borderRadius: 8,
+      overflow: 'hidden',
+    } as any,
+    loadingContainer: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(255, 255, 255, 0.8)',
+    },
+    containerWeb: {
+      flex: 1,
+      margin: 0,
+      padding: 0,
+      position: 'relative',
+    },
+  });
+};

--- a/mcm-app/app/screens/JubileoHomeScreen.tsx
+++ b/mcm-app/app/screens/JubileoHomeScreen.tsx
@@ -42,6 +42,12 @@ const navigationItems: NavigationItem[] = [
     backgroundColor: '#4FC3F7',
   },
   {
+    label: 'Comida',
+    icon: '🍽️',
+    target: 'Comida',
+    backgroundColor: '#F06292',
+  },
+  {
     label: 'Visitas',
     icon: '🚌',
     target: 'Visitas',

--- a/mcm-app/declarations.d.ts
+++ b/mcm-app/declarations.d.ts
@@ -3,3 +3,8 @@ declare module '*.json' {
   const value: any;
   export default value;
 }
+
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
- add Comida section to Jubileo navigation
- show four food-related options
- embed external websites with a reusable web screen
- allow opening links in the system browser
- update type declarations for CSS modules

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688557bc00608326af3fa84fb5394de6