### PR TITLE
Implement rich text support for materiales and profundiza

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,22 @@ Puedes definir algunas variables para ajustar ciertas funciones de la app. Expo 
    Asegúrate de que todas las variables empiecen con `EXPO_PUBLIC_`.
 4. El archivo `.env.local` se encuentra en `.gitignore`, por lo que tus claves no se subirán al repositorio.
 5. Al arrancar la app (`npm start`) Expo cargará automáticamente dichas variables de entorno.
+
+## Formato de texto para "Materiales" y "Profundiza"
+
+Los textos que se reciben en formato JSON admiten un pequeño sistema de etiquetas para dar estilo. Se basa en un lenguaje similar a BBCode y se convierte a HTML dentro de la app.
+
+Etiquetas disponibles:
+
+- `[b]negrita[/b]`, `[i]cursiva[/i]`, `[u]subrayado[/u]`
+- `[h1]Encabezado[/h1]`
+- `[url=https://ejemplo.com]Enlace[/url]`
+- `[btn-primary=https://ejemplo.com]Botón principal[/btn-primary]`
+- `[btn-secondary=https://ejemplo.com]Botón secundario[/btn-secondary]`
+- `[color=primary]texto azul[/color]`, también `accent`, `info` o `success`
+- `[quote]cita corta[/quote]`
+- `[gquote]cita larga o evangelio[/gquote]`
+- Listas: `[list][*]primer punto[*]segundo punto[/list]`
+- Saltos de línea: `[br]`
+
+Estas etiquetas permiten resaltar información importante y enlazar a recursos externos dentro de la app.

--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -17,6 +17,7 @@ import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import useFontScale from '@/hooks/useFontScale';
 import spacing from '@/constants/spacing';
+import FormattedContent from '@/components/FormattedContent';
 import { JubileoStackParamList } from '../(tabs)/jubileo';
 
 interface Pagina {
@@ -115,7 +116,7 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
           )}
         </View>
         <ScrollView contentContainerStyle={styles.pageContent}>
-          <Text style={styles.pageText}>{item.texto}</Text>
+          {item.texto && <FormattedContent text={item.texto} />}
         </ScrollView>
       </View>
     );

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { List, Text } from 'react-native-paper';
+import FormattedContent from '@/components/FormattedContent';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import useFontScale from '@/hooks/useFontScale';
@@ -42,7 +43,7 @@ export default function ProfundizaScreen() {
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <Text style={styles.mainTitle}>{data.titulo}</Text>
-      <Text style={styles.intro}>{data.introduccion}</Text>
+      <FormattedContent text={data.introduccion} />
       <View style={{ marginTop: 16 }}>
         <List.AccordionGroup>
           {data.paginas.map((p, idx) => (
@@ -60,7 +61,7 @@ export default function ProfundizaScreen() {
                 {p.subtitulo && (
                   <Text style={styles.subtitulo}>{p.subtitulo}</Text>
                 )}
-                {p.texto && <Text style={styles.texto}>{p.texto}</Text>}
+                {p.texto && <FormattedContent text={p.texto} />}
               </View>
             </List.Accordion>
           ))}
@@ -81,7 +82,6 @@ const createStyles = (scheme: 'light' | 'dark', scale: number) => {
       marginBottom: 8,
       color: theme.text,
     },
-    intro: { fontSize: 16 * scale, marginBottom: 16, color: theme.text },
     accordion: { marginBottom: 12, borderRadius: 16 },
     accordionTitle: { color: colors.white, fontWeight: 'bold' },
     accordionContent: {
@@ -97,6 +97,5 @@ const createStyles = (scheme: 'light' | 'dark', scale: number) => {
       color: theme.text,
       fontSize: 14 * scale,
     },
-    texto: { marginBottom: 12, color: theme.text, fontSize: 14 * scale },
   });
 };

--- a/mcm-app/components/FormattedContent.tsx
+++ b/mcm-app/components/FormattedContent.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useWindowDimensions, Linking } from 'react-native';
+import RenderHTML from 'react-native-render-html';
+import colors from '@/constants/colors';
+import { formatBBCodeToHtml } from '@/utils/formatText';
+
+const tagsStyles = {
+  h2: { fontSize: 22, fontWeight: 'bold', marginBottom: 8 },
+  ul: { marginVertical: 8, paddingLeft: 20 },
+  li: { marginBottom: 4 },
+  blockquote: {
+    borderLeftWidth: 4,
+    borderLeftColor: colors.info,
+    paddingLeft: 8,
+    marginVertical: 8,
+  },
+};
+
+const classesStyles = {
+  'btn-primary': {
+    backgroundColor: colors.primary,
+    color: colors.white,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    textAlign: 'center',
+    marginVertical: 4,
+    display: 'inline-block',
+  },
+  'btn-secondary': {
+    backgroundColor: colors.accent,
+    color: colors.white,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    textAlign: 'center',
+    marginVertical: 4,
+    display: 'inline-block',
+  },
+  'color-primary': { color: colors.primary },
+  'color-accent': { color: colors.accent },
+  'color-info': { color: colors.info },
+  'color-success': { color: colors.success },
+};
+
+export default function FormattedContent({ text }: { text: string }) {
+  const html = React.useMemo(() => formatBBCodeToHtml(text), [text]);
+  const { width } = useWindowDimensions();
+  return (
+    <RenderHTML
+      contentWidth={width}
+      source={{ html }}
+      tagsStyles={tagsStyles as any}
+      classesStyles={classesStyles as any}
+      onLinkPress={(_, href) => Linking.openURL(href)}
+    />
+  );
+}

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -56,6 +56,7 @@
         "react-native-onesignal": "^5.2.11",
         "react-native-paper": "^5.14.4",
         "react-native-reanimated": "~3.17.4",
+        "react-native-render-html": "^6.3.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-web": "~0.20.0",
@@ -3733,6 +3734,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsamr/counter-style": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jsamr/counter-style/-/counter-style-2.0.2.tgz",
+      "integrity": "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ==",
+      "license": "MIT"
+    },
+    "node_modules/@jsamr/react-native-li": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz",
+      "integrity": "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@jsamr/counter-style": "^1.0.0 || ^2.0.0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
@@ -3744,6 +3762,40 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@native-html/css-processor": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-1.11.0.tgz",
+      "integrity": "sha512-NnhBEbJX5M2gBGltPKOetiLlKhNf3OHdRafc8//e2ZQxXN8JaSW/Hy8cm94pnIckQxwaMKxrtaNT3x4ZcffoNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "csstype": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*"
+      }
+    },
+    "node_modules/@native-html/transient-render-engine": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@native-html/transient-render-engine/-/transient-render-engine-11.2.3.tgz",
+      "integrity": "sha512-zXwgA3gPUEmFs3I3syfnvDvS6WiUHXEE6jY09OBzK+trq7wkweOSFWIoyXiGkbXrozGYG0KY90YgPyr8Tg8Uyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@native-html/css-processor": "1.11.0",
+        "@types/ramda": "^0.27.44",
+        "csstype": "^3.0.9",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "htmlparser2": "^7.1.2",
+        "ramda": "^0.27.2"
+      },
+      "peerDependencies": {
+        "@types/react-native": "*",
+        "react-native": "^*"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4922,6 +4974,20 @@
       "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
       "license": "MIT"
     },
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.72.8",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.8.tgz",
+      "integrity": "sha512-J3Q4Bkuo99k7mu+jPS9gSUSgq+lLRSI/+ahXNwV92XgJ/8UgOTxu2LPwhJnBk/sQKxq7E8WkZBnBiozukQMqrw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-navigation/bottom-tabs": {
       "version": "7.3.14",
       "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.3.14.tgz",
@@ -5282,14 +5348,33 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/ramda": {
+      "version": "0.27.66",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.66.tgz",
+      "integrity": "sha512-i2YW+E2U6NfMt3dp0RxNcejox+bxJUNDjB7BpYuRuoHIzv5juPHkJkNgcUOu+YSQEmaWu8cnAo/8r63C0NnuVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
       "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-native": {
+      "version": "0.72.8",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.8.tgz",
+      "integrity": "sha512-St6xA7+EoHN5mEYfdWnfYt0e8u6k2FR0P9s2arYgakQGFgU1f9FlPrIEcj0X24pLCF5c5i3WVuLCUdiCYHmOoA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@react-native/virtualized-lists": "^0.72.4",
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -5303,6 +5388,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.25",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
+      "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7074,6 +7165,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001727",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
@@ -7118,6 +7218,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chordsheetjs": {
@@ -7649,6 +7769,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
@@ -7656,6 +7785,17 @@
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssom": {
@@ -7689,7 +7829,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -8015,6 +8154,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -8037,6 +8211,35 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -10515,6 +10718,37 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -15099,6 +15333,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -15441,6 +15681,27 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-render-html": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-render-html/-/react-native-render-html-6.3.4.tgz",
+      "integrity": "sha512-H2jSMzZjidE+Wo3qCWPUMU1nm98Vs2SGCvQCz/i6xf0P3Y9uVtG/b0sDbG/cYFir2mSYBYCIlS1Dv0WC1LjYig==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jsamr/counter-style": "^2.0.1",
+        "@jsamr/react-native-li": "^2.3.0",
+        "@native-html/transient-render-engine": "11.2.3",
+        "@types/ramda": "^0.27.40",
+        "@types/urijs": "^1.19.15",
+        "prop-types": "^15.5.7",
+        "ramda": "^0.27.2",
+        "stringify-entities": "^3.1.0",
+        "urijs": "^1.19.6"
+      },
+      "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
@@ -17033,6 +17294,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+      "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -17632,6 +17908,12 @@
       "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
       "license": "ISC"
     },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -17988,6 +18270,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -18664,6 +18952,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -59,6 +59,7 @@
     "react-native-onesignal": "^5.2.11",
     "react-native-paper": "^5.14.4",
     "react-native-reanimated": "~3.17.4",
+    "react-native-render-html": "^6.3.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",

--- a/mcm-app/utils/formatText.ts
+++ b/mcm-app/utils/formatText.ts
@@ -1,0 +1,27 @@
+export function formatBBCodeToHtml(text: string): string {
+  const replaceIteratively = (pattern: RegExp, replacer: string | ((...args: any[]) => string)) => {
+    let prev: string;
+    do {
+      prev = text;
+      text = text.replace(pattern, replacer as any);
+    } while (prev !== text);
+  };
+
+  replaceIteratively(/\[br\]/gi, '<br/>');
+  replaceIteratively(/\[b\](.*?)\[\/b\]/gis, '<strong>$1</strong>');
+  replaceIteratively(/\[i\](.*?)\[\/i\]/gis, '<em>$1</em>');
+  replaceIteratively(/\[u\](.*?)\[\/u\]/gis, '<u>$1</u>');
+  replaceIteratively(/\[h1\](.*?)\[\/h1\]/gis, '<h2>$1</h2>');
+  replaceIteratively(/\[url=(.*?)\](.*?)\[\/url\]/gis, '<a href="$1">$2</a>');
+  replaceIteratively(/\[btn-primary=(.*?)\](.*?)\[\/btn-primary\]/gis, '<a href="$1" class="btn-primary">$2</a>');
+  replaceIteratively(/\[btn-secondary=(.*?)\](.*?)\[\/btn-secondary\]/gis, '<a href="$1" class="btn-secondary">$2</a>');
+  replaceIteratively(/\[color=(.*?)\](.*?)\[\/color\]/gis, '<span class="color-$1">$2</span>');
+  replaceIteratively(/\[quote\](.*?)\[\/quote\]/gis, '<blockquote class="quote">$1</blockquote>');
+  replaceIteratively(/\[gquote\](.*?)\[\/gquote\]/gis, '<blockquote class="gquote">$1</blockquote>');
+  replaceIteratively(/\[list\](.*?)\[\/list\]/gis, (_match, items) => {
+    const html = items.replace(/\[\*\](.*?)(?=\[\*\]|$)/gis, '<li>$1</li>');
+    return `<ul>${html}</ul>`;
+  });
+
+  return text;
+}


### PR DESCRIPTION
## Summary
- add `react-native-render-html` to handle html fragments
- convert BBCode-like markup to HTML
- render formatted content in MaterialPages and Profundiza screens
- document formatting syntax in README

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6885593887448326ad713f904898aa0b