### PR TITLE
feat: enable text copying across content

### DIFF
--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -174,8 +174,14 @@ export default function HorarioScreen() {
             },
           ]}
         >
-          <ThemedText style={styles.titleText}>{dia.titulo}</ThemedText>
-          {isLastDay && <ThemedText style={styles.sadEmoji}>😢</ThemedText>}
+          <ThemedText style={styles.titleText} selectable>
+            {dia.titulo}
+          </ThemedText>
+          {isLastDay && (
+            <ThemedText style={styles.sadEmoji} selectable>
+              😢
+            </ThemedText>
+          )}
         </Animated.View>
         {dia.eventos.map(
           (ev: EventItemData, idx: React.Key | null | undefined) => (

--- a/mcm-app/app/screens/MaterialPagesScreen.tsx
+++ b/mcm-app/app/screens/MaterialPagesScreen.tsx
@@ -88,9 +88,13 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
             }
           />
         ))}
-        <Text style={styles.introEmoji}>{actividad.emoji}</Text>
-        <Text style={styles.introTitle}>{actividad.nombre.toUpperCase()}</Text>
-        <Text style={styles.introDate}>
+        <Text style={styles.introEmoji} selectable>
+          {actividad.emoji}
+        </Text>
+        <Text style={styles.introTitle} selectable>
+          {actividad.nombre.toUpperCase()}
+        </Text>
+        <Text style={styles.introDate} selectable>
           {new Date(fecha)
             .toLocaleDateString('es-ES', {
               weekday: 'long',
@@ -100,7 +104,9 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
             .replace(',', '')
             .toUpperCase()}
         </Text>
-        <Text style={styles.introHint}>Desliza para ver el material</Text>
+        <Text style={styles.introHint} selectable>
+          Desliza para ver el material
+        </Text>
       </View>
     );
   };
@@ -122,9 +128,13 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
           <View
             style={[styles.pageHeader, { backgroundColor: actividad.color }]}
           >
-            <Text style={styles.pageTitle}>{item.titulo}</Text>
+            <Text style={styles.pageTitle} selectable>
+              {item.titulo}
+            </Text>
             {item.subtitulo && (
-              <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>
+              <Text style={styles.pageSubtitle} selectable>
+                {item.subtitulo}
+              </Text>
             )}
           </View>
           <div
@@ -145,9 +155,13 @@ export default function MaterialPagesScreen({ route }: { route: RouteProps }) {
     return (
       <View style={[styles.page, { width }]}>
         <View style={[styles.pageHeader, { backgroundColor: actividad.color }]}>
-          <Text style={styles.pageTitle}>{item.titulo}</Text>
+          <Text style={styles.pageTitle} selectable>
+            {item.titulo}
+          </Text>
           {item.subtitulo && (
-            <Text style={styles.pageSubtitle}>{item.subtitulo}</Text>
+            <Text style={styles.pageSubtitle} selectable>
+              {item.subtitulo}
+            </Text>
           )}
         </View>
         <ScrollView

--- a/mcm-app/app/screens/MaterialesScreen.tsx
+++ b/mcm-app/app/screens/MaterialesScreen.tsx
@@ -40,7 +40,7 @@ export default function MaterialesScreen() {
     'jubileo/materiales',
     'jubileo_materiales',
   );
-  
+
   // Get initial day index from navigation params, default to 0
   const initialDayIndex = route.params?.initialDayIndex ?? 0;
   const [index, setIndex] = useState(initialDayIndex);
@@ -79,8 +79,12 @@ export default function MaterialesScreen() {
               })
             }
           >
-            <Text style={styles.emoji}>{act.emoji}</Text>
-            <Text style={styles.cardText}>{act.nombre.toUpperCase()}</Text>
+            <Text style={styles.emoji} selectable>
+              {act.emoji}
+            </Text>
+            <Text style={styles.cardText} selectable>
+              {act.nombre.toUpperCase()}
+            </Text>
           </TouchableOpacity>
         ))}
       </ScrollView>

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -17,6 +17,7 @@ import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSelectedSongs } from '../../contexts/SelectedSongsContext'; // Import context hook
 import { IconSymbol } from '../../components/ui/IconSymbol'; // Import IconSymbol
 import { useSettings } from '../../contexts/SettingsContext'; // <<<--- ADD THIS IMPORT
+import * as Clipboard from 'expo-clipboard';
 
 const availableFonts = [
   {
@@ -214,6 +215,22 @@ export default function SongDetailScreen({
     });
   };
 
+  const handleCopyLyrics = async () => {
+    if (!originalChordPro) return;
+    let lyrics = originalChordPro
+      .replace(/\[[^\]]+\]/g, '')
+      .replace(/\{[^}]+\}\n?/g, '')
+      .replace(/[ \t]+/g, ' ')
+      .replace(/ *\n */g, '\n');
+    lyrics = lyrics
+      .split('\n')
+      .map((line) => line.trim())
+      .join('\n')
+      .replace(/\n{2,}/g, '\n\n')
+      .trim();
+    await Clipboard.setStringAsync(lyrics);
+  };
+
   const animateAndSet = (params: any, direction: 'next' | 'prev') => {
     const toValue = direction === 'next' ? -screenWidth : screenWidth;
     Animated.timing(slideAnim, {
@@ -300,6 +317,7 @@ export default function SongDetailScreen({
         onSetFontFamily={handleSetFontFamily}
         onToggleNotation={handleToggleNotation}
         onNavigateToFullscreen={handleNavigateToFullscreen}
+        onCopyLyrics={handleCopyLyrics}
         songTitle={_navScreenTitle}
         songFilename={filename}
       />

--- a/mcm-app/components/DateSelector.tsx
+++ b/mcm-app/components/DateSelector.tsx
@@ -61,10 +61,16 @@ export default function DateSelector({
     return (
       <TouchableOpacity onPress={() => onSelectDate(item.fecha, index)}>
         <View style={[styles.item, selected && styles.itemSelected]}>
-          <Text style={[styles.dateText, selected && styles.textSelected]}>
+          <Text
+            style={[styles.dateText, selected && styles.textSelected]}
+            selectable
+          >
             {label}
           </Text>
-          <Text style={[styles.weekdayText, selected && styles.textSelected]}>
+          <Text
+            style={[styles.weekdayText, selected && styles.textSelected]}
+            selectable
+          >
             {weekday}
           </Text>
         </View>

--- a/mcm-app/components/EventItem.tsx
+++ b/mcm-app/components/EventItem.tsx
@@ -65,11 +65,15 @@ export default function EventItem({
       <Card.Content style={styles.cardContent}>
         <View style={styles.row}>
           <View style={styles.iconContainer}>
-            <Text style={styles.emoji}>{event.icono || '📅'}</Text>
+            <Text style={styles.emoji} selectable>
+              {event.icono || '📅'}
+            </Text>
           </View>
           <View style={styles.contentContainer}>
             <View style={styles.headerRow}>
-              <Text style={styles.title}>{event.nombre}</Text>
+              <Text style={styles.title} selectable>
+                {event.nombre}
+              </Text>
               <View style={styles.rightSection}>
                 {event.materiales && (
                   <TouchableOpacity
@@ -82,18 +86,24 @@ export default function EventItem({
                       size={12 * fontScale}
                       color="#fff"
                     />
-                    <Text style={styles.materialsText}>Materiales</Text>
+                    <Text style={styles.materialsText} selectable>
+                      Materiales
+                    </Text>
                   </TouchableOpacity>
                 )}
                 {shouldShowHour(event.hora) && (
                   <View style={styles.timeContainer}>
-                    <Text style={styles.timeText}>{event.hora}</Text>
+                    <Text style={styles.timeText} selectable>
+                      {event.hora}
+                    </Text>
                   </View>
                 )}
               </View>
             </View>
             {event.subtitulo && (
-              <Text style={styles.subtitle}>{event.subtitulo}</Text>
+              <Text style={styles.subtitle} selectable>
+                {event.subtitulo}
+              </Text>
             )}
             <View style={styles.bottomRow}>
               {event.lugar && (
@@ -103,7 +113,9 @@ export default function EventItem({
                     size={14 * fontScale}
                     color="#999"
                   />
-                  <Text style={styles.location}>{event.lugar}</Text>
+                  <Text style={styles.location} selectable>
+                    {event.lugar}
+                  </Text>
                 </View>
               )}
               {event.maps && (
@@ -117,7 +129,9 @@ export default function EventItem({
                     size={16 * fontScale}
                     color="#4285F4"
                   />
-                  <Text style={styles.mapsText}>Ver en Maps</Text>
+                  <Text style={styles.mapsText} selectable>
+                    Ver en Maps
+                  </Text>
                 </TouchableOpacity>
               )}
             </View>

--- a/mcm-app/components/FormattedContent.tsx
+++ b/mcm-app/components/FormattedContent.tsx
@@ -220,12 +220,13 @@ export default function FormattedContent({
     <RenderHTML
       contentWidth={width}
       source={{ html }}
+      defaultTextProps={{ selectable: true }}
       tagsStyles={dynamicTagsStyles as any}
       classesStyles={dynamicClassesStyles as any}
       renderers={{
         span: ({ tnode }: { tnode: any }) => {
           const className = tnode.attributes?.class;
-          
+
           if (className === 'btn-primary') {
             const buttonStyles = {
               backgroundColor: colors.primary,
@@ -262,7 +263,7 @@ export default function FormattedContent({
               </TouchableOpacity>
             );
           }
-          
+
           if (className === 'btn-secondary') {
             const buttonStyles = {
               backgroundColor: colors.accent,
@@ -299,7 +300,7 @@ export default function FormattedContent({
               </TouchableOpacity>
             );
           }
-          
+
           // Para otros spans, usar el renderizador por defecto
           return undefined;
         },

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -28,6 +28,7 @@ interface SongControlsProps {
   onSetFontFamily: (fontFamily: string) => void;
   onToggleNotation: () => void;
   onNavigateToFullscreen: () => void;
+  onCopyLyrics: () => void;
   // Añadir props para el reporte de fallitos
   songTitle?: string;
   songFilename?: string;
@@ -46,6 +47,7 @@ const SongControls: React.FC<SongControlsProps> = ({
   onSetFontFamily,
   onToggleNotation,
   onNavigateToFullscreen,
+  onCopyLyrics,
   songTitle,
   songFilename,
 }) => {
@@ -54,6 +56,7 @@ const SongControls: React.FC<SongControlsProps> = ({
   const [showFontPanel, setShowFontPanel] = useState(false);
   const [showReportBugsModal, setShowReportBugsModal] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
+  const [showCopyToast, setShowCopyToast] = useState(false);
 
   const handleOpenTransposePanel = () => setShowTransposePanel(true);
   const handleOpenFontPanel = () => setShowFontPanel(true);
@@ -151,6 +154,15 @@ const SongControls: React.FC<SongControlsProps> = ({
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.fabAction}
+              onPress={() => {
+                onCopyLyrics();
+                setShowCopyToast(true);
+              }}
+            >
+              <Text style={styles.fabActionText}>Copiar letra</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.fabAction}
               onPress={() => setShowReportBugsModal(true)}
             >
               <Text style={styles.fabActionText}>¿Fallitos? 🐛</Text>
@@ -204,6 +216,23 @@ const SongControls: React.FC<SongControlsProps> = ({
         songFilename={songFilename}
         onSuccess={handleReportSuccess}
       />
+
+      <Snackbar
+        visible={showCopyToast}
+        onDismiss={() => setShowCopyToast(false)}
+        duration={2000}
+        style={{
+          backgroundColor: colors.info,
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+        }}
+      >
+        <Text style={{ color: '#fff', fontWeight: 'bold' }}>
+          Letra copiada al portapapeles
+        </Text>
+      </Snackbar>
 
       {/* Toast de éxito */}
       <Snackbar


### PR DESCRIPTION
## Summary
- allow copying song lyrics without chords
- make schedule and material texts selectable

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(warn: prettier/prettier, @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf58aff48326bc49587072033e17