### PR TITLE
Show Wordle leaderboard names

### DIFF
--- a/mcm-app/hooks/useWordleLeaderboard.ts
+++ b/mcm-app/hooks/useWordleLeaderboard.ts
@@ -45,8 +45,8 @@ export default function useWordleLeaderboard(
           );
           const top = arr.slice(0, 3).map((r) => ({
             userId: r.userId,
-            name: users[r.userId]?.name || 'Anónimo',
-            place: users[r.userId]?.place || '',
+            name: r.userName || users[r.userId]?.name || 'Anónimo',
+            place: r.userLocation || users[r.userId]?.place || '',
             attempts: r.attempts,
           }));
           setTopToday(top);
@@ -67,8 +67,8 @@ export default function useWordleLeaderboard(
             const avg = played ? totalAttempts / played : Infinity;
             return {
               userId: uid,
-              name: users[uid]?.name || 'Anónimo',
-              place: users[uid]?.place || '',
+              name: data.userName || users[uid]?.name || 'Anónimo',
+              place: data.userLocation || users[uid]?.place || '',
               played,
               average: avg,
             };


### PR DESCRIPTION
## Summary
- display stored user name and location instead of anonymous in Wordle leaderboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d3f37e208326a0ae9cd7a2641657