### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-03 - [React Native Performance] FlatList virtualization props
 **Learning:** Default FlatList virtualization can result in rendering too many items upfront, delaying the initial render. Furthermore, passing an inline `renderItem` function causes new function references on every render, which can defeat `React.memo` on list items.
 **Action:** Always provide `initialNumToRender`, `maxToRenderPerBatch`, and `windowSize` props to FlatLists rendering complex items. Wrap the `renderItem` function in `useCallback` to preserve function references and ensure list items wrapped in `React.memo` actually benefit from memoization.
+## 2024-05-14 - [React Native FlatList Headers Optimization]
+**Learning:** Defining inline functional components (e.g., `const ListHeader = () => ...`) inside a parent screen component forces React to treat the component as a totally new component type on each render. When passed to a FlatList as a `ListHeaderComponent`, this leads to expensive unmount/remount cycles.
+**Action:** Always extract ListHeader/ListFooter components into static definitions outside the parent component, or use `useMemo` to return the raw JSX element to prevent full DOM trashing.

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -394,24 +394,27 @@ const SelectedSongsScreen: React.FC = () => {
     [allSongsData, allSongsMap, songIndexMap, flatSelectedSongs, navigation],
   );
 
-  const renderCategory = ({ item }: { item: CategorizedSongs }) => (
-    <View style={styles.categoryContainer}>
-      <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
-      {item.data
-        .filter(
-          (song): song is Song & { filename: string } =>
-            song &&
-            typeof song.filename === 'string' &&
-            song.filename.length > 0,
-        )
-        .map((song) => (
-          <SongListItem
-            key={song.filename}
-            song={song}
-            onPress={handleSongPress}
-          />
-        ))}
-    </View>
+  const renderCategory = useCallback(
+    ({ item }: { item: CategorizedSongs }) => (
+      <View style={styles.categoryContainer}>
+        <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
+        {item.data
+          .filter(
+            (song): song is Song & { filename: string } =>
+              song &&
+              typeof song.filename === 'string' &&
+              song.filename.length > 0,
+          )
+          .map((song) => (
+            <SongListItem
+              key={song.filename}
+              song={song}
+              onPress={handleSongPress}
+            />
+          ))}
+      </View>
+    ),
+    [styles, handleSongPress]
   );
 
   const headerIconColor =
@@ -496,6 +499,18 @@ const SelectedSongsScreen: React.FC = () => {
     headerIconColor,
   ]);
 
+  const listCountHeader = useMemo(
+    () => (
+      <View style={styles.countHeader}>
+        <Text style={styles.selectionCount}>
+          {selectedSongs.length}{' '}
+          {selectedSongs.length === 1 ? 'canción' : 'canciones'}
+        </Text>
+      </View>
+    ),
+    [selectedSongs.length, styles],
+  );
+
   if (loading && selectedSongs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -533,22 +548,13 @@ const SelectedSongsScreen: React.FC = () => {
     );
   }
 
-  const ListCountHeader = () => (
-    <View style={styles.countHeader}>
-      <Text style={styles.selectionCount}>
-        {selectedSongs.length}{' '}
-        {selectedSongs.length === 1 ? 'canción' : 'canciones'}
-      </Text>
-    </View>
-  );
-
   return (
     <View style={styles.container}>
       <FlatList
         data={categorizedSelectedSongs}
         renderItem={renderCategory}
         keyExtractor={(item) => item.categoryTitle}
-        ListHeaderComponent={<ListCountHeader />}
+        ListHeaderComponent={listCountHeader}
         contentContainerStyle={styles.listContentContainer}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -262,6 +262,54 @@ export default function SongsListScreen({
     [songs, categoryId, navigation],
   );
 
+  const renderItem = useCallback(
+    ({ item }: { item: Song }) => (
+      <SongListItem
+        song={item}
+        onPress={handleSongPress}
+        isSearchAllMode={isSearchAll}
+      />
+    ),
+    [handleSongPress, isSearchAll]
+  );
+
+  // ListHeaderComponent: search bar + song count
+  // Goes inside the FlatList so it scrolls with content on iOS
+  // (avoids getting hidden behind transparent header)
+  const listHeader = useMemo(
+    () => (
+      <View>
+        {searchVisible && (
+          <View style={styles.searchContainer}>
+            <SearchField
+              value={search}
+              onChange={setSearch}
+            >
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input
+                  placeholder="Título, autor..."
+                  autoFocus={!isSearchAll}
+                  returnKeyType="search"
+                />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+          </View>
+        )}
+        {/* Conteo de canciones — siempre visible, muy sutil */}
+        <View style={styles.countRow}>
+          <Text style={styles.songCount}>
+            {filteredSongs.length}{' '}
+            {filteredSongs.length === 1 ? 'canción' : 'canciones'}
+            {search.length > 0 ? ' encontradas' : ''}
+          </Text>
+        </View>
+      </View>
+    ),
+    [searchVisible, search, isSearchAll, filteredSongs.length, styles],
+  );
+
   if ((isLoading || loadingSongs) && songs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -278,40 +326,6 @@ export default function SongsListScreen({
     );
   }
 
-  // ListHeaderComponent: search bar + song count
-  // Goes inside the FlatList so it scrolls with content on iOS
-  // (avoids getting hidden behind transparent header)
-  const ListHeader = () => (
-    <View>
-      {searchVisible && (
-        <View style={styles.searchContainer}>
-          <SearchField
-            value={search}
-            onChange={setSearch}
-          >
-            <SearchField.Group>
-              <SearchField.SearchIcon />
-              <SearchField.Input
-                placeholder="Título, autor..."
-                autoFocus={!isSearchAll}
-                returnKeyType="search"
-              />
-              <SearchField.ClearButton />
-            </SearchField.Group>
-          </SearchField>
-        </View>
-      )}
-      {/* Conteo de canciones — siempre visible, muy sutil */}
-      <View style={styles.countRow}>
-        <Text style={styles.songCount}>
-          {filteredSongs.length}{' '}
-          {filteredSongs.length === 1 ? 'canción' : 'canciones'}
-          {search.length > 0 ? ' encontradas' : ''}
-        </Text>
-      </View>
-    </View>
-  );
-
   return (
     <View style={styles.container}>
       <FlatList
@@ -320,14 +334,8 @@ export default function SongsListScreen({
         initialNumToRender={15}
         maxToRenderPerBatch={20}
         windowSize={5}
-        renderItem={({ item }) => (
-          <SongListItem
-            song={item}
-            onPress={handleSongPress}
-            isSearchAllMode={isSearchAll}
-          />
-        )}
-        ListHeaderComponent={<ListHeader />}
+        renderItem={renderItem}
+        ListHeaderComponent={listHeader}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
💡 What: Memoized `ListHeader` and `ListCountHeader` as `useMemo` hooks returning JSX directly, and wrapped `renderItem` and `renderCategory` with `useCallback` inside `SongListScreen` and `SelectedSongsScreen`.
🎯 Why: Defining a functional component inline within a parent component triggers a full unmount and remount cycle on every render, severely hindering performance for large lists inside a React Native `FlatList`. Additionally, inline `renderItem` methods break `React.memo` logic.
📊 Impact: This fix reduces `FlatList` component trashing, prevents state destruction in headers, and significantly lowers unnecessary item re-renders across two core screens.
🔬 Measurement: Verify rendering speed via native profiling tools during song list navigation, or by logging component mount/unmount counts.

---
*PR created automatically by Jules for task [13477527169667318492](https://jules.google.com/task/13477527169667318492) started by @mcmespana*