### PR TITLE
⚡ Bolt: Optimize SelectedSongsScreen rendering and memory

### DIFF
--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -122,7 +122,7 @@ export default function Home() {
   // Notifications
   const { firebaseNotifications, readIds, unreadCount } = useNotifications();
   const latestNotification = firebaseNotifications[0] ?? null;
-  
+
   const [isUnread, setIsUnread] = useState(false);
 
   useEffect(() => {
@@ -134,7 +134,10 @@ export default function Home() {
       setIsUnread(false);
       return;
     }
-    const dateStr = 'receivedAt' in latestNotification ? latestNotification.receivedAt : latestNotification.createdAt;
+    const dateStr =
+      'receivedAt' in latestNotification
+        ? latestNotification.receivedAt
+        : latestNotification.createdAt;
     if (isNotificationOlderThan60Days(dateStr)) {
       setIsUnread(false);
       return;

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -68,54 +68,35 @@ const SelectedSongsScreen: React.FC = () => {
   const { data: allSongsData, loading } = useFirebaseData<
     Record<string, { categoryTitle: string; songs: Song[] }>
   >('songs', 'songs');
-  const [categorizedSelectedSongs, setCategorizedSelectedSongs] = useState<
-    CategorizedSongs[]
-  >([]);
   const { toast } = useToast();
   const [showExportModal, setShowExportModal] = useState(false);
   const [exportFileName, setExportFileName] = useState('');
 
-  useEffect(() => {
-    const processSongs = () => {
-      if (!selectedSongs || selectedSongs.length === 0) {
-        setCategorizedSelectedSongs([]);
-        return;
+  const categorizedSelectedSongs = useMemo(() => {
+    if (!selectedSongs || selectedSongs.length === 0 || !allSongsData) {
+      return [];
+    }
+
+    // ⚡ Bolt: Use a Set for O(1) lookups inside the filter loop instead of O(N) array includes
+    const selectedSet = new Set(selectedSongs);
+    const categories: CategorizedSongs[] = [];
+
+    for (const categoryName in allSongsData) {
+      const category = allSongsData[categoryName];
+      const songsInCategory = category.songs;
+      const selectedInCategory = songsInCategory.filter((song) =>
+        selectedSet.has(song.filename),
+      );
+
+      if (selectedInCategory.length > 0) {
+        categories.push({
+          categoryTitle: category.categoryTitle,
+          data: selectedInCategory,
+        });
       }
-
-      if (!allSongsData) {
-        setCategorizedSelectedSongs([]);
-        return;
-      }
-
-      const categories: CategorizedSongs[] = [];
-      for (const categoryName in allSongsData) {
-        const songsInCategory = (
-          allSongsData as Record<
-            string,
-            { categoryTitle: string; songs: Song[] }
-          >
-        )[categoryName].songs;
-        const selectedInCategory = songsInCategory.filter((song) =>
-          selectedSongs.includes(song.filename),
-        );
-
-        if (selectedInCategory.length > 0) {
-          categories.push({
-            categoryTitle: (
-              allSongsData as Record<
-                string,
-                { categoryTitle: string; songs: Song[] }
-              >
-            )[categoryName].categoryTitle,
-            data: selectedInCategory,
-          });
-        }
-      }
-      categories.sort((a, b) => a.categoryTitle.localeCompare(b.categoryTitle));
-      setCategorizedSelectedSongs(categories);
-    };
-
-    processSongs();
+    }
+    categories.sort((a, b) => a.categoryTitle.localeCompare(b.categoryTitle));
+    return categories;
   }, [selectedSongs, allSongsData]);
 
   const handleExport = useCallback(() => {
@@ -144,30 +125,30 @@ const SelectedSongsScreen: React.FC = () => {
       const categoryLetter = category.categoryTitle.charAt(0).toUpperCase();
 
       category.data.forEach((song) => {
-        if (selectedSongs.includes(song.filename)) {
-          const songTitleClean = song.title.replace(/^\d+\.\s*/, '');
+        // ⚡ Bolt: Removed redundant `selectedSongs.includes` check
+        // because `categorizedSelectedSongs` is already fully filtered
+        const songTitleClean = song.title.replace(/^\d+\.\s*/, '');
 
-          let chordCapoString = '';
-          if (song.key) {
-            chordCapoString = `\`${song.key}\``;
-            if (song.capo && song.capo > 0) {
-              chordCapoString += ` \`C/${song.capo}\``;
-            }
+        let chordCapoString = '';
+        if (song.key) {
+          chordCapoString = `\`${song.key}\``;
+          if (song.capo && song.capo > 0) {
+            chordCapoString += ` \`C/${song.capo}\``;
           }
-
-          const songIdMatch = song.title.match(/^\d+/);
-          const songId = songIdMatch ? songIdMatch[0] : '??';
-
-          let line = `*${categoryLetter}.* ${songTitleClean}`;
-          if (chordCapoString) {
-            line += ` · ${chordCapoString}`;
-          }
-          line += ` · *[#${songId}]*`;
-          if (song.author) {
-            line += ` · ${song.author}`;
-          }
-          formattedSongLines.push(line);
         }
+
+        const songIdMatch = song.title.match(/^\d+/);
+        const songId = songIdMatch ? songIdMatch[0] : '??';
+
+        let line = `*${categoryLetter}.* ${songTitleClean}`;
+        if (chordCapoString) {
+          line += ` · ${chordCapoString}`;
+        }
+        line += ` · *[#${songId}]*`;
+        if (song.author) {
+          line += ` · ${song.author}`;
+        }
+        formattedSongLines.push(line);
       });
     });
 
@@ -336,8 +317,17 @@ const SelectedSongsScreen: React.FC = () => {
     if (!allSongsData) return;
 
     let completeSong: Song | undefined;
-    for (const cat of Object.values(allSongsData)) {
-      completeSong = cat.songs.find((s) => s.filename === song.filename);
+
+    // ⚡ Bolt: Replaced Object.values(...).find() with a fast nested loop
+    // to avoid allocating intermediate arrays and closure functions
+    for (const categoryName in allSongsData) {
+      const categorySongs = allSongsData[categoryName].songs;
+      for (let i = 0; i < categorySongs.length; i++) {
+        if (categorySongs[i].filename === song.filename) {
+          completeSong = categorySongs[i];
+          break;
+        }
+      }
       if (completeSong) break;
     }
 

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -276,7 +276,8 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
 
   const handleNotificationPress = useCallback(
     async (notification: NotificationData | ReceivedNotification) => {
-      if (!isNotificationRead(notification)) await handleMarkAsRead(notification.id);
+      if (!isNotificationRead(notification))
+        await handleMarkAsRead(notification.id);
       setSelectedNotification(notification);
     },
     [isNotificationRead, handleMarkAsRead],

--- a/mcm-app/hooks/useContigoHabits.ts
+++ b/mcm-app/hooks/useContigoHabits.ts
@@ -85,7 +85,7 @@ export function useContigoHabits() {
     date: string,
     duration: PrayerDuration,
     emotion: Emotion,
-    durationMinutes?: number
+    durationMinutes?: number,
   ) => {
     const record = ensureRecord(date);
     const newRecords = {

--- a/mcm-app/hooks/useDailyReadings.ts
+++ b/mcm-app/hooks/useDailyReadings.ts
@@ -89,12 +89,14 @@ export function useDailyReadings(dateStr: string) {
           // activoComentario → fuente del comentario (vaticanNews +1..+14, vidaNueva hoy)
           if (data.evangelio) {
             const activoTexto = data.evangelio.activoTexto || 'vidaNueva';
-            const activoComentario = data.evangelio.activoComentario || 'vidaNueva';
+            const activoComentario =
+              data.evangelio.activoComentario || 'vidaNueva';
             parsedReadings.evangelio = {
               texto: data.evangelio[`${activoTexto}EvangelioTexto`] || '',
               cita: data.evangelio[`${activoTexto}Cita`] || '',
               comentario: data.evangelio[`${activoComentario}Comentario`] || '',
-              comentarista: data.evangelio[`${activoComentario}Comentarista`] || '',
+              comentarista:
+                data.evangelio[`${activoComentario}Comentarista`] || '',
               url: data.evangelio[`${activoTexto}URL`] || '',
             };
           }

--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -35,7 +35,9 @@ import { router } from 'expo-router';
  * es un UUID aleatorio por cada entrega, lo que causaba que la
  * deduplicación fallara y aparecieran duplicados.
  */
-function getStableNotificationId(content: Notifications.NotificationContent): string {
+function getStableNotificationId(
+  content: Notifications.NotificationContent,
+): string {
   // 1. ID explícito del backend — siempre preferido
   if (content.data?.id && typeof content.data.id === 'string') {
     return content.data.id;
@@ -47,7 +49,7 @@ function getStableNotificationId(content: Notifications.NotificationContent): st
   let hash = 0;
   for (let i = 0; i < raw.length; i++) {
     const char = raw.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash |= 0; // Convert to 32-bit integer
   }
   return `local_${Math.abs(hash).toString(36)}`;
@@ -82,7 +84,9 @@ export default function usePushNotifications() {
     // Listener para notificaciones recibidas (app en foreground)
     notificationListener.current =
       Notifications.addNotificationReceivedListener((notification) => {
-        const notificationId = getStableNotificationId(notification.request.content);
+        const notificationId = getStableNotificationId(
+          notification.request.content,
+        );
         const receivedNotification: ReceivedNotification = {
           id: notificationId,
           title: notification.request.content.title || 'Notificación',
@@ -137,7 +141,9 @@ export default function usePushNotifications() {
         }
 
         // Guardar y marcar como leída
-        const notificationId = getStableNotificationId(response.notification.request.content);
+        const notificationId = getStableNotificationId(
+          response.notification.request.content,
+        );
         const receivedNotification: ReceivedNotification = {
           id: notificationId,
           title: response.notification.request.content.title || 'Notificación',

--- a/mcm-app/services/pushNotificationService.ts
+++ b/mcm-app/services/pushNotificationService.ts
@@ -416,7 +416,8 @@ export const markAllNotificationsAsRead = async (
       const updated = notifications.map((n) => {
         if (idsSet.has(n.id)) return { ...n, isRead: true };
         // También marcar por contenido idéntico
-        if (contentKeys.has(`${n.title}|${n.body}`)) return { ...n, isRead: true };
+        if (contentKeys.has(`${n.title}|${n.body}`))
+          return { ...n, isRead: true };
         return n;
       });
       await AsyncStorage.setItem(
@@ -464,11 +465,13 @@ export const getUnreadNotificationsCount = async (): Promise<number> => {
     const firebaseNotifications = await getNotificationsHistory();
 
     // Combinar, priorizando locales
-    const combined = [...localNotifications, ...firebaseNotifications].sort((a, b) => {
-      const dateA = new Date('receivedAt' in a ? a.receivedAt : a.createdAt);
-      const dateB = new Date('receivedAt' in b ? b.receivedAt : b.createdAt);
-      return dateB.getTime() - dateA.getTime();
-    });
+    const combined = [...localNotifications, ...firebaseNotifications].sort(
+      (a, b) => {
+        const dateA = new Date('receivedAt' in a ? a.receivedAt : a.createdAt);
+        const dateB = new Date('receivedAt' in b ? b.receivedAt : b.createdAt);
+        return dateB.getTime() - dateA.getTime();
+      },
+    );
 
     // Deduplicar
     const seenContentKeys = new Set<string>();
@@ -490,7 +493,7 @@ export const getUnreadNotificationsCount = async (): Promise<number> => {
       return false;
     };
 
-    return deduplicated.filter(n => !isNotificationRead(n)).length;
+    return deduplicated.filter((n) => !isNotificationRead(n)).length;
   } catch (error) {
     console.error('Error contando notificaciones sin leer:', error);
     return 0;


### PR DESCRIPTION
💡 What: 
- Replaced a `useState` + `useEffect` combo with `useMemo` for derived `categorizedSelectedSongs` state.
- Upgraded an `Array.includes` O(N) lookup to a `Set.has` O(1) lookup inside the categorization filter loop.
- Removed a redundant `selectedSongs.includes` filter in the `handleExport` method.
- Replaced `Object.values(allSongsData).find()` with a fast native nested `for...in`/`for` loop in `handleSongPress`.

🎯 Why: 
The previous setup caused an unnecessary re-render every time `selectedSongs` changed, and filtering relied on slower O(N) lookups. Additionally, `Object.values().find()` allocates intermediate arrays and closures, which adds memory pressure and CPU cycles during interaction.

📊 Impact: 
- Halves the number of component re-renders when the selected songs list updates.
- Significantly improves time complexity of the list filter (from O(N*M) to O(N+M)), particularly visible with large lists.
- Avoids garbage collection stutters when pressing a song by using zero-allocation nested loops.

🔬 Measurement: 
To verify, open `SelectedSongsScreen`, load a large number of songs, and observe that UI interactions and exports are noticeably smoother and do not trigger duplicate render cycles. Test suite and linter have passed.

---
*PR created automatically by Jules for task [4477167586678035691](https://jules.google.com/task/4477167586678035691) started by @mcmespana*