### PR TITLE
⚡ Bolt: Memoize renderItem in SongListScreen FlatList

### DIFF
--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -262,6 +262,17 @@ export default function SongsListScreen({
     [songs, categoryId, navigation],
   );
 
+  const renderItem = useCallback(
+    ({ item }: { item: Song }) => (
+      <SongListItem
+        song={item}
+        onPress={handleSongPress}
+        isSearchAllMode={isSearchAll}
+      />
+    ),
+    [handleSongPress, isSearchAll],
+  );
+
   if ((isLoading || loadingSongs) && songs.length === 0) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
@@ -320,13 +331,7 @@ export default function SongsListScreen({
         initialNumToRender={15}
         maxToRenderPerBatch={20}
         windowSize={5}
-        renderItem={({ item }) => (
-          <SongListItem
-            song={item}
-            onPress={handleSongPress}
-            isSearchAllMode={isSearchAll}
-          />
-        )}
+        renderItem={renderItem}
         ListHeaderComponent={<ListHeader />}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"


### PR DESCRIPTION
💡 What: Memoize the `renderItem` function passed to `FlatList` in `SongListScreen.tsx` using `useCallback`.
🎯 Why: In React Native, passing an inline, anonymous function to `renderItem` causes the function to be recreated on every render of the parent component, which can lead to unnecessary re-renders of the entire list or individual list items. Memoizing it is a documented best practice for `FlatList` performance.
📊 Impact: Reduces unnecessary re-renders of `SongListItem` components during state updates in the parent component (like search typing), improving list scrolling performance and search responsiveness.
🔬 Measurement: Run performance tools / React DevTools profiler when typing in the search bar to confirm that existing items do not re-render unnecessarily.

---
*PR created automatically by Jules for task [13122871419852410766](https://jules.google.com/task/13122871419852410766) started by @mcmespana*