### PR TITLE
⚡ Bolt: Fix inner component anti-pattern causing input focus loss and render jank

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-03 - [React Native Performance] FlatList virtualization props
 **Learning:** Default FlatList virtualization can result in rendering too many items upfront, delaying the initial render. Furthermore, passing an inline `renderItem` function causes new function references on every render, which can defeat `React.memo` on list items.
 **Action:** Always provide `initialNumToRender`, `maxToRenderPerBatch`, and `windowSize` props to FlatLists rendering complex items. Wrap the `renderItem` function in `useCallback` to preserve function references and ensure list items wrapped in `React.memo` actually benefit from memoization.
+
+## 2024-05-13 - [React Performance] Inner component anti-pattern
+**Learning:** Defining React functional components inside other component render scopes (e.g., `const ListHeader = () => <View>...</View>`) forces React to see the inner component as a completely new type on every render. This causes React to completely unmount and remount the element rather than reconciling it, destroying local state (such as input focus) and causing significant re-render performance jank.
+**Action:** When a piece of UI needs to be rendered dynamically but relies on closure variables, instead of creating an inner component, use `useMemo` to memoize the returned JSX element (e.g., `const listHeaderElement = useMemo(() => <View>...</View>, [deps])`).

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -496,6 +496,18 @@ const SelectedSongsScreen: React.FC = () => {
     headerIconColor,
   ]);
 
+  const listCountHeaderElement = useMemo(
+    () => (
+      <View style={styles.countHeader}>
+        <Text style={styles.selectionCount}>
+          {selectedSongs.length}{' '}
+          {selectedSongs.length === 1 ? 'canción' : 'canciones'}
+        </Text>
+      </View>
+    ),
+    [selectedSongs.length, styles],
+  );
+
   if (loading && selectedSongs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -533,22 +545,13 @@ const SelectedSongsScreen: React.FC = () => {
     );
   }
 
-  const ListCountHeader = () => (
-    <View style={styles.countHeader}>
-      <Text style={styles.selectionCount}>
-        {selectedSongs.length}{' '}
-        {selectedSongs.length === 1 ? 'canción' : 'canciones'}
-      </Text>
-    </View>
-  );
-
   return (
     <View style={styles.container}>
       <FlatList
         data={categorizedSelectedSongs}
         renderItem={renderCategory}
         keyExtractor={(item) => item.categoryTitle}
-        ListHeaderComponent={<ListCountHeader />}
+        ListHeaderComponent={listCountHeaderElement}
         contentContainerStyle={styles.listContentContainer}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -262,6 +262,57 @@ export default function SongsListScreen({
     [songs, categoryId, navigation],
   );
 
+  // ListHeaderComponent: search bar + song count
+  // Goes inside the FlatList so it scrolls with content on iOS
+  // (avoids getting hidden behind transparent header)
+  // ⚡ Bolt: Memoize the rendered element instead of defining a component inside the render scope
+  // to prevent React from unmounting and remounting the input, losing focus on every keystroke.
+  const listHeaderElement = useMemo(
+    () => (
+      <View>
+        {searchVisible && (
+          <View style={styles.searchContainer}>
+            <SearchField
+              value={search}
+              onChange={setSearch}
+            >
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input
+                  placeholder="Título, autor..."
+                  autoFocus={!isSearchAll}
+                  returnKeyType="search"
+                />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+          </View>
+        )}
+        {/* Conteo de canciones — siempre visible, muy sutil */}
+        <View style={styles.countRow}>
+          <Text style={styles.songCount}>
+            {filteredSongs.length}{' '}
+            {filteredSongs.length === 1 ? 'canción' : 'canciones'}
+            {search.length > 0 ? ' encontradas' : ''}
+          </Text>
+        </View>
+      </View>
+    ),
+    [searchVisible, search, isSearchAll, filteredSongs.length, styles],
+  );
+
+  // ⚡ Bolt: Extract renderItem and wrap in useCallback to prevent child re-renders
+  const renderItem = useCallback(
+    ({ item }: { item: Song }) => (
+      <SongListItem
+        song={item}
+        onPress={handleSongPress}
+        isSearchAllMode={isSearchAll}
+      />
+    ),
+    [handleSongPress, isSearchAll],
+  );
+
   if ((isLoading || loadingSongs) && songs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -278,40 +329,6 @@ export default function SongsListScreen({
     );
   }
 
-  // ListHeaderComponent: search bar + song count
-  // Goes inside the FlatList so it scrolls with content on iOS
-  // (avoids getting hidden behind transparent header)
-  const ListHeader = () => (
-    <View>
-      {searchVisible && (
-        <View style={styles.searchContainer}>
-          <SearchField
-            value={search}
-            onChange={setSearch}
-          >
-            <SearchField.Group>
-              <SearchField.SearchIcon />
-              <SearchField.Input
-                placeholder="Título, autor..."
-                autoFocus={!isSearchAll}
-                returnKeyType="search"
-              />
-              <SearchField.ClearButton />
-            </SearchField.Group>
-          </SearchField>
-        </View>
-      )}
-      {/* Conteo de canciones — siempre visible, muy sutil */}
-      <View style={styles.countRow}>
-        <Text style={styles.songCount}>
-          {filteredSongs.length}{' '}
-          {filteredSongs.length === 1 ? 'canción' : 'canciones'}
-          {search.length > 0 ? ' encontradas' : ''}
-        </Text>
-      </View>
-    </View>
-  );
-
   return (
     <View style={styles.container}>
       <FlatList
@@ -320,14 +337,8 @@ export default function SongsListScreen({
         initialNumToRender={15}
         maxToRenderPerBatch={20}
         windowSize={5}
-        renderItem={({ item }) => (
-          <SongListItem
-            song={item}
-            onPress={handleSongPress}
-            isSearchAllMode={isSearchAll}
-          />
-        )}
-        ListHeaderComponent={<ListHeader />}
+        renderItem={renderItem}
+        ListHeaderComponent={listHeaderElement}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
💡 **What:** Replaced the inner functional components `ListHeader` and `ListCountHeader` with memoized JSX elements (`listHeaderElement` and `listCountHeaderElement` via `useMemo`) inside `SongListScreen.tsx` and `SelectedSongsScreen.tsx`. Extracted the inline arrow function for `renderItem` in `SongListScreen.tsx` using `useCallback`.

🎯 **Why:** Defining a React component inside the render scope of another component is a severe anti-pattern. React sees the inner component as a completely new reference on every parent render. This forces React to completely unmount and remount the DOM element instead of reconciling it. This destroys local state (specifically, the search input focus is lost on every keystroke) and causes thousands of unnecessary memory allocations and garbage collections (render jank).

📊 **Impact:** 
* Prevents the Search Input in `SongListScreen.tsx` from stealing/losing focus on every keystroke.
* Eliminates unmount/remount rendering cycles for the list headers.
* Ensures list items wrapped in `React.memo` (rendered via `renderItem`) successfully benefit from memoization by receiving a stable `renderItem` function reference.

🔬 **Measurement:** Verify by typing into the search bar inside the SongListScreen—the input should not drop focus on each keystroke. Linting and 64 tests across 7 suites pass successfully.

---
*PR created automatically by Jules for task [1744204164230952439](https://jules.google.com/task/1744204164230952439) started by @mcmespana*