### PR TITLE
Add user profile modal and store name

### DIFF
--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -25,6 +25,11 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { useStatusBarTheme } from '@/hooks/useStatusBarTheme';
 import { AppSettingsProvider } from '@/contexts/AppSettingsContext';
 import { FeatureFlagsProvider } from '@/contexts/FeatureFlagsContext';
+import {
+  UserProfileProvider,
+  useUserProfile,
+} from '@/contexts/UserProfileContext';
+import UserProfileModal from '@/components/UserProfileModal';
 import { HelloWave } from '@/components/HelloWave'; // Import HelloWave
 import AddToHomeBanner from '@/components/AddToHomeBanner';
 import {
@@ -41,7 +46,9 @@ export default function RootLayout() {
   return (
     <FeatureFlagsProvider>
       <AppSettingsProvider>
-        <InnerLayout />
+        <UserProfileProvider>
+          <InnerLayout />
+        </UserProfileProvider>
       </AppSettingsProvider>
     </FeatureFlagsProvider>
   );
@@ -51,6 +58,8 @@ function InnerLayout() {
   const [showAnimation, setShowAnimation] = useState(true);
   const scheme = useColorScheme(); // Keep existing hooks
   const pathname = usePathname();
+  const { profile, loading: profileLoading } = useUserProfile();
+  const [profileVisible, setProfileVisible] = useState(false);
 
   // Hook para actualizar el tema de la barra de estado dinámicamente
   useStatusBarTheme(pathname);
@@ -74,6 +83,13 @@ function InnerLayout() {
 
     return () => clearTimeout(timer); // Cleanup timer on unmount
   }, []);
+
+  useEffect(() => {
+    if (showAnimation) return;
+    if (!profileLoading && (!profile.name || !profile.location)) {
+      setProfileVisible(true);
+    }
+  }, [showAnimation, profileLoading, profile]);
 
   // NOTIS - Comentado para eliminar sistema notificaciones
   //usePushNotifications(); // 3️⃣ inicializa el hook
@@ -183,6 +199,10 @@ function InnerLayout() {
             </Stack>
             <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
             <AddToHomeBanner />
+            <UserProfileModal
+              visible={profileVisible}
+              onClose={() => setProfileVisible(false)}
+            />
           </NavThemeProvider>
         </PaperProvider>
       </SafeAreaProvider>

--- a/mcm-app/components/AppFeedbackModal.tsx
+++ b/mcm-app/components/AppFeedbackModal.tsx
@@ -15,6 +15,7 @@ import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/hooks/firebaseApp';
+import { useUserProfile } from '@/contexts/UserProfileContext';
 
 interface AppFeedbackModalProps {
   visible: boolean;
@@ -70,6 +71,7 @@ export default function AppFeedbackModal({
 }: AppFeedbackModalProps) {
   const scheme = useColorScheme();
   const theme = Colors[scheme];
+  const { profile } = useUserProfile();
   const [selectedCategory, setSelectedCategory] =
     useState<FeedbackCategory | null>(null);
   const [feedbackText, setFeedbackText] = useState('');
@@ -104,6 +106,8 @@ export default function AppFeedbackModal({
         status: 'pending', // pending, reviewed, resolved
         reportedAt: new Date().toISOString(),
         category: selectedCategory,
+        userName: profile.name,
+        userLocation: profile.location,
       });
 
       // Limpiar y cerrar

--- a/mcm-app/components/ReportBugsModal.tsx
+++ b/mcm-app/components/ReportBugsModal.tsx
@@ -17,6 +17,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/hooks/firebaseApp';
 import { getCategoryFromFilename, cleanSongTitle } from '@/utils/songUtils';
+import { useUserProfile } from '@/contexts/UserProfileContext';
 
 interface ReportBugsModalProps {
   visible: boolean;
@@ -35,6 +36,7 @@ export default function ReportBugsModal({
 }: ReportBugsModalProps) {
   const scheme = useColorScheme();
   const theme = Colors[scheme];
+  const { profile } = useUserProfile();
   const [bugDescription, setBugDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -71,6 +73,8 @@ export default function ReportBugsModal({
         platform: Platform.OS,
         status: 'pending', // pending, reviewed, fixed
         reportedAt: new Date().toISOString(),
+        userName: profile.name,
+        userLocation: profile.location,
       });
 
       // Limpiar y cerrar

--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import Modal from 'react-native-modal';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -6,6 +6,7 @@ import useFontScale from '@/hooks/useFontScale';
 import { useAppSettings, ThemeScheme } from '@/contexts/AppSettingsContext';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import UserProfileModal from './UserProfileModal';
 
 interface Props {
   visible: boolean;
@@ -17,6 +18,7 @@ export default function SettingsPanel({ visible, onClose }: Props) {
   const scheme = useColorScheme();
   const theme = Colors[scheme];
   const fontScale = useFontScale();
+  const [editVisible, setEditVisible] = useState(false);
 
   const increase = () => {
     setSettings({ fontScale: Math.min(settings.fontScale + 0.1, 2) });
@@ -97,7 +99,20 @@ export default function SettingsPanel({ visible, onClose }: Props) {
             />
           </TouchableOpacity>
         </View>
+        <TouchableOpacity
+          style={styles.nameButton}
+          onPress={() => setEditVisible(true)}
+        >
+          <MaterialIcons name="person" size={24} color={theme.text} />
+          <Text style={[styles.nameButtonText, { color: theme.text }]}>
+            Cambia tu nombre
+          </Text>
+        </TouchableOpacity>
       </View>
+      <UserProfileModal
+        visible={editVisible}
+        onClose={() => setEditVisible(false)}
+      />
     </Modal>
   );
 }
@@ -129,5 +144,15 @@ const styles = StyleSheet.create({
   },
   themeSelected: {
     opacity: 1,
+  },
+  nameButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  nameButtonText: {
+    marginLeft: 8,
+    fontSize: 16,
+    fontWeight: '600',
   },
 });

--- a/mcm-app/components/SuggestSongModal.tsx
+++ b/mcm-app/components/SuggestSongModal.tsx
@@ -15,6 +15,7 @@ import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/hooks/firebaseApp';
+import { useUserProfile } from '@/contexts/UserProfileContext';
 
 interface SuggestSongModalProps {
   visible: boolean;
@@ -33,6 +34,7 @@ export default function SuggestSongModal({
 }: SuggestSongModalProps) {
   const scheme = useColorScheme();
   const theme = Colors[scheme];
+  const { profile } = useUserProfile();
 
   const [titulo, setTitulo] = useState('');
   const [artista, setArtista] = useState('');
@@ -69,6 +71,8 @@ export default function SuggestSongModal({
         timestamp: Date.now(),
         platform: Platform.OS,
         requestedAt: new Date().toISOString(),
+        userName: profile.name,
+        userLocation: profile.location,
       });
 
       await set(ref(db, 'songs/updatedAt'), Date.now().toString());

--- a/mcm-app/components/UserProfileModal.tsx
+++ b/mcm-app/components/UserProfileModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import BottomSheet from './BottomSheet';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { useUserProfile } from '@/contexts/UserProfileContext';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function UserProfileModal({ visible, onClose }: Props) {
+  const { profile, setProfile } = useUserProfile();
+  const [name, setName] = useState(profile.name);
+  const [location, setLocation] = useState(profile.location);
+  const scheme = useColorScheme();
+  const theme = Colors[scheme];
+
+  useEffect(() => {
+    setName(profile.name);
+    setLocation(profile.location);
+  }, [profile]);
+
+  const save = () => {
+    setProfile({ name: name.trim(), location: location.trim() });
+    onClose();
+  };
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose}>
+      <Text style={[styles.title, { color: theme.text }]}>Tu nombre</Text>
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: theme.background,
+            color: theme.text,
+            borderColor: theme.icon,
+          },
+        ]}
+        placeholder="Introduce tu nombre"
+        placeholderTextColor={theme.icon}
+        value={name}
+        onChangeText={setName}
+      />
+      <Text style={[styles.title, { color: theme.text }]}>Lugar de origen</Text>
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: theme.background,
+            color: theme.text,
+            borderColor: theme.icon,
+          },
+        ]}
+        placeholder="Tu ciudad o comunidad"
+        placeholderTextColor={theme.icon}
+        value={location}
+        onChangeText={setLocation}
+      />
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor: theme.tint }]}
+        onPress={save}
+        disabled={!name.trim()}
+      >
+        <Text style={styles.buttonText}>Guardar</Text>
+      </TouchableOpacity>
+      <Text style={[styles.disclaimer, { color: theme.icon }]}>
+        Usaremos tu nombre para el ranking del Wordle y en tus comentarios
+      </Text>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: { fontSize: 16, fontWeight: '600', marginBottom: 8 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  button: {
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
+  disclaimer: { fontSize: 12, textAlign: 'center', marginTop: 12 },
+});

--- a/mcm-app/contexts/UserProfileContext.tsx
+++ b/mcm-app/contexts/UserProfileContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface UserProfile {
+  name: string;
+  location: string;
+}
+
+interface UserProfileContextType {
+  profile: UserProfile;
+  setProfile: (values: Partial<UserProfile>) => void;
+  loading: boolean;
+}
+
+const defaultProfile: UserProfile = { name: '', location: '' };
+const STORAGE_KEY = '@user_profile';
+
+const UserProfileContext = createContext<UserProfileContextType | undefined>(
+  undefined,
+);
+
+export const UserProfileProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [profile, setProfileState] = useState<UserProfile>(defaultProfile);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await AsyncStorage.getItem(STORAGE_KEY);
+        if (data) {
+          setProfileState((prev) => ({ ...prev, ...JSON.parse(data) }));
+        }
+      } catch (e) {
+        console.error('Failed loading user profile', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (loading) return;
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(profile)).catch((e) =>
+      console.error('Failed saving user profile', e),
+    );
+  }, [profile, loading]);
+
+  const update = (values: Partial<UserProfile>) => {
+    setProfileState((prev) => ({ ...prev, ...values }));
+  };
+
+  return (
+    <UserProfileContext.Provider
+      value={{ profile, setProfile: update, loading }}
+    >
+      {children}
+    </UserProfileContext.Provider>
+  );
+};
+
+export const useUserProfile = () => {
+  const ctx = useContext(UserProfileContext);
+  if (!ctx)
+    throw new Error('useUserProfile must be used within UserProfileProvider');
+  return ctx;
+};

--- a/mcm-app/hooks/useWordleStats.ts
+++ b/mcm-app/hooks/useWordleStats.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getDatabase, push, ref, set } from 'firebase/database';
 import { getFirebaseApp } from './firebaseApp';
+import { useUserProfile } from '@/contexts/UserProfileContext';
 
 // Función simple para generar IDs únicos
 const generateId = () => {
@@ -26,6 +27,7 @@ const defaultStats: WordleStats = {
 export default function useWordleStats() {
   const [stats, setStats] = useState<WordleStats>(defaultStats);
   const [loading, setLoading] = useState(true);
+  const { profile } = useUserProfile();
 
   useEffect(() => {
     const load = async () => {
@@ -68,6 +70,8 @@ export default function useWordleStats() {
       const entryRef = push(ref(db, `wordle/${date}/${cycle}`));
       await set(entryRef, {
         userId: stats.userId,
+        userName: profile.name,
+        userLocation: profile.location,
         attempts,
         timestamp: Date.now(),
       });


### PR DESCRIPTION
## Summary
- prompt for name and location on first launch
- allow editing profile from Settings
- store profile along suggestions, bug reports and Wordle results

## Testing
- `npm --prefix mcm-app test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688a059c5fdc832698f181a2132ac244