### PR TITLE
⚡ Bolt: Optimize SelectedSongsContext for large lists

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 **Action:** Use `useMemo` to memoize the result of computationally expensive array operations (like filtering or sorting) so they only run when their dependencies (e.g., search term or the original array) change. Also, move invariant logic (like `search.toLowerCase()`) outside of the filter loop.
 ## Array Performance
 - Avoid using `Object.values().flatMap().find()` for simple lookups, as it allocates numerous intermediate arrays and closure functions. Instead, use nested `for...in` and `for` loops which provide significant performance gains.
+## 2024-04-24 - Unmemoized React Context & O(N) derived lookups in large list renderers
+**Learning:** Contexts that manage arrays (like selected items) and are heavily consumed by large list renderers can cause severe performance bottlenecks if not optimized. If the context value is not memoized, any state change re-renders all consumers. More importantly, checking if an item is selected inside list items using `array.includes()` creates an O(N) operation per item, which scales poorly when rendering many components.
+**Action:** Always memoize context values with `useMemo`, wrap provider functions with `useCallback`, and convert array states to a memoized `Set` inside the provider to expose an O(1) lookup method (e.g., `isItemSelected`) for consumers, especially those in FlatLists.

--- a/mcm-app/contexts/SelectedSongsContext.tsx
+++ b/mcm-app/contexts/SelectedSongsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode } from 'react';
+import React, { createContext, useState, useContext, ReactNode, useMemo, useCallback } from 'react';
 
 // Define the shape of the context value
 interface SelectedSongsContextType {
@@ -25,39 +25,41 @@ export const SelectedSongsProvider: React.FC<SelectedSongsProviderProps> = ({
 }) => {
   const [selectedSongs, setSelectedSongs] = useState<string[]>([]);
 
-  const addSong = (filename: string) => {
+  const selectedSongsSet = useMemo(() => new Set(selectedSongs), [selectedSongs]);
+
+  const addSong = useCallback((filename: string) => {
     setSelectedSongs((prevSelectedSongs) => {
       if (!prevSelectedSongs.includes(filename)) {
         return [...prevSelectedSongs, filename];
       }
       return prevSelectedSongs;
     });
-  };
+  }, []);
 
-  const removeSong = (filename: string) => {
+  const removeSong = useCallback((filename: string) => {
     setSelectedSongs((prevSelectedSongs) =>
       prevSelectedSongs.filter((song) => song !== filename),
     );
-  };
+  }, []);
 
-  const isSongSelected = (filename: string): boolean => {
-    return selectedSongs.includes(filename);
-  };
+  const isSongSelected = useCallback((filename: string): boolean => {
+    return selectedSongsSet.has(filename);
+  }, [selectedSongsSet]);
 
-  const clearSelection = () => {
+  const clearSelection = useCallback(() => {
     setSelectedSongs([]);
-  };
+  }, []);
+
+  const contextValue = useMemo(() => ({
+    selectedSongs,
+    addSong,
+    removeSong,
+    isSongSelected,
+    clearSelection,
+  }), [selectedSongs, addSong, removeSong, isSongSelected, clearSelection]);
 
   return (
-    <SelectedSongsContext.Provider
-      value={{
-        selectedSongs,
-        addSong,
-        removeSong,
-        isSongSelected,
-        clearSelection,
-      }}
-    >
+    <SelectedSongsContext.Provider value={contextValue}>
       {children}
     </SelectedSongsContext.Provider>
   );


### PR DESCRIPTION
💡 **What:** 
Optimized `SelectedSongsContext` by converting the `selectedSongs` array to a `Set` within a `useMemo` for fast O(1) lookups in the `isSongSelected` function. Added `useMemo` for the context value and `useCallback` for the provider modifier functions to maintain stable references. Documented this finding in `.jules/bolt.md`.

🎯 **Why:** 
The `SelectedSongsContext` manages an array of song filenames and is consumed by components nested within large lists (like `SongListItem` in `SongListScreen`). Previously, every time `isSongSelected` was called in a list render, it executed `Array.includes()`, leading to an O(N) lookup. Across M list items, this resulted in an O(M * N) bottleneck. Additionally, because the provider value wasn't memoized, any state change re-rendered all consumers indiscriminately.

📊 **Impact:** 
- Reduces `isSongSelected` lookup complexity from O(N) to O(1).
- Prevents unnecessary re-renders for context consumers since the modifier functions and overall context value now retain stable references across renders unless the specific state dependencies change.

🔬 **Measurement:** 
- Compile the app or run tests. All existing behaviors involving selecting, unselecting, and listing songs remain functionally unchanged, but the time to execute `isSongSelected` inside list items is substantially reduced. Run `npm run test` and verify that the song and feature tests pass.

---
*PR created automatically by Jules for task [12985169643085982493](https://jules.google.com/task/12985169643085982493) started by @mcmespana*