### PR TITLE
Remove debug logs from push notifications hook

### DIFF
--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -10,8 +10,6 @@
 //      a. notificationReceived — app en foreground: guarda la notificación localmente y actualiza badge
 //      b. notificationResponse — usuario toca la notificación: navega a la ruta correspondiente y marca como leída
 //
-// TODO: Eliminar console.log/warn/error de debug una vez estabilizado el sistema de notificaciones
-//
 import { useEffect, useRef } from 'react';
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
@@ -22,32 +20,10 @@ import {
   updateLastActive,
   saveReceivedNotificationLocally,
   markNotificationAsRead,
-  getDeviceId,
 } from '@/services/pushNotificationService';
 import { ReceivedNotification } from '@/types/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { router } from 'expo-router';
-import { getDatabase, ref, set } from 'firebase/database';
-import { getFirebaseApp } from '@/hooks/firebaseApp';
-
-/**
- * Escribe logs de diagnóstico en Firebase /debug/{deviceId}
- * Así puedes verlos en Firebase Console sin necesitar herramientas de desarrollo.
- * BORRAR cuando el problema esté resuelto.
- */
-async function logToFirebase(data: Record<string, any>) {
-  try {
-    const deviceId = await getDeviceId();
-    const db = getDatabase(getFirebaseApp());
-    await set(ref(db, `debug/${deviceId}`), {
-      ...data,
-      platform: Platform.OS,
-      timestamp: new Date().toISOString(),
-    });
-  } catch {
-    // Silencioso: si esto falla también, al menos tenemos console.error
-  }
-}
 
 // Mapeo de actionIdentifier de iOS a rutas internas
 const ACTION_ROUTES: Record<string, string> = {
@@ -64,17 +40,13 @@ export default function usePushNotifications() {
   useEffect(() => {
     // Registrar token y guardar en Firebase, luego heartbeat inicial
     registerAndSaveToken().then(() => {
-      updateLastActive().catch((err) =>
-        console.error('Error en heartbeat inicial:', err),
-      );
+      updateLastActive().catch(() => {});
     });
 
     // Actualizar última actividad periódicamente (cada 5 minutos)
     const intervalId = setInterval(
       () => {
-        updateLastActive().catch((err) =>
-          console.error('Error actualizando lastActive:', err),
-        );
+        updateLastActive().catch(() => {});
       },
       5 * 60 * 1000,
     );
@@ -82,8 +54,6 @@ export default function usePushNotifications() {
     // Listener para notificaciones recibidas (app en foreground)
     notificationListener.current =
       Notifications.addNotificationReceivedListener((notification) => {
-        console.log('🔔 Notificación recibida:', notification.request.content);
-
         const notificationId =
           (notification.request.content.data?.id as string) ||
           notification.request.identifier;
@@ -110,9 +80,7 @@ export default function usePushNotifications() {
             // Actualizar badge en tiempo real al recibir en foreground
             refreshCount();
           })
-          .catch((err) =>
-            console.error('Error guardando notificación localmente:', err),
-          );
+          .catch(() => {});
       });
 
     // Listener para cuando el usuario toca la notificación
@@ -139,9 +107,7 @@ export default function usePushNotifications() {
         if (targetRoute) {
           try {
             router.navigate(targetRoute as any);
-          } catch (error) {
-            console.error('Error navegando a ruta:', error);
-          }
+          } catch {}
         }
 
         // Guardar y marcar como leída
@@ -164,9 +130,7 @@ export default function usePushNotifications() {
         saveReceivedNotificationLocally(receivedNotification)
           .then(() => markNotificationAsRead(receivedNotification.id))
           .then(() => refreshCount())
-          .catch((err) =>
-            console.error('Error procesando notificación:', err),
-          );
+          .catch(() => {});
       });
 
     // Cleanup
@@ -193,7 +157,6 @@ async function registerAndSaveToken() {
     // 1. Permisos
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
-    console.log('📋 [PASO 1] Estado de permisos:', existingStatus);
 
     if (existingStatus !== 'granted') {
       const { status } = await Notifications.requestPermissionsAsync();
@@ -201,11 +164,8 @@ async function registerAndSaveToken() {
     }
 
     if (finalStatus !== 'granted') {
-      console.warn('⚠️ Permisos denegados:', finalStatus);
-      logToFirebase({ paso: 1, resultado: 'PERMISOS_DENEGADOS', finalStatus });
       return;
     }
-    console.log('✅ [PASO 1] Permisos concedidos');
 
     // 2. Canal Android
     if (Platform.OS === 'android') {
@@ -221,43 +181,23 @@ async function registerAndSaveToken() {
     const projectId =
       Constants?.expoConfig?.extra?.eas?.projectId ??
       Constants?.easConfig?.projectId;
-    console.log('📋 [PASO 3] projectId:', projectId || '(auto)');
 
-    let tokenResponse;
-    try {
-      tokenResponse = await Notifications.getExpoPushTokenAsync(
-        projectId ? { projectId } : undefined,
-      );
-    } catch (tokenError: any) {
-      const msg = tokenError?.message || String(tokenError);
-      console.error('❌ [PASO 3] getExpoPushTokenAsync FALLÓ:', msg);
-      logToFirebase({ paso: 3, resultado: 'TOKEN_ERROR', error: msg, projectId: projectId || '(auto)' });
-      throw tokenError;
-    }
+    const tokenResponse = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined,
+    );
 
     const token = tokenResponse.data;
     if (!token) {
-      console.error('❌ [PASO 3] token vacío');
-      logToFirebase({ paso: 3, resultado: 'TOKEN_VACIO' });
       return;
     }
-    console.log('✅ [PASO 3] Token:', token.substring(0, 40) + '...');
 
     // 4. Cachear
     await cachePushToken(token);
-    console.log('✅ [PASO 4] Token cacheado');
 
     // 5. Guardar en Firebase
-    console.log('📋 [PASO 5] Guardando en Firebase...');
     await saveTokenToFirebase(token);
-    console.log('✅ [PASO 5] Token guardado en Firebase');
-    logToFirebase({ paso: 5, resultado: 'EXITO', token: token.substring(0, 30) + '...' });
 
-  } catch (error: any) {
-    const msg = error?.message || String(error);
-    console.error('❌ Error en registerAndSaveToken:', msg);
-    logToFirebase({ resultado: 'ERROR_GENERAL', error: msg });
-  }
+  } catch {}
 }
 
 


### PR DESCRIPTION
Removed all debugging console logs and the `logToFirebase` diagnostic utility from the push notifications hook (`mcm-app/notifications/usePushNotifications.ts`). Cleaned up the resulting unused imports and simplified some error-handling logic that became redundant after the removals. Verified that the code remains syntactically correct.

---
*PR created automatically by Jules for task [719145873826438582](https://jules.google.com/task/719145873826438582) started by @mcmespana*