### PR TITLE
⚡ Bolt: Use O(1) lookup in SelectedSongsScreen for song selection

### DIFF
--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -60,7 +60,7 @@ type SelectedSongsScreenNavigationProp = NativeStackNavigationProp<
 >;
 
 const SelectedSongsScreen: React.FC = () => {
-  const { selectedSongs, clearSelection, addSong } = useSelectedSongs();
+  const { selectedSongs, clearSelection, addSong, isSongSelected } = useSelectedSongs();
   const navigation = useNavigation<SelectedSongsScreenNavigationProp>();
   const scheme = useColorScheme() || 'light';
   const isDark = scheme === 'dark';
@@ -95,8 +95,11 @@ const SelectedSongsScreen: React.FC = () => {
             { categoryTitle: string; songs: Song[] }
           >
         )[categoryName].songs;
+        // ⚡ Bolt: Replace O(N*M) nested loop search (`selectedSongs.includes()`)
+        // with O(1) Set lookup (`isSongSelected()`) to significantly improve filtering
+        // performance when checking thousands of songs.
         const selectedInCategory = songsInCategory.filter((song) =>
-          selectedSongs.includes(song.filename),
+          isSongSelected(song.filename),
         );
 
         if (selectedInCategory.length > 0) {
@@ -116,7 +119,7 @@ const SelectedSongsScreen: React.FC = () => {
     };
 
     processSongs();
-  }, [selectedSongs, allSongsData]);
+  }, [selectedSongs, allSongsData, isSongSelected]);
 
   const handleExport = useCallback(() => {
     const date = new Date()
@@ -144,7 +147,8 @@ const SelectedSongsScreen: React.FC = () => {
       const categoryLetter = category.categoryTitle.charAt(0).toUpperCase();
 
       category.data.forEach((song) => {
-        if (selectedSongs.includes(song.filename)) {
+        // ⚡ Bolt: Use O(1) Set lookup instead of O(N) array search for export check
+        if (isSongSelected(song.filename)) {
           const songTitleClean = song.title.replace(/^\d+\.\s*/, '');
 
           let chordCapoString = '';


### PR DESCRIPTION
⚡ Bolt: Use O(1) lookup in SelectedSongsScreen for song selection

💡 What:
Replaced `selectedSongs.includes(song.filename)` with the `isSongSelected(song.filename)` context method in `SelectedSongsScreen.tsx`.

🎯 Why:
The `includes` array method requires O(N) traversal. Since this logic was placed inside `.filter` and `.forEach` loops iterating over large subsets of songs, it resulted in O(N*M) time complexity, leading to potential lag during song categorization and export processing. By using `isSongSelected`, which internally leverages an O(1) Set lookup pre-calculated by the context, the complexity is reduced to O(M).

📊 Impact:
Eliminates O(N*M) bottlenecks during `processSongs` rendering loop and the `handleExport` sequence, ensuring smooth interactions even when users have a large number of selected songs.

🔬 Measurement:
Can be verified by noting decreased rendering times in React Native Profiler when navigating to the SelectedSongs screen with many songs selected.

---
*PR created automatically by Jules for task [2725345478996177344](https://jules.google.com/task/2725345478996177344) started by @mcmespana*