### PR TITLE
⚡ Bolt: [performance improvement] Memoize renderItem and ListHeader in SongListScreen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-03 - [React Native Performance] FlatList virtualization props
 **Learning:** Default FlatList virtualization can result in rendering too many items upfront, delaying the initial render. Furthermore, passing an inline `renderItem` function causes new function references on every render, which can defeat `React.memo` on list items.
 **Action:** Always provide `initialNumToRender`, `maxToRenderPerBatch`, and `windowSize` props to FlatLists rendering complex items. Wrap the `renderItem` function in `useCallback` to preserve function references and ensure list items wrapped in `React.memo` actually benefit from memoization.
+
+## 2024-05-07 - [React Performance] Inline Component Definitions Anti-pattern
+**Learning:** Defining a functional component inside another component's scope (e.g., `const ListHeader = () => ...` inside `SongListScreen`) creates a new component type on every render. This forces React to completely unmount and remount the DOM subtree instead of simply updating it, destroying local state like input focus and harming performance, especially in `FlatList` headers.
+**Action:** Never define components inside other components. Either extract the component to the module scope and pass props, or, if it heavily relies on local state, simply render it as a memoized JSX element (`const listHeader = useMemo(() => <View>...</View>, [...])`) and pass that element directly (e.g., `ListHeaderComponent={listHeader}`).

--- a/mcm-app/app/(tabs)/contigo/evangelio.tsx
+++ b/mcm-app/app/(tabs)/contigo/evangelio.tsx
@@ -36,6 +36,8 @@ import BottomSheet from '@/components/BottomSheet';
 import { radii, shadows } from '@/constants/uiStyles';
 import { hexAlpha } from '@/utils/colorUtils';
 
+import { CelebrationAnimation } from '@/components/contigo/CelebrationAnimation';
+
 // ── Contigo warm palette (aligned with redesign tokens) ──
 const WARM = {
   light: {
@@ -94,8 +96,6 @@ function addDays(dateStr: string, offset: number): string {
   const nd = String(date.getDate()).padStart(2, '0');
   return `${ny}-${nm}-${nd}`;
 }
-
-import { CelebrationAnimation } from '@/components/contigo/CelebrationAnimation';
 
 export default function EvangelioScreen() {
   const scheme = useColorScheme();

--- a/mcm-app/app/screens/AppsScreen.tsx
+++ b/mcm-app/app/screens/AppsScreen.tsx
@@ -15,10 +15,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
-import {
-  getEventCacheKey,
-  getEventFirebasePath,
-} from '@/constants/events';
+import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 
 interface AppInfo {

--- a/mcm-app/app/screens/ComunicaGestionScreen.tsx
+++ b/mcm-app/app/screens/ComunicaGestionScreen.tsx
@@ -19,7 +19,7 @@ import { Colors as ThemeColors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 // CSS module reutilizado del iframe (solo aplica en web)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+
 const iframeStyles =
   Platform.OS === 'web' ? require('../../styles/comunica.module.css') : null;
 

--- a/mcm-app/app/screens/ComunicaScreen.tsx
+++ b/mcm-app/app/screens/ComunicaScreen.tsx
@@ -18,7 +18,7 @@ import { Colors as ThemeColors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 // CSS module reutilizado del iframe (solo aplica en web)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+
 const iframeStyles =
   Platform.OS === 'web' ? require('../../styles/comunica.module.css') : null;
 

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -21,10 +21,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
-import {
-  getEventCacheKey,
-  getEventFirebasePath,
-} from '@/constants/events';
+import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
 
 type MaterialIconName = React.ComponentProps<typeof MaterialIcons>['name'];
 

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -8,10 +8,7 @@ import spacing from '@/constants/spacing';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
-import {
-  getEventCacheKey,
-  getEventFirebasePath,
-} from '@/constants/events';
+import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
 import DateSelector from '@/components/DateSelector';
 import EventItem, { EventItemData } from '@/components/EventItem';
 import { ThemedText } from '@/components/ThemedText';

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -15,10 +15,7 @@ import useFontScale from '@/hooks/useFontScale';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
-import {
-  getEventCacheKey,
-  getEventFirebasePath,
-} from '@/constants/events';
+import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
 
 interface Pagina {
   titulo: string;

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -160,8 +160,11 @@ export default function SongsListScreen({
                 }
                 // ⚡ Bolt: Pre-calculate the clean title for sorting (Schwartzian transform)
                 // This prevents running the regex multiple times per item during the O(N log N) sort phase.
-                const sortTitle = song.title.replace(/^\d+\.\s*/, '').toLowerCase();
-                const searchableText = `${song.title || ''} ${song.author || ''}`.toLowerCase();
+                const sortTitle = song.title
+                  .replace(/^\d+\.\s*/, '')
+                  .toLowerCase();
+                const searchableText =
+                  `${song.title || ''} ${song.author || ''}`.toLowerCase();
                 return {
                   ...song,
                   originalCategoryKey: categoryLetter,
@@ -200,8 +203,13 @@ export default function SongsListScreen({
                     numericPart = filenameMatch[1].padStart(2, '0');
                   }
                 }
-                const searchableText = `${song.title || ''} ${song.author || ''}`.toLowerCase();
-                return { ...song, numericFilenamePart: numericPart, searchableText };
+                const searchableText =
+                  `${song.title || ''} ${song.author || ''}`.toLowerCase();
+                return {
+                  ...song,
+                  numericFilenamePart: numericPart,
+                  searchableText,
+                };
               });
               songsWithNumericPart.sort((a, b) => {
                 const numA = parseInt(a.numericFilenamePart, 10) || Infinity;
@@ -262,6 +270,51 @@ export default function SongsListScreen({
     [songs, categoryId, navigation],
   );
 
+  // ListHeaderComponent: search bar + song count
+  // Goes inside the FlatList so it scrolls with content on iOS
+  // (avoids getting hidden behind transparent header)
+  const listHeader = useMemo(
+    () => (
+      <View>
+        {searchVisible && (
+          <View style={styles.searchContainer}>
+            <SearchField value={search} onChange={setSearch}>
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input
+                  placeholder="Título, autor..."
+                  autoFocus={!isSearchAll}
+                  returnKeyType="search"
+                />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+          </View>
+        )}
+        {/* Conteo de canciones — siempre visible, muy sutil */}
+        <View style={styles.countRow}>
+          <Text style={styles.songCount}>
+            {filteredSongs.length}{' '}
+            {filteredSongs.length === 1 ? 'canción' : 'canciones'}
+            {search.length > 0 ? ' encontradas' : ''}
+          </Text>
+        </View>
+      </View>
+    ),
+    [searchVisible, search, isSearchAll, filteredSongs.length, styles],
+  );
+
+  const renderSongItem = useCallback(
+    ({ item }: { item: Song }) => (
+      <SongListItem
+        song={item}
+        onPress={handleSongPress}
+        isSearchAllMode={isSearchAll}
+      />
+    ),
+    [handleSongPress, isSearchAll],
+  );
+
   if ((isLoading || loadingSongs) && songs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -278,40 +331,6 @@ export default function SongsListScreen({
     );
   }
 
-  // ListHeaderComponent: search bar + song count
-  // Goes inside the FlatList so it scrolls with content on iOS
-  // (avoids getting hidden behind transparent header)
-  const ListHeader = () => (
-    <View>
-      {searchVisible && (
-        <View style={styles.searchContainer}>
-          <SearchField
-            value={search}
-            onChange={setSearch}
-          >
-            <SearchField.Group>
-              <SearchField.SearchIcon />
-              <SearchField.Input
-                placeholder="Título, autor..."
-                autoFocus={!isSearchAll}
-                returnKeyType="search"
-              />
-              <SearchField.ClearButton />
-            </SearchField.Group>
-          </SearchField>
-        </View>
-      )}
-      {/* Conteo de canciones — siempre visible, muy sutil */}
-      <View style={styles.countRow}>
-        <Text style={styles.songCount}>
-          {filteredSongs.length}{' '}
-          {filteredSongs.length === 1 ? 'canción' : 'canciones'}
-          {search.length > 0 ? ' encontradas' : ''}
-        </Text>
-      </View>
-    </View>
-  );
-
   return (
     <View style={styles.container}>
       <FlatList
@@ -320,14 +339,8 @@ export default function SongsListScreen({
         initialNumToRender={15}
         maxToRenderPerBatch={20}
         windowSize={5}
-        renderItem={({ item }) => (
-          <SongListItem
-            song={item}
-            onPress={handleSongPress}
-            isSearchAllMode={isSearchAll}
-          />
-        )}
-        ListHeaderComponent={<ListHeader />}
+        renderItem={renderSongItem}
+        ListHeaderComponent={listHeader}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -276,7 +276,8 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
 
   const handleNotificationPress = useCallback(
     async (notification: NotificationData | ReceivedNotification) => {
-      if (!isNotificationRead(notification)) await handleMarkAsRead(notification.id);
+      if (!isNotificationRead(notification))
+        await handleMarkAsRead(notification.id);
       setSelectedNotification(notification);
     },
     [isNotificationRead, handleMarkAsRead],

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -425,8 +425,7 @@ const styles = StyleSheet.create({
         width: 54,
         height: 54,
         borderRadius: 27,
-        boxShadow:
-          '0 3px 16px rgba(0,0,0,0.18), 0 1px 4px rgba(0,0,0,0.08)',
+        boxShadow: '0 3px 16px rgba(0,0,0,0.18), 0 1px 4px rgba(0,0,0,0.08)',
         cursor: 'pointer',
       },
       default: {

--- a/mcm-app/components/contigo/ReadingCard.tsx
+++ b/mcm-app/components/contigo/ReadingCard.tsx
@@ -9,8 +9,6 @@ import { hexAlpha } from '@/utils/colorUtils';
 
 import useFontScale from '@/hooks/useFontScale';
 
-
-
 interface ReadingCardProps {
   title: string;
   cita: string;


### PR DESCRIPTION
**What:**
- Converted `renderItem` inline arrow function to a `useCallback` hook named `renderSongItem`.
- Refactored `ListHeader` from an inline component definition (which gets re-created on every render) into a `useMemo` hook that directly returns the JSX elements.

**Why:**
- The `FlatList` in `SongListScreen` was receiving a new function reference for `renderItem` on every render, defeating the `React.memo` optimization of `SongListItem`.
- `ListHeaderComponent` was receiving an inline component defined within the render scope. This causes React to completely unmount and remount the header element (and the SearchField inside it) on every render, leading to potential focus loss and performance degradation on keystrokes.

**Impact:**
- Significantly reduces unnecessary re-renders of list items during filtering.
- Prevents DOM destruction/re-creation of the search header, improving responsiveness when typing.

**Measurement:**
- Verify by using the search bar in the song list; keystrokes should feel more responsive and the component should not lose focus.

---
*PR created automatically by Jules for task [130743776633400198](https://jules.google.com/task/130743776633400198) started by @mcmespana*