### PR TITLE
Fix: Notification read status and 60-day rule

### DIFF
--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -34,6 +34,7 @@ import {
   getReadNotificationIds,
   markAllNotificationsAsRead,
   initializeNewUserReadStatus,
+  isNotificationOlderThan60Days,
 } from '@/services/pushNotificationService';
 import { NotificationData, ReceivedNotification } from '@/types/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
@@ -119,7 +120,13 @@ export default function NotificationsScreen() {
 
   const handleMarkAllAsRead = async () => {
     const unreadIds = allNotifications
-      .filter((n) => !readIds.has(n.id) && !('isRead' in n && n.isRead))
+      .filter((n) => {
+        if (readIds.has(n.id)) return false;
+        if ('isRead' in n && n.isRead) return false;
+        const dateStr = 'receivedAt' in n ? n.receivedAt : n.createdAt;
+        if (isNotificationOlderThan60Days(dateStr)) return false;
+        return true;
+      })
       .map((n) => n.id);
     if (unreadIds.length === 0) return;
     await markAllNotificationsAsRead(unreadIds);
@@ -129,9 +136,11 @@ export default function NotificationsScreen() {
 
   const handleNotificationPress = useCallback(
     async (notification: NotificationData | ReceivedNotification) => {
+      const dateStr = 'receivedAt' in notification ? notification.receivedAt : notification.createdAt;
       const isRead =
         readIds.has(notification.id) ||
-        ('isRead' in notification && notification.isRead);
+        ('isRead' in notification && notification.isRead) ||
+        isNotificationOlderThan60Days(dateStr);
       if (!isRead) {
         await handleMarkAsRead(notification.id);
       }
@@ -147,9 +156,11 @@ export default function NotificationsScreen() {
     ) => {
       // Prevenir que el tap llegue al card padre
       if (e?.stopPropagation) e.stopPropagation();
+      const dateStr = 'receivedAt' in notification ? notification.receivedAt : notification.createdAt;
       const isRead =
         readIds.has(notification.id) ||
-        ('isRead' in notification && notification.isRead);
+        ('isRead' in notification && notification.isRead) ||
+        isNotificationOlderThan60Days(dateStr);
       if (!isRead) {
         handleMarkAsRead(notification.id).catch((err) =>
           console.error('Error marcando como leída:', err),
@@ -204,9 +215,11 @@ export default function NotificationsScreen() {
   }: {
     item: NotificationData | ReceivedNotification;
   }) => {
+    const dateStr = 'receivedAt' in notification ? notification.receivedAt : notification.createdAt;
     const isRead =
       readIds.has(notification.id) ||
-      ('isRead' in notification && notification.isRead);
+      ('isRead' in notification && notification.isRead) ||
+      isNotificationOlderThan60Days(dateStr);
     const isUnread = !isRead;
     const date = new Date(
       'receivedAt' in notification
@@ -341,9 +354,13 @@ export default function NotificationsScreen() {
     });
   }, [localNotifications, firebaseNotifications]);
 
-  const hasUnread = allNotifications.some(
-    (n) => !readIds.has(n.id) && !('isRead' in n && n.isRead),
-  );
+  const hasUnread = allNotifications.some((n) => {
+    if (readIds.has(n.id)) return false;
+    if ('isRead' in n && n.isRead) return false;
+    const dateStr = 'receivedAt' in n ? n.receivedAt : n.createdAt;
+    if (isNotificationOlderThan60Days(dateStr)) return false;
+    return true;
+  });
 
   return (
     <SafeAreaView

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -35,6 +35,7 @@ import {
   getReadNotificationIds,
   markAllNotificationsAsRead,
   initializeNewUserReadStatus,
+  isNotificationOlderThan60Days,
 } from '@/services/pushNotificationService';
 import { NotificationData, ReceivedNotification } from '@/types/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
@@ -226,9 +227,13 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
       return i === self.findIndex((x) => x.id === n.id);
     });
 
-  const hasUnread = allNotifications.some(
-    (n) => !readIds.has(n.id) && !('isRead' in n && n.isRead),
-  );
+  const hasUnread = allNotifications.some((n) => {
+    if (readIds.has(n.id)) return false;
+    if ('isRead' in n && n.isRead) return false;
+    const dateStr = 'receivedAt' in n ? n.receivedAt : n.createdAt;
+    if (isNotificationOlderThan60Days(dateStr)) return false;
+    return true;
+  });
 
   const handleMarkAsRead = useCallback(
     async (id: string) => {
@@ -241,7 +246,13 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
 
   const handleMarkAllAsRead = async () => {
     const unreadIds = allNotifications
-      .filter((n) => !readIds.has(n.id) && !('isRead' in n && n.isRead))
+      .filter((n) => {
+        if (readIds.has(n.id)) return false;
+        if ('isRead' in n && n.isRead) return false;
+        const dateStr = 'receivedAt' in n ? n.receivedAt : n.createdAt;
+        if (isNotificationOlderThan60Days(dateStr)) return false;
+        return true;
+      })
       .map((n) => n.id);
     if (!unreadIds.length) return;
     await markAllNotificationsAsRead(unreadIds);
@@ -306,9 +317,11 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
   }: {
     item: NotificationData | ReceivedNotification;
   }) => {
+    const dateStr = 'receivedAt' in notification ? notification.receivedAt : notification.createdAt;
     const isRead =
       readIds.has(notification.id) ||
-      ('isRead' in notification && notification.isRead);
+      ('isRead' in notification && notification.isRead) ||
+      isNotificationOlderThan60Days(dateStr);
     const isUnread = !isRead;
     const date = new Date(
       'receivedAt' in notification ? notification.receivedAt : notification.createdAt,

--- a/mcm-app/services/pushNotificationService.ts
+++ b/mcm-app/services/pushNotificationService.ts
@@ -417,6 +417,19 @@ export const markAllNotificationsAsRead = async (
  * Cuenta las notificaciones sin leer
  * Combina notificaciones locales y de Firebase
  */
+
+/**
+ * Verifica si una notificación tiene más de 60 días
+ */
+export const isNotificationOlderThan60Days = (dateStr?: string): boolean => {
+  if (!dateStr) return false;
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffTime = now.getTime() - date.getTime();
+  const diffDays = diffTime / (1000 * 60 * 60 * 24);
+  return diffDays > 60;
+};
+
 export const getUnreadNotificationsCount = async (): Promise<number> => {
   try {
     const readIds = await getReadNotificationIds();
@@ -424,13 +437,13 @@ export const getUnreadNotificationsCount = async (): Promise<number> => {
     // Contar notificaciones locales sin leer
     const localNotifications = await getLocalNotificationsHistory();
     const unreadLocal = localNotifications.filter(
-      (n) => !readIds.has(n.id) && !n.isRead,
+      (n) => !readIds.has(n.id) && !n.isRead && !isNotificationOlderThan60Days(n.receivedAt),
     );
 
     // Contar notificaciones de Firebase sin leer
     const firebaseNotifications = await getNotificationsHistory();
     const unreadFirebase = firebaseNotifications.filter(
-      (n) => !readIds.has(n.id),
+      (n) => !readIds.has(n.id) && !isNotificationOlderThan60Days(n.createdAt),
     );
 
     // Eliminar duplicados por ID y contar


### PR DESCRIPTION
Fixes multiple issues related to marking notifications as read:
1. Notifications older than 60 days are now automatically considered read.
2. Unread counts in the context correctly exclude notifications older than 60 days.
3. The Mark All As Read button excludes these implicitly read old notifications.
4. Correctly addresses bottom sheet and inline notification tap interaction to reflect the read status properly across the board.

---
*PR created automatically by Jules for task [9105187760184242862](https://jules.google.com/task/9105187760184242862) started by @mcmespana*