### PR TITLE
feat(cancionero): rediseño selección de canciones (transpose, orden libre, nube y modo Coro)

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 2026-05-17 — Rediseño selección de canciones: transpose persistido, orden libre, nube y modo Coro
+
+- **Nuevo modelo de selección** (`contexts/SelectedSongsContext.tsx`): `SelectedSong[]` con `{ filename, transpose, order, categoryHint, addedAt }`. Persistencia en `AsyncStorage` (`@mcm_playlist_v2`) con migración tolerante del formato anterior (array de strings). API ampliada: `setTranspose`, `moveSong`, `replaceAll`, `getSelectedSong`, `isHydrated`.
+- **Transpose persistido por canción**: si la canción está seleccionada, su transpose vive en el contexto y se preserva al exportar / compartir / sincronizar. En `SongDetailScreen`, el transpose efímero local solo aplica si la canción NO está en la selección. La pill de tono muestra el original tachado + tono final + badge "+N" tanto en `SongListItem` como en la nueva `PlaylistRow`.
+- **Exportar/Importar archivo `.mcm` v2**: nuevo schema `{ version: 2, songs: SelectedSong[], createdAt }` que incluye tono y orden. Importación tolerante con el formato v1 (array de strings). `hooks/useIncomingPlaylist.ts` actualizado para entender ambos.
+- **Subir/Descargar playlists desde Firebase RTDB con código de 4 dígitos** (`services/cloudPlaylistService.ts`, ruta `/playlistShares/{code}`): cualquiera con el código puede importar; al subir, si el código ya existe se ofrece sobrescribir / elegir otro / cancelar. Cambio de código y borrado disponibles. Se almacena `expiresAt` con +6 meses (purga real pendiente — recomendación: Cloud Function programada). URL compartible `https://mcm.expo.app/playlist?p=1234` que en web salta a la pantalla de seleccionadas con autoimport (nuevo `app/playlist.tsx` + `utils/pendingCloudPlaylist.ts`).
+- **Modo Coro** (`contexts/ChoirSessionContext.tsx`, `services/choirSessionService.ts`, ruta `/choirSessions/{code}`): un dispositivo maestro publica `current { filename, transpose, title, content, ... }` en tiempo real y N esclavos siguen automáticamente la canción (navegando a `SongDetail`). El esclavo puede activar "Mi tono" para desincronizar el transpose localmente sin afectar al resto. La sesión persiste si el maestro cierra la app; expira a las 2 semanas. Banner persistente `<ChoirSessionBanner />` con código, rol, tono activo y botón salir/cerrar. Códigos editables vía mismo diálogo OTP. Observador del esclavo montado en `app/(tabs)/cancionero.tsx` para que el stack del cantoral navegue solo.
+- **UI rediseñada de "Seleccionadas"** (`app/screens/SelectedSongsScreen.tsx`): header con un único botón "…" que abre un menú con todas las acciones (BottomSheet-style). Vista doble "Por categoría" / "Orden libre" con controles ↑↓ para reordenar. Empty state con accesos rápidos (importar archivo / código nube / unirse a coro). Diálogo OTP visual de 4 dígitos (`components/playlist/CodeInputDialog.tsx`) con sugerencias "Aleatorio" y "Hoy (DDMM)". Diálogo de confirmación multi-acción reutilizable. Tono final/original con flecha visible en cada fila.
+- **Tamaño de código fácilmente ampliable**: cambiar `CODE_LENGTH` en `utils/playlistCodes.ts` (hoy 4, sirve para 6/8 sin más).
+- **Estructura Firebase nueva**:
+  - `/playlistShares/{code}` → `{ v: 2, songs, name?, createdAt, updatedAt, expiresAt }`
+  - `/choirSessions/{code}` → `{ v: 1, master: {deviceId, name?, lastSeen}, playlist, current?, createdAt, updatedAt, lastActivity, expiresAt }`
+  - Sin reglas de seguridad: cualquier cliente puede leer/escribir bajo el código. Aceptable para el uso esperado (~20 dispositivos en confianza, baja frecuencia).
+- **Pendientes recomendados** (no implementados):
+  - Cloud Function programada para purga de `playlistShares` y `choirSessions` expirados.
+  - Deep link nativo (iOS Universal Links / Android App Links) para abrir el deep `/playlist?p=` directamente en la app instalada. Hoy funciona en web.
+- Archivos clave nuevos: `contexts/ChoirSessionContext.tsx`, `services/cloudPlaylistService.ts`, `services/choirSessionService.ts`, `components/playlist/*`, `utils/playlistCodes.ts`, `utils/transposeKey.ts`, `utils/pendingCloudPlaylist.ts`, `app/playlist.tsx`.
+
+---
+
 ## 2026-04-29 — Rediseño Contigo (Evangelio + Oración + Revisión)
 
 - **Nueva home `/contigo`**: layout reordenado a header (título + fecha + chip litúrgico + botón guardados) → hero card con `ProgressRing` (1/2/3 colores: azul, naranja, verde) → 3 `HabitTile`s (Evangelio · Oración · Revisión) → teaser del evangelio del día (título + cita + fade-out preview + chip "Leído hoy") → strip semanal Lun–Dom con dots por hábito → 3 `StatCard`s (racha · min sem. · lecturas mes) → `MonthHeatmap`. `app/(tabs)/contigo/index.tsx` reescrita.

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -11,6 +11,7 @@ import SongFullscreenScreen from '../screens/SongFullscreenScreen';
 import SelectedSongsScreen from '../screens/SelectedSongsScreen';
 
 import { SettingsProvider } from '../../contexts/SettingsContext';
+import { useChoirSession } from '../../contexts/ChoirSessionContext';
 
 export interface SongNavItem {
   title: string;
@@ -44,7 +45,7 @@ export type RootStackParamList = {
     capo?: number;
     content: string;
   };
-  SelectedSongs: undefined;
+  SelectedSongs: { p?: string } | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -58,6 +59,7 @@ export default function CancioneroTab() {
   const webStatusBarHeight = isWeb ? insets.top : undefined;
 
   const navigation = useNavigation();
+  const choir = useChoirSession();
 
   useEffect(() => {
     const unsubscribe = navigation
@@ -71,6 +73,48 @@ export default function CancioneroTab() {
 
     return unsubscribe;
   }, [navigation]);
+
+  // Modo coro - ESCLAVO: cuando el maestro cambia la canción actual,
+  // navegamos automáticamente a SongDetail con los metadatos publicados.
+  // Cubre tanto el caso "ya estoy en SongDetail" (navigate hace setParams)
+  // como "estoy en otra pantalla del stack" (navigate hace push).
+  useEffect(() => {
+    if (choir.mode !== 'slave') return;
+    const remote = choir.session?.current;
+    if (!remote || !remote.filename) return;
+    const nav = stackNavRef.current;
+    if (!nav) return;
+    try {
+      const state = nav.getState?.();
+      const route = state?.routes?.[state.index];
+      if (
+        route?.name === 'SongDetail' &&
+        (route.params as any)?.filename === remote.filename
+      ) {
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    nav.navigate('SongDetail', {
+      filename: remote.filename,
+      title: remote.title ?? remote.filename,
+      author: remote.author,
+      key: remote.songKey,
+      capo: remote.capo,
+      content: remote.content ?? '',
+      firebaseCategory: remote.firebaseCategory,
+      source: 'selection',
+    });
+    // Reaccionamos solo cuando el maestro cambia de canción o re-publica
+    // explícitamente (`updatedAt`). Acceder a `choir.session` aquí causaría
+    // un re-disparo en cada actualización irrelevante (p. ej. `lastActivity`).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    choir.mode,
+    choir.session?.current?.filename,
+    choir.session?.current?.updatedAt,
+  ]);
 
   return (
     <SettingsProvider>

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -27,6 +27,7 @@ import {
   SelectedSongsProvider,
   useSelectedSongs,
 } from '@/contexts/SelectedSongsContext';
+import { ChoirSessionProvider } from '@/contexts/ChoirSessionContext';
 import { useIncomingPlaylist } from '@/hooks/useIncomingPlaylist';
 import { useRegisterServiceWorker } from '@/hooks/useRegisterServiceWorker';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
@@ -52,9 +53,11 @@ export default function RootLayout() {
                 <UniwindThemeBridge />
                 <UserProfileProvider>
                   <SelectedSongsProvider>
-                    <NotificationsProvider>
-                      <InnerLayout />
-                    </NotificationsProvider>
+                    <ChoirSessionProvider>
+                      <NotificationsProvider>
+                        <InnerLayout />
+                      </NotificationsProvider>
+                    </ChoirSessionProvider>
                   </SelectedSongsProvider>
                 </UserProfileProvider>
               </AppSettingsProvider>
@@ -171,6 +174,12 @@ function InnerLayout() {
           options={{
             headerShown: true,
             title: 'Wordle Jubileo',
+          }}
+        />
+        <Stack.Screen
+          name="playlist"
+          options={{
+            headerShown: false,
           }}
         />
       </Stack>

--- a/mcm-app/app/coro.tsx
+++ b/mcm-app/app/coro.tsx
@@ -1,0 +1,52 @@
+/**
+ * Pantalla "puente" del deep link `https://mcm.expo.app/coro?c=1234`.
+ *
+ * Toma el código `?c=` de la URL, lo persiste en una mini-cola in-memory
+ * y redirige al stack del cancionero. Allí, `CategoriesScreen` detectará
+ * el pending code y navegará automáticamente a "Seleccionadas" para
+ * unirse al coro.
+ */
+import { useEffect } from 'react';
+import { View, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { setPendingChoirCode } from '@/utils/pendingCloudPlaylist';
+import { isValidCode } from '@/utils/playlistCodes';
+
+export default function ChoirDeepLink() {
+  const params = useLocalSearchParams<{ c?: string; code?: string }>();
+  const code =
+    typeof params.c === 'string'
+      ? params.c
+      : typeof params.code === 'string'
+        ? params.code
+        : undefined;
+
+  useEffect(() => {
+    if (code && isValidCode(code)) {
+      setPendingChoirCode(code);
+    }
+    // En web, también limpiamos el query string para que no se quede en la URL.
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      try {
+        window.history.replaceState({}, document.title, '/');
+      } catch {
+        // ignore
+      }
+    }
+    router.replace('/(tabs)/cancionero' as any);
+  }, [code]);
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mcm-app/app/playlist.tsx
+++ b/mcm-app/app/playlist.tsx
@@ -1,0 +1,52 @@
+/**
+ * Pantalla "puente" del deep link `https://mcm.expo.app/playlist?p=1234`.
+ *
+ * Toma el código `?p=` de la URL, lo persiste en una mini-cola in-memory
+ * y redirige al stack del cancionero. Allí, `CategoriesScreen` detectará
+ * el pending code y navegará automáticamente a "Seleccionadas" para
+ * autoimportar la playlist.
+ */
+import { useEffect } from 'react';
+import { View, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { setPendingCloudPlaylistCode } from '@/utils/pendingCloudPlaylist';
+import { isValidCode } from '@/utils/playlistCodes';
+
+export default function PlaylistDeepLink() {
+  const params = useLocalSearchParams<{ p?: string; code?: string }>();
+  const code =
+    typeof params.p === 'string'
+      ? params.p
+      : typeof params.code === 'string'
+        ? params.code
+        : undefined;
+
+  useEffect(() => {
+    if (code && isValidCode(code)) {
+      setPendingCloudPlaylistCode(code);
+    }
+    // En web, también limpiamos el query string para que no se quede en la URL.
+    if (Platform.OS === 'web' && typeof window !== 'undefined') {
+      try {
+        window.history.replaceState({}, document.title, '/');
+      } catch {
+        // ignore
+      }
+    }
+    router.replace('/(tabs)/cancionero' as any);
+  }, [code]);
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -18,7 +18,10 @@ import SuggestSongModal from '@/components/SuggestSongModal';
 import { filterSongsData } from '@/utils/filterSongsData';
 import { useSelectedSongs } from '@/contexts/SelectedSongsContext';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { consumePendingCloudPlaylistCode } from '@/utils/pendingCloudPlaylist';
+import {
+  consumePendingCloudPlaylistCode,
+  consumePendingChoirCode,
+} from '@/utils/pendingCloudPlaylist';
 
 const ALL_SONGS_CATEGORY_ID = '__ALL__';
 const ALL_SONGS_CATEGORY_NAME = '🔎 Buscar una canción...';
@@ -51,7 +54,7 @@ export default function CategoriesScreen({
     Categories: undefined;
     SongsList: { categoryId: string; categoryName: string };
     SongDetail: { songId: string; songTitle?: string };
-    SelectedSongs: { p?: string } | undefined;
+    SelectedSongs: { p?: string; c?: string } | undefined;
   }>;
 }) {
   const scheme = useColorScheme();
@@ -95,13 +98,17 @@ export default function CategoriesScreen({
   };
 
   // Deep link: si llegamos con un código pendiente de la nube
-  // (proveniente de /playlist?p=1234), saltamos a la pantalla de
-  // seleccionadas con ese código para que dispare el autoimport.
+  // (proveniente de /playlist?p=1234 o /coro?c=1234), saltamos a la pantalla de
+  // seleccionadas con ese código para que dispare el autoimport o auto-join.
   useEffect(() => {
-    const pending = consumePendingCloudPlaylistCode();
-    if (pending) {
+    const pendingPlaylist = consumePendingCloudPlaylistCode();
+    const pendingChoir = consumePendingChoirCode();
+
+    if (pendingPlaylist) {
       // setParams no funciona para una nueva pantalla; usamos navigate.
-      navigation.navigate('SelectedSongs', { p: pending } as any);
+      navigation.navigate('SelectedSongs', { p: pendingPlaylist } as any);
+    } else if (pendingChoir) {
+      navigation.navigate('SelectedSongs', { c: pendingChoir } as any);
     }
   }, [navigation]);
 

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -1,6 +1,12 @@
 import { FlatList, Text, StyleSheet, View, Platform } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useLayoutEffect, useMemo, useState, useCallback } from 'react';
+import {
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -12,6 +18,7 @@ import SuggestSongModal from '@/components/SuggestSongModal';
 import { filterSongsData } from '@/utils/filterSongsData';
 import { useSelectedSongs } from '@/contexts/SelectedSongsContext';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { consumePendingCloudPlaylistCode } from '@/utils/pendingCloudPlaylist';
 
 const ALL_SONGS_CATEGORY_ID = '__ALL__';
 const ALL_SONGS_CATEGORY_NAME = '🔎 Buscar una canción...';
@@ -44,7 +51,7 @@ export default function CategoriesScreen({
     Categories: undefined;
     SongsList: { categoryId: string; categoryName: string };
     SongDetail: { songId: string; songTitle?: string };
-    SelectedSongs: undefined;
+    SelectedSongs: { p?: string } | undefined;
   }>;
 }) {
   const scheme = useColorScheme();
@@ -86,6 +93,17 @@ export default function CategoriesScreen({
   const handleSuccessSubmit = () => {
     toast.show({ variant: 'success', label: '¡Sugerencia enviada!' });
   };
+
+  // Deep link: si llegamos con un código pendiente de la nube
+  // (proveniente de /playlist?p=1234), saltamos a la pantalla de
+  // seleccionadas con ese código para que dispare el autoimport.
+  useEffect(() => {
+    const pending = consumePendingCloudPlaylistCode();
+    if (pending) {
+      // setParams no funciona para una nueva pantalla; usamos navigate.
+      navigation.navigate('SelectedSongs', { p: pending } as any);
+    }
+  }, [navigation]);
 
   // Header: search + add buttons together (integrado en el header)
   useLayoutEffect(() => {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -556,7 +556,7 @@ const SelectedSongsScreen: React.FC = () => {
   // --- Nube -----------------------------------------------------------------
 
   const handleUploadToCloud = useCallback(
-    async (code: string) => {
+    async (code: string, name?: string) => {
       const exists = await cloudPlaylistExists(code);
       if (exists) {
         // Pedimos confirmación: sobrescribir / cambiar código / cancelar.
@@ -572,9 +572,9 @@ const SelectedSongsScreen: React.FC = () => {
               onPress: async () => {
                 setConfirmDialog(null);
                 try {
-                  await uploadCloudPlaylist(code, selectedSongs);
+                  await uploadCloudPlaylist(code, selectedSongs, { name });
                   setLastUploadCode(code);
-                  showUploadSuccess(code);
+                  showUploadSuccess(code, name);
                 } catch (e: any) {
                   toast.show({ label: e?.message ?? 'Error al subir' });
                 }
@@ -598,20 +598,22 @@ const SelectedSongsScreen: React.FC = () => {
         // Lanzamos error para que el diálogo no se cierre automáticamente.
         throw new Error('__handled__');
       }
-      await uploadCloudPlaylist(code, selectedSongs);
+      await uploadCloudPlaylist(code, selectedSongs, { name });
       setLastUploadCode(code);
       setCodeDialog(null);
-      showUploadSuccess(code);
+      showUploadSuccess(code, name);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedSongs],
   );
 
   const showUploadSuccess = useCallback(
-    (code: string) => {
+    (code: string, name?: string) => {
       const url = `${WEB_BASE_URL}/playlist?p=${code}`;
       setConfirmDialog({
-        title: `¡Subida! Código ${code}`,
+        title: name
+          ? `¡${name} subida! Código ${code}`
+          : `¡Subida! Código ${code}`,
         description: `Compártelo o copia el enlace:\n${url}`,
         actions: [
           {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -1,9 +1,10 @@
 import React, {
-  useEffect,
-  useState,
-  useLayoutEffect,
   useCallback,
+  useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
+  useState,
 } from 'react';
 import {
   View,
@@ -18,23 +19,51 @@ import {
   TouchableWithoutFeedback,
 } from 'react-native';
 import { useToast, PressableFeedback } from 'heroui-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import * as DocumentPicker from 'expo-document-picker';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
-import { useSelectedSongs } from '../../contexts/SelectedSongsContext';
-import SongListItem from '../../components/SongListItem';
-import { IconSymbol } from '../../components/ui/IconSymbol';
-import ProgressWithMessage from '@/components/ProgressWithMessage';
+import {
+  useSelectedSongs,
+  SelectedSong,
+} from '@/contexts/SelectedSongsContext';
+import { useChoirSession } from '@/contexts/ChoirSessionContext';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
-import { RootStackParamList } from '../(tabs)/cancionero';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
-import { radii, shadows } from '@/constants/uiStyles';
+import { radii } from '@/constants/uiStyles';
+import { RootStackParamList } from '../(tabs)/cancionero';
+import ProgressWithMessage from '@/components/ProgressWithMessage';
+
+import PlaylistRow from '@/components/playlist/PlaylistRow';
+import PlaylistActionsSheet, {
+  PlaylistAction,
+} from '@/components/playlist/PlaylistActionsSheet';
+import CodeInputDialog, {
+  CodeDialogVariant,
+} from '@/components/playlist/CodeInputDialog';
+import ConfirmChoiceDialog from '@/components/playlist/ConfirmChoiceDialog';
+import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
+
+import {
+  cloudPlaylistExists,
+  fetchCloudPlaylist,
+  uploadCloudPlaylist,
+  changeCloudPlaylistCode,
+  deleteCloudPlaylist,
+} from '@/services/cloudPlaylistService';
+import {
+  choirSessionExists,
+  fetchChoirSession,
+} from '@/services/choirSessionService';
+import { transposeLabel, transposeKey } from '@/utils/transposeKey';
+import { convertChord } from '@/utils/chordNotation';
+import { useSettings } from '@/contexts/SettingsContext';
 
 interface Song {
   title: string;
@@ -47,8 +76,13 @@ interface Song {
 }
 
 interface CategorizedSongs {
+  categoryKey: string;
   categoryTitle: string;
-  data: Song[];
+  data: (Song & {
+    originalCategoryKey: string;
+    transpose: number;
+    order: number;
+  })[];
 }
 
 type SelectedSongsScreenNavigationProp = NativeStackNavigationProp<
@@ -56,99 +90,191 @@ type SelectedSongsScreenNavigationProp = NativeStackNavigationProp<
   'SongDetail'
 >;
 
+const WEB_BASE_URL = 'https://mcm.expo.app';
+
+type ViewMode = 'category' | 'manual';
+
 const SelectedSongsScreen: React.FC = () => {
-  const { selectedSongs, clearSelection, addSong, isSongSelected } =
-    useSelectedSongs();
+  const {
+    selectedSongs,
+    isHydrated,
+    clearSelection,
+    addSong,
+    removeSong,
+    moveSong,
+    replaceAll,
+  } = useSelectedSongs();
+  const choir = useChoirSession();
+  const { settings } = useSettings();
+
   const navigation = useNavigation<SelectedSongsScreenNavigationProp>();
+  const route = useRoute();
   const scheme = useColorScheme() || 'light';
   const isDark = scheme === 'dark';
   const styles = useMemo(() => createStyles(scheme), [scheme]);
   const { data: allSongsData, loading } = useFirebaseData<
     Record<string, { categoryTitle: string; songs: Song[] }>
   >('songs', 'songs');
-  const [categorizedSelectedSongs, setCategorizedSelectedSongs] = useState<
-    CategorizedSongs[]
-  >([]);
   const { toast } = useToast();
-  const [showExportModal, setShowExportModal] = useState(false);
+
+  const [viewMode, setViewMode] = useState<ViewMode>('category');
+
+  // Modales / sheets
+  const [showActions, setShowActions] = useState(false);
+  const [showExportFileModal, setShowExportFileModal] = useState(false);
   const [exportFileName, setExportFileName] = useState('');
 
-  // O(1) lookup map for all songs, preserving original category context
+  // Diálogo genérico de código (variant decide la operación a hacer en submit).
+  const [codeDialog, setCodeDialog] = useState<{
+    variant: CodeDialogVariant;
+    initial?: string;
+  } | null>(null);
+
+  // Diálogo de confirmación múltiple genérico.
+  const [confirmDialog, setConfirmDialog] = useState<{
+    title: string;
+    description?: string;
+    actions: {
+      label: string;
+      onPress: () => void;
+      variant?: 'primary' | 'secondary' | 'danger';
+    }[];
+  } | null>(null);
+
+  // Código de la última subida a la nube (para "cambiar código" / "borrar").
+  // Persistido para sobrevivir al cierre de la app.
+  const [lastUploadCode, setLastUploadCodeState] = useState<string | null>(
+    null,
+  );
+  const LAST_UPLOAD_CODE_KEY = '@mcm_last_upload_code';
+  useEffect(() => {
+    AsyncStorage.getItem(LAST_UPLOAD_CODE_KEY).then((v) => {
+      if (v) setLastUploadCodeState(v);
+    });
+  }, []);
+  const setLastUploadCode = useCallback((code: string | null) => {
+    setLastUploadCodeState(code);
+    if (code) {
+      AsyncStorage.setItem(LAST_UPLOAD_CODE_KEY, code).catch(() => {});
+    } else {
+      AsyncStorage.removeItem(LAST_UPLOAD_CODE_KEY).catch(() => {});
+    }
+  }, []);
+
+  // Auto-import si llegamos con ?p=XXXX en web (deep link).
+  const autoImportAttempted = useRef(false);
+  useEffect(() => {
+    if (autoImportAttempted.current) return;
+    const params: any = (route?.params as any) || {};
+    const code = params.p ?? params.code;
+    if (typeof code === 'string' && /^\d{4}$/.test(code)) {
+      autoImportAttempted.current = true;
+      void handleDownloadFromCloud(code);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Mapa filename → datos completos de la canción (con categoría original).
   const allSongsMap = useMemo(() => {
     const map = new Map<string, Song & { originalCategoryKey: string }>();
     if (!allSongsData) return map;
-
     for (const [categoryKey, categoryData] of Object.entries(allSongsData)) {
       categoryData.songs.forEach((song) => {
-        map.set(song.filename, {
-          ...song,
-          originalCategoryKey: categoryKey,
-        });
+        map.set(song.filename, { ...song, originalCategoryKey: categoryKey });
       });
     }
     return map;
   }, [allSongsData]);
 
-  // O(1) lookup maps for flattened selected songs
-  const { flatSelectedSongs, songIndexMap } = useMemo(() => {
-    const flat: Song[] = [];
-    const indexMap = new Map<string, number>();
+  // Datos enriquecidos de la selección, ordenados por el campo `order`.
+  const enrichedSelected = useMemo(() => {
+    return selectedSongs
+      .map((sel) => {
+        const meta = allSongsMap.get(sel.filename);
+        if (!meta) return null;
+        return {
+          ...meta,
+          transpose: sel.transpose,
+          order: sel.order,
+        };
+      })
+      .filter(
+        (
+          s,
+        ): s is Song & {
+          originalCategoryKey: string;
+          transpose: number;
+          order: number;
+        } => s !== null,
+      );
+  }, [selectedSongs, allSongsMap]);
 
-    categorizedSelectedSongs.forEach((category) => {
-      category.data.forEach((song) => {
-        indexMap.set(song.filename, flat.length);
-        flat.push(song);
-      });
-    });
+  // Lista plana ordenada (para modo "manual") y para navegación entre canciones.
+  const flatSelectedSongs = useMemo(
+    () => [...enrichedSelected].sort((a, b) => a.order - b.order),
+    [enrichedSelected],
+  );
 
-    return { flatSelectedSongs: flat, songIndexMap: indexMap };
-  }, [categorizedSelectedSongs]);
+  const songIndexMap = useMemo(() => {
+    const m = new Map<string, number>();
+    flatSelectedSongs.forEach((s, i) => m.set(s.filename, i));
+    return m;
+  }, [flatSelectedSongs]);
 
+  // Agrupación por categoría (modo "category").
+  const categorized = useMemo<CategorizedSongs[]>(() => {
+    if (!allSongsData) return [];
+    const out: CategorizedSongs[] = [];
+    for (const [categoryKey, categoryData] of Object.entries(allSongsData)) {
+      const selectedInCat = enrichedSelected
+        .filter((s) => s.originalCategoryKey === categoryKey)
+        .sort((a, b) => a.filename.localeCompare(b.filename));
+      if (selectedInCat.length > 0) {
+        out.push({
+          categoryKey,
+          categoryTitle: categoryData.categoryTitle,
+          data: selectedInCat,
+        });
+      }
+    }
+    out.sort((a, b) => a.categoryTitle.localeCompare(b.categoryTitle));
+    return out;
+  }, [allSongsData, enrichedSelected]);
+
+  // Si el maestro publica cambios en la playlist, refrescamos.
   useEffect(() => {
-    const processSongs = () => {
-      if (!selectedSongs || selectedSongs.length === 0) {
-        setCategorizedSelectedSongs([]);
-        return;
-      }
+    if (choir.mode !== 'master') return;
+    void choir.publishPlaylist(selectedSongs);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [choir.mode, selectedSongs]);
 
-      if (!allSongsData) {
-        setCategorizedSelectedSongs([]);
-        return;
-      }
+  // --- Acciones --------------------------------------------------------------
 
-      const categories: CategorizedSongs[] = [];
-      for (const categoryName in allSongsData) {
-        const songsInCategory = (
-          allSongsData as Record<
-            string,
-            { categoryTitle: string; songs: Song[] }
-          >
-        )[categoryName].songs;
-        // ⚡ Bolt Performance: Use isSongSelected (O(1) Set lookup) instead of includes (O(N) Array lookup)
-        const selectedInCategory = songsInCategory.filter((song) =>
-          isSongSelected(song.filename),
-        );
+  const handleSongPress = useCallback(
+    (song: Song) => {
+      const completeSong = allSongsMap.get(song.filename);
+      if (!completeSong) return;
+      const index = songIndexMap.get(completeSong.filename) ?? -1;
+      navigation.navigate('SongDetail', {
+        filename: completeSong.filename,
+        title: completeSong.title,
+        ...(completeSong.author && { author: completeSong.author }),
+        ...(completeSong.key && { key: completeSong.key }),
+        ...(typeof completeSong.capo !== 'undefined' && {
+          capo: completeSong.capo,
+        }),
+        content: completeSong.content || '',
+        navigationList: flatSelectedSongs,
+        currentIndex: index,
+        source: 'selection',
+        firebaseCategory: completeSong.originalCategoryKey || 'entrada',
+      });
+    },
+    [allSongsMap, songIndexMap, flatSelectedSongs, navigation],
+  );
 
-        if (selectedInCategory.length > 0) {
-          categories.push({
-            categoryTitle: (
-              allSongsData as Record<
-                string,
-                { categoryTitle: string; songs: Song[] }
-              >
-            )[categoryName].categoryTitle,
-            data: selectedInCategory,
-          });
-        }
-      }
-      categories.sort((a, b) => a.categoryTitle.localeCompare(b.categoryTitle));
-      setCategorizedSelectedSongs(categories);
-    };
-
-    processSongs();
-  }, [selectedSongs, allSongsData, isSongSelected]);
-
-  const handleExport = useCallback(() => {
+  /** Texto formateado: usa el TONO TRANSPORTADO (no el original). */
+  const buildShareText = useCallback(() => {
     const date = new Date()
       .toLocaleDateString('es-ES', { day: 'numeric', month: 'short' })
       .toUpperCase()
@@ -167,67 +293,75 @@ const SelectedSongsScreen: React.FC = () => {
     const randomEmoji =
       musicalEmojis[Math.floor(Math.random() * musicalEmojis.length)];
     const header = `*CANCIONES ${date} ${randomEmoji}*`;
+    const lines: string[] = [];
 
-    const formattedSongLines: string[] = [];
+    // Recorremos en el orden actualmente visible (manual o por categoría).
+    const visibleGroups: {
+      categoryTitle: string;
+      data: typeof flatSelectedSongs;
+    }[] =
+      viewMode === 'manual'
+        ? [{ categoryTitle: '', data: flatSelectedSongs }]
+        : categorized.map((c) => ({
+            categoryTitle: c.categoryTitle,
+            data: c.data,
+          }));
 
-    categorizedSelectedSongs.forEach((category) => {
-      const categoryLetter = category.categoryTitle.charAt(0).toUpperCase();
-
-      category.data.forEach((song) => {
-        // ⚡ Bolt Performance: Use isSongSelected (O(1) Set lookup) instead of includes (O(N) Array lookup)
-        if (isSongSelected(song.filename)) {
-          const songTitleClean = song.title.replace(/^\d+\.\s*/, '');
-
-          let chordCapoString = '';
-          if (song.key) {
-            chordCapoString = `\`${song.key}\``;
-            if (song.capo && song.capo > 0) {
-              chordCapoString += ` \`C/${song.capo}\``;
-            }
+    visibleGroups.forEach((group) => {
+      const letter = group.categoryTitle
+        ? group.categoryTitle.charAt(0).toUpperCase()
+        : '';
+      group.data.forEach((song) => {
+        const cleanTitle = song.title.replace(/^\d+\.\s*/, '');
+        let toneStr = '';
+        if (song.key) {
+          const original = song.key.toUpperCase();
+          if (song.transpose === 0) {
+            toneStr = `\`${convertChord(original, settings.notation)}\``;
+          } else {
+            const target = transposeKey(original, song.transpose);
+            const lbl = transposeLabel(song.transpose);
+            toneStr =
+              `\`${convertChord(original, settings.notation)}→` +
+              `${convertChord(target, settings.notation)}\` *(${lbl} st)*`;
           }
-
-          const songIdMatch = song.title.match(/^\d+/);
-          const songId = songIdMatch ? songIdMatch[0] : '??';
-
-          let line = `*${categoryLetter}.* ${songTitleClean}`;
-          if (chordCapoString) {
-            line += ` · ${chordCapoString}`;
+          if (song.capo && song.capo > 0) {
+            toneStr += ` \`C/${song.capo}\``;
           }
-          line += ` · *[#${songId}]*`;
-          if (song.author) {
-            line += ` · ${song.author}`;
-          }
-          formattedSongLines.push(line);
         }
+        const idMatch = song.title.match(/^\d+/);
+        const songId = idMatch ? idMatch[0] : '??';
+        let line = letter ? `*${letter}.* ${cleanTitle}` : `• ${cleanTitle}`;
+        if (toneStr) line += ` · ${toneStr}`;
+        line += ` · *[#${songId}]*`;
+        if (song.author) line += ` · ${song.author}`;
+        lines.push(line);
       });
     });
 
-    const finalText = [header, ...formattedSongLines].join('\n');
+    return [header, ...lines].join('\n');
+  }, [viewMode, flatSelectedSongs, categorized, settings.notation]);
 
-    if (
+  const handleShareText = useCallback(() => {
+    const text = buildShareText();
+    const desktopLike =
       Platform.OS === 'web' ||
       Platform.OS === 'windows' ||
-      Platform.OS === 'macos'
-    ) {
-      try {
-        Clipboard.setStringAsync(finalText);
-        toast.show({ label: 'Lista copiada al portapapeles' });
-      } catch (error) {
-        console.error('Error copying to clipboard:', error);
-        toast.show({ label: 'Error al copiar la lista' });
-      }
+      Platform.OS === 'macos';
+    if (desktopLike) {
+      Clipboard.setStringAsync(text)
+        .then(() => toast.show({ label: 'Lista copiada al portapapeles' }))
+        .catch(() => toast.show({ label: 'Error al copiar la lista' }));
     } else {
       try {
-        Share.share({
-          message: finalText,
-        });
-      } catch (error) {
-        console.error('Error sharing:', error);
+        Share.share({ message: text });
+      } catch (e) {
+        console.error(e);
       }
     }
-  }, [categorizedSelectedSongs, isSongSelected]);
+  }, [buildShareText, toast]);
 
-  const handleShareFile = useCallback(async () => {
+  const handleStartExportFile = useCallback(() => {
     const monthNames = [
       'ene',
       'feb',
@@ -244,20 +378,20 @@ const SelectedSongsScreen: React.FC = () => {
     ];
     const now = new Date();
     const dateStr = `${now.getDate()}-${monthNames[now.getMonth()]}`;
-    const defaultFileName = `Playlist ${dateStr}`;
-
-    setExportFileName(defaultFileName);
-    setShowExportModal(true);
+    setExportFileName(`Playlist ${dateStr}`);
+    setShowExportFileModal(true);
   }, []);
 
-  const handleConfirmExport = useCallback(async () => {
+  const handleConfirmExportFile = useCallback(async () => {
     try {
       const fileName = `${exportFileName}.mcm`;
-
+      const payload = JSON.stringify({
+        version: 2,
+        createdAt: Date.now(),
+        songs: selectedSongs,
+      });
       if (Platform.OS === 'web') {
-        const blob = new Blob([JSON.stringify(selectedSongs)], {
-          type: 'application/octet-stream',
-        });
+        const blob = new Blob([payload], { type: 'application/octet-stream' });
         const url = window.URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
@@ -268,34 +402,105 @@ const SelectedSongsScreen: React.FC = () => {
         setTimeout(() => window.URL.revokeObjectURL(url), 1000);
       } else {
         const path = FileSystem.cacheDirectory + fileName;
-        await FileSystem.writeAsStringAsync(
-          path,
-          JSON.stringify(selectedSongs),
-          {
-            encoding: FileSystem.EncodingType.UTF8,
-          },
-        );
+        await FileSystem.writeAsStringAsync(path, payload, {
+          encoding: FileSystem.EncodingType.UTF8,
+        });
         await Sharing.shareAsync(path, {
           mimeType: 'application/octet-stream',
           dialogTitle: 'Compartir playlist',
           UTI: 'com.mcmespana.mcmapp.playlist',
         });
       }
-
-      setShowExportModal(false);
+      setShowExportFileModal(false);
       toast.show({ label: 'Playlist exportada' });
     } catch (err) {
-      console.error('Error sharing file', err);
-      setShowExportModal(false);
+      console.error('Error exportando playlist', err);
+      setShowExportFileModal(false);
       toast.show({ label: 'Error al exportar' });
     }
-  }, [selectedSongs, exportFileName]);
+  }, [exportFileName, selectedSongs, toast]);
+
+  /**
+   * Importa una lista desde texto JSON. Soporta:
+   *  - v2: { version: 2, songs: SelectedSong[] }
+   *  - v1: string[]
+   */
+  const importFromJson = useCallback((raw: string): SelectedSong[] | null => {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.version === 2 && Array.isArray(parsed.songs)) {
+        return parsed.songs as SelectedSong[];
+      }
+      if (Array.isArray(parsed)) {
+        const now = Date.now();
+        return parsed.map((filename: string, i: number) => ({
+          filename,
+          transpose: 0,
+          order: i,
+          addedAt: now + i,
+        }));
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  /** Muestra el confirmador "reemplazar / añadir / cancelar" tras una importación. */
+  const askMergeOrReplace = useCallback(
+    (imported: SelectedSong[]) => {
+      if (selectedSongs.length === 0) {
+        replaceAll(imported);
+        toast.show({
+          label: `Playlist importada (${imported.length} canciones)`,
+        });
+        return;
+      }
+      setConfirmDialog({
+        title: 'Ya tienes una playlist',
+        description: `Tu lista actual tiene ${selectedSongs.length} canciones. La importada tiene ${imported.length}.`,
+        actions: [
+          {
+            label: 'Reemplazar la mía',
+            variant: 'primary',
+            onPress: () => {
+              setConfirmDialog(null);
+              replaceAll(imported);
+              toast.show({ label: 'Playlist reemplazada' });
+            },
+          },
+          {
+            label: 'Añadir las nuevas',
+            variant: 'secondary',
+            onPress: () => {
+              setConfirmDialog(null);
+              const existing = new Set(selectedSongs.map((s) => s.filename));
+              imported.forEach((s) => {
+                if (!existing.has(s.filename)) {
+                  addSong(s.filename, {
+                    transpose: s.transpose,
+                    categoryHint: s.categoryHint,
+                  });
+                }
+              });
+              toast.show({ label: 'Canciones añadidas' });
+            },
+          },
+          {
+            label: 'Cancelar',
+            variant: 'secondary',
+            onPress: () => setConfirmDialog(null),
+          },
+        ],
+      });
+    },
+    [selectedSongs, replaceAll, addSong, toast],
+  );
 
   const handleImportFile = useCallback(async () => {
-    const validExtensions = ['.mcm', '.json', '.mcmsongs'];
-    const isValidFile = (name: string) =>
-      validExtensions.some((ext) => name.toLowerCase().endsWith(ext));
-
+    const valid = ['.mcm', '.json', '.mcmsongs'];
+    const isValid = (n: string) =>
+      valid.some((ext) => n.toLowerCase().endsWith(ext));
     try {
       if (Platform.OS === 'web') {
         const input = document.createElement('input');
@@ -304,27 +509,17 @@ const SelectedSongsScreen: React.FC = () => {
         input.onchange = async () => {
           if (!input.files || input.files.length === 0) return;
           const file = input.files[0];
-          if (file.name && !isValidFile(file.name)) {
+          if (file.name && !isValid(file.name)) {
             toast.show({ label: 'Selecciona un archivo .mcm' });
             return;
           }
           const text = await file.text();
-          try {
-            const parsed = JSON.parse(text);
-            if (Array.isArray(parsed)) {
-              if (parsed.length === 0) {
-                toast.show({ label: 'El archivo está vacío' });
-                return;
-              }
-              parsed.forEach((fn: string) => addSong(fn));
-              toast.show({ label: 'Playlist importada' });
-            } else {
-              toast.show({ label: 'Formato de archivo inválido' });
-            }
-          } catch (parseError) {
-            console.error('Error parsing JSON:', parseError);
-            toast.show({ label: 'El archivo no es un JSON válido' });
+          const songs = importFromJson(text);
+          if (!songs || songs.length === 0) {
+            toast.show({ label: 'Archivo vacío o inválido' });
+            return;
           }
+          askMergeOrReplace(songs);
         };
         input.click();
       } else {
@@ -333,190 +528,489 @@ const SelectedSongsScreen: React.FC = () => {
         });
         if (res.canceled || !res.assets || res.assets.length === 0) return;
         const file = res.assets[0];
-        if (file.name && !isValidFile(file.name)) {
+        if (file.name && !isValid(file.name)) {
           toast.show({ label: 'Selecciona un archivo .mcm' });
           return;
         }
         const content = await FileSystem.readAsStringAsync(file.uri, {
           encoding: FileSystem.EncodingType.UTF8,
         });
-        try {
-          const parsed = JSON.parse(content);
-          if (Array.isArray(parsed)) {
-            if (parsed.length === 0) {
-              toast.show({ label: 'El archivo está vacío' });
-              return;
-            }
-            parsed.forEach((fn: string) => addSong(fn));
-            toast.show({ label: 'Playlist importada' });
-          } else {
-            toast.show({ label: 'Formato de archivo inválido' });
-          }
-        } catch (parseError) {
-          console.error('Error parsing JSON:', parseError);
-          toast.show({ label: 'El archivo no es un JSON válido' });
+        const songs = importFromJson(content);
+        if (!songs || songs.length === 0) {
+          toast.show({ label: 'Archivo vacío o inválido' });
+          return;
         }
+        askMergeOrReplace(songs);
       }
     } catch (err) {
-      console.error('Error importing playlist', err);
+      console.error('Error importando playlist', err);
       toast.show({ label: 'Error al importar' });
     }
-  }, [addSong]);
+  }, [importFromJson, askMergeOrReplace, toast]);
 
-  const handleSongPress = useCallback(
-    (song: Song) => {
-      if (!allSongsData) return;
+  // --- Nube -----------------------------------------------------------------
 
-      const completeSong = allSongsMap.get(song.filename);
-
-      if (!completeSong) {
-        console.error('Song not found in allSongsData:', song.filename);
-        return;
+  const handleUploadToCloud = useCallback(
+    async (code: string) => {
+      const exists = await cloudPlaylistExists(code);
+      if (exists) {
+        // Pedimos confirmación: sobrescribir / cambiar código / cancelar.
+        // Cerramos diálogo de código temporalmente para evitar dos modales.
+        setCodeDialog(null);
+        setConfirmDialog({
+          title: 'Código ocupado',
+          description: `Ya hay una playlist subida con el código ${code}. ¿Quieres sobrescribirla?`,
+          actions: [
+            {
+              label: 'Sobrescribir',
+              variant: 'danger',
+              onPress: async () => {
+                setConfirmDialog(null);
+                try {
+                  await uploadCloudPlaylist(code, selectedSongs);
+                  setLastUploadCode(code);
+                  showUploadSuccess(code);
+                } catch (e: any) {
+                  toast.show({ label: e?.message ?? 'Error al subir' });
+                }
+              },
+            },
+            {
+              label: 'Elegir otro código',
+              variant: 'primary',
+              onPress: () => {
+                setConfirmDialog(null);
+                setCodeDialog({ variant: 'cloud-upload', initial: undefined });
+              },
+            },
+            {
+              label: 'Cancelar',
+              variant: 'secondary',
+              onPress: () => setConfirmDialog(null),
+            },
+          ],
+        });
+        // Lanzamos error para que el diálogo no se cierre automáticamente.
+        throw new Error('__handled__');
       }
+      await uploadCloudPlaylist(code, selectedSongs);
+      setLastUploadCode(code);
+      setCodeDialog(null);
+      showUploadSuccess(code);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedSongs],
+  );
 
-      const index = songIndexMap.get(completeSong.filename) ?? -1;
-
-      navigation.navigate('SongDetail', {
-        filename: completeSong.filename,
-        title: completeSong.title,
-        ...(completeSong.author && { author: completeSong.author }),
-        ...(completeSong.key && { key: completeSong.key }),
-        ...(typeof completeSong.capo !== 'undefined' && {
-          capo: completeSong.capo,
-        }),
-        content: completeSong.content || '',
-        navigationList: flatSelectedSongs,
-        currentIndex: index,
-        source: 'selection',
-        firebaseCategory: completeSong.originalCategoryKey || 'entrada',
+  const showUploadSuccess = useCallback(
+    (code: string) => {
+      const url = `${WEB_BASE_URL}/cancionero/seleccionadas?p=${code}`;
+      setConfirmDialog({
+        title: `¡Subida! Código ${code}`,
+        description: `Compártelo o copia el enlace:\n${url}`,
+        actions: [
+          {
+            label: 'Copiar enlace',
+            variant: 'primary',
+            onPress: () => {
+              void Clipboard.setStringAsync(url);
+              toast.show({ label: 'Enlace copiado' });
+              setConfirmDialog(null);
+            },
+          },
+          {
+            label: 'Copiar solo el código',
+            variant: 'secondary',
+            onPress: () => {
+              void Clipboard.setStringAsync(code);
+              toast.show({ label: 'Código copiado' });
+              setConfirmDialog(null);
+            },
+          },
+          {
+            label: 'Cerrar',
+            variant: 'secondary',
+            onPress: () => setConfirmDialog(null),
+          },
+        ],
       });
     },
-    [allSongsData, allSongsMap, songIndexMap, flatSelectedSongs, navigation],
+    [toast],
   );
 
-  const renderCategory = ({ item }: { item: CategorizedSongs }) => (
-    <View style={styles.categoryContainer}>
-      <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
-      {item.data
-        .filter(
-          (song): song is Song & { filename: string } =>
-            song &&
-            typeof song.filename === 'string' &&
-            song.filename.length > 0,
-        )
-        .map((song) => (
-          <SongListItem
-            key={song.filename}
-            song={song}
-            onPress={handleSongPress}
-          />
-        ))}
-    </View>
+  const handleDownloadFromCloud = useCallback(
+    async (code: string) => {
+      const data = await fetchCloudPlaylist(code);
+      if (!data) {
+        throw new Error('No existe ninguna playlist con ese código');
+      }
+      setCodeDialog(null);
+      askMergeOrReplace(data.songs);
+    },
+    [askMergeOrReplace],
   );
 
-  const headerIconColor =
-    Platform.OS === 'ios'
-      ? '#1a1a1a'
-      : Platform.OS === 'web'
-        ? '#1a1a1a'
-        : '#fff';
+  const handleChangeCloudCode = useCallback(
+    async (newCode: string) => {
+      if (!lastUploadCode) return;
+      await changeCloudPlaylistCode(lastUploadCode, newCode);
+      setLastUploadCode(newCode);
+      setCodeDialog(null);
+      toast.show({ label: `Código cambiado a ${newCode}` });
+    },
+    [lastUploadCode, toast, setLastUploadCode],
+  );
 
-  useLayoutEffect(() => {
-    if (selectedSongs.length > 0) {
-      const isDesktopLike =
-        Platform.OS === 'web' ||
-        Platform.OS === 'windows' ||
-        Platform.OS === 'macos';
-      navigation.setOptions({
-        headerRight: () => (
-          <View style={styles.headerActions}>
-            <TouchableOpacity
-              onPress={handleExport}
-              style={styles.headerIconBtn}
-              hitSlop={6}
-              accessibilityLabel={
-                isDesktopLike
-                  ? 'Copiar lista al portapapeles'
-                  : 'Compartir lista'
-              }
-            >
-              <IconSymbol
-                name={isDesktopLike ? 'doc.on.doc' : 'square.and.arrow.up'}
-                size={20}
-                color={headerIconColor}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleShareFile}
-              style={styles.headerIconBtn}
-              hitSlop={6}
-              accessibilityLabel="Exportar como archivo"
-            >
-              <MaterialIcons
-                name="file-upload"
-                size={22}
-                color={headerIconColor}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleImportFile}
-              style={styles.headerIconBtn}
-              hitSlop={6}
-              accessibilityLabel="Importar archivo"
-            >
-              <MaterialIcons
-                name="file-download"
-                size={22}
-                color={headerIconColor}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={clearSelection}
-              style={styles.headerIconBtn}
-              hitSlop={6}
-              accessibilityLabel="Borrar playlist"
-            >
-              <MaterialIcons name="delete-outline" size={22} color="#FF453A" />
-            </TouchableOpacity>
-          </View>
-        ),
-      });
-    } else {
-      navigation.setOptions({
-        headerRight: () => null,
-      });
+  const handleDeleteFromCloud = useCallback(async () => {
+    if (!lastUploadCode) return;
+    setConfirmDialog({
+      title: `Borrar playlist ${lastUploadCode} de la nube`,
+      description: 'Cualquiera con el código dejará de poder importarla.',
+      actions: [
+        {
+          label: 'Borrar de la nube',
+          variant: 'danger',
+          onPress: async () => {
+            setConfirmDialog(null);
+            try {
+              await deleteCloudPlaylist(lastUploadCode);
+              setLastUploadCode(null);
+              toast.show({ label: 'Borrada de la nube' });
+            } catch (e: any) {
+              toast.show({ label: e?.message ?? 'Error al borrar' });
+            }
+          },
+        },
+        {
+          label: 'Cancelar',
+          variant: 'secondary',
+          onPress: () => setConfirmDialog(null),
+        },
+      ],
+    });
+  }, [lastUploadCode, toast, setLastUploadCode]);
+
+  // --- Coro -----------------------------------------------------------------
+
+  const handleStartChoir = useCallback(
+    async (code: string) => {
+      const exists = await choirSessionExists(code);
+      if (exists) {
+        setCodeDialog(null);
+        const existing = await fetchChoirSession(code);
+        setConfirmDialog({
+          title: 'Código de coro ocupado',
+          description: existing
+            ? `Ya hay una sesión activa con código ${code}. ¿Sobrescribirla?`
+            : 'Ese código ya está en uso.',
+          actions: [
+            {
+              label: 'Sobrescribir',
+              variant: 'danger',
+              onPress: async () => {
+                setConfirmDialog(null);
+                try {
+                  await choir.startAsMaster(code, selectedSongs);
+                  toast.show({ label: `Sesión coro iniciada: ${code}` });
+                } catch (e: any) {
+                  toast.show({ label: e?.message ?? 'Error al iniciar' });
+                }
+              },
+            },
+            {
+              label: 'Elegir otro código',
+              variant: 'primary',
+              onPress: () => {
+                setConfirmDialog(null);
+                setCodeDialog({ variant: 'choir-start' });
+              },
+            },
+            {
+              label: 'Cancelar',
+              variant: 'secondary',
+              onPress: () => setConfirmDialog(null),
+            },
+          ],
+        });
+        throw new Error('__handled__');
+      }
+      await choir.startAsMaster(code, selectedSongs);
+      setCodeDialog(null);
+      toast.show({ label: `Sesión coro iniciada: ${code}` });
+    },
+    [choir, selectedSongs, toast],
+  );
+
+  const handleJoinChoir = useCallback(
+    async (code: string) => {
+      const session = await fetchChoirSession(code);
+      if (!session) {
+        throw new Error('No existe sesión con ese código');
+      }
+      // Importamos la playlist del maestro como nuestra selección base.
+      replaceAll(session.playlist || []);
+      await choir.joinAsSlave(code);
+      setCodeDialog(null);
+      toast.show({ label: `Conectado al coro ${code}` });
+    },
+    [choir, replaceAll, toast],
+  );
+
+  const handleChangeChoirCode = useCallback(
+    async (newCode: string) => {
+      if (!choir.code) return;
+      await choir.changeCode(newCode);
+      setCodeDialog(null);
+      toast.show({ label: `Código coro: ${newCode}` });
+    },
+    [choir, toast],
+  );
+
+  // --- Reorden manual -------------------------------------------------------
+
+  const handleMoveUp = useCallback(
+    (filename: string) => {
+      const idx = flatSelectedSongs.findIndex((s) => s.filename === filename);
+      if (idx > 0) moveSong(filename, idx - 1);
+    },
+    [flatSelectedSongs, moveSong],
+  );
+
+  const handleMoveDown = useCallback(
+    (filename: string) => {
+      const idx = flatSelectedSongs.findIndex((s) => s.filename === filename);
+      if (idx >= 0 && idx < flatSelectedSongs.length - 1) {
+        moveSong(filename, idx + 1);
+      }
+    },
+    [flatSelectedSongs, moveSong],
+  );
+
+  // --- Acciones del sheet ---------------------------------------------------
+
+  const sheetActions = useMemo<PlaylistAction[]>(() => {
+    const actions: PlaylistAction[] = [
+      {
+        id: 'share-text',
+        icon: 'share',
+        label:
+          Platform.OS === 'web' ||
+          Platform.OS === 'windows' ||
+          Platform.OS === 'macos'
+            ? 'Copiar lista al portapapeles'
+            : 'Compartir lista como texto',
+        description: 'Mensaje con título, tono y autor',
+        onPress: handleShareText,
+      },
+      {
+        id: 'export-file',
+        icon: 'file-upload',
+        label: 'Exportar a archivo (.mcm)',
+        description: 'Incluye el tono cambiado y el orden personalizado',
+        onPress: handleStartExportFile,
+        separator: true,
+      },
+      {
+        id: 'import-file',
+        icon: 'file-download',
+        label: 'Importar desde archivo',
+        onPress: handleImportFile,
+      },
+      {
+        id: 'upload-cloud',
+        icon: 'cloud-upload',
+        label: 'Subir a la nube (código 4 dígitos)',
+        description: lastUploadCode
+          ? `Subida actual: ${lastUploadCode}`
+          : 'Cualquiera con el código podrá importarla',
+        onPress: () => setCodeDialog({ variant: 'cloud-upload' }),
+        separator: true,
+      },
+      {
+        id: 'download-cloud',
+        icon: 'cloud-download',
+        label: 'Descargar desde la nube',
+        onPress: () => setCodeDialog({ variant: 'cloud-download' }),
+      },
+    ];
+
+    if (lastUploadCode) {
+      actions.push(
+        {
+          id: 'change-cloud-code',
+          icon: 'edit',
+          label: 'Cambiar código de la nube',
+          description: `Actual: ${lastUploadCode}`,
+          onPress: () =>
+            setCodeDialog({
+              variant: 'change-code',
+              initial: lastUploadCode,
+            }),
+        },
+        {
+          id: 'delete-cloud',
+          icon: 'cloud-off',
+          label: 'Borrar de la nube',
+          variant: 'danger',
+          onPress: handleDeleteFromCloud,
+        },
+      );
     }
+
+    if (choir.mode === 'off') {
+      actions.push(
+        {
+          id: 'choir-start',
+          icon: 'campaign',
+          label: 'Iniciar sesión de coro (maestro)',
+          description:
+            'Otros dispositivos te siguen con un código de 4 dígitos',
+          onPress: () => setCodeDialog({ variant: 'choir-start' }),
+          separator: true,
+        },
+        {
+          id: 'choir-join',
+          icon: 'headphones',
+          label: 'Unirse a sesión de coro',
+          onPress: () => setCodeDialog({ variant: 'choir-join' }),
+        },
+      );
+    } else {
+      actions.push(
+        {
+          id: 'choir-change-code',
+          icon: 'edit',
+          label: 'Cambiar código del coro',
+          description: `Actual: ${choir.code}${choir.mode === 'slave' ? ' (solo maestro puede cambiarlo)' : ''}`,
+          onPress: () =>
+            setCodeDialog({
+              variant: 'change-code',
+              initial: choir.code ?? undefined,
+            }),
+          separator: true,
+          disabled: choir.mode !== 'master',
+        },
+        {
+          id: 'choir-leave',
+          icon: 'logout',
+          label:
+            choir.mode === 'master'
+              ? 'Cerrar sesión de coro'
+              : 'Salir del coro',
+          variant: 'danger',
+          onPress: () => choir.leave(),
+        },
+      );
+    }
+
+    actions.push({
+      id: 'clear',
+      icon: 'delete-outline',
+      label: 'Vaciar playlist',
+      variant: 'danger',
+      separator: true,
+      onPress: () => {
+        setConfirmDialog({
+          title: '¿Vaciar la playlist?',
+          description: 'Se quitarán todas las canciones seleccionadas.',
+          actions: [
+            {
+              label: 'Vaciar',
+              variant: 'danger',
+              onPress: () => {
+                clearSelection();
+                setConfirmDialog(null);
+              },
+            },
+            {
+              label: 'Cancelar',
+              variant: 'secondary',
+              onPress: () => setConfirmDialog(null),
+            },
+          ],
+        });
+      },
+    });
+
+    return actions;
   }, [
-    navigation,
-    handleExport,
-    handleShareFile,
+    handleShareText,
+    handleStartExportFile,
     handleImportFile,
+    lastUploadCode,
+    choir,
+    handleDeleteFromCloud,
     clearSelection,
-    selectedSongs.length,
-    headerIconColor,
   ]);
 
-  if (loading && selectedSongs.length === 0) {
+  // --- Header ---------------------------------------------------------------
+
+  const headerIconColor =
+    Platform.OS === 'ios' || Platform.OS === 'web' ? '#1a1a1a' : '#fff';
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={() => setShowActions(true)}
+            style={styles.headerIconBtn}
+            hitSlop={6}
+            accessibilityLabel="Acciones"
+          >
+            <MaterialIcons
+              name="more-horiz"
+              size={24}
+              color={headerIconColor}
+            />
+          </TouchableOpacity>
+        </View>
+      ),
+    });
+  }, [navigation, headerIconColor, styles]);
+
+  // --- Render ---------------------------------------------------------------
+
+  if (loading && selectedSongs.length === 0 && isHydrated) {
     return <ProgressWithMessage message="Cargando canciones..." />;
   }
 
-  if (selectedSongs.length === 0) {
-    return (
-      <View style={styles.emptyContainer}>
-        <View style={styles.emptyContent}>
-          <View style={styles.emptyIconContainer}>
-            <MaterialIcons
-              name="queue-music"
-              size={56}
-              color={isDark ? '#636366' : '#C7C7CC'}
-            />
-          </View>
-          <Text style={styles.emptyTitle}>Sin canciones seleccionadas</Text>
-          <Text style={styles.emptyDescription}>
-            Desliza una canción hacia la izquierda para seleccionarla o usa el
-            botón + en la pantalla de detalle.
-          </Text>
+  const submitForVariant = (variant: CodeDialogVariant) => {
+    switch (variant) {
+      case 'cloud-upload':
+        return handleUploadToCloud;
+      case 'cloud-download':
+        return handleDownloadFromCloud;
+      case 'choir-start':
+        return handleStartChoir;
+      case 'choir-join':
+        return handleJoinChoir;
+      case 'change-code':
+        return lastUploadCode
+          ? handleChangeCloudCode
+          : choir.mode === 'master'
+            ? handleChangeChoirCode
+            : async () => {};
+    }
+  };
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyContainer}>
+      <View style={styles.emptyContent}>
+        <View style={styles.emptyIconContainer}>
+          <MaterialIcons
+            name="queue-music"
+            size={56}
+            color={isDark ? '#636366' : '#C7C7CC'}
+          />
         </View>
+        <Text style={styles.emptyTitle}>Sin canciones seleccionadas</Text>
+        <Text style={styles.emptyDescription}>
+          Desliza una canción hacia la izquierda para añadirla o usa el botón +
+          en la pantalla de detalle.
+        </Text>
+      </View>
+      <View style={{ gap: 10, marginBottom: Platform.OS === 'ios' ? 100 : 20 }}>
         <PressableFeedback
           onPress={handleImportFile}
           style={styles.importButton}
@@ -527,43 +1021,221 @@ const SelectedSongsScreen: React.FC = () => {
             size={20}
             color={isDark ? '#7AB3FF' : '#253883'}
           />
-          <Text style={styles.importButtonText}>Importar playlist</Text>
+          <Text style={styles.importButtonText}>Importar desde archivo</Text>
+        </PressableFeedback>
+        <PressableFeedback
+          onPress={() => setCodeDialog({ variant: 'cloud-download' })}
+          style={styles.importButton}
+        >
+          <PressableFeedback.Highlight />
+          <MaterialIcons
+            name="cloud-download"
+            size={20}
+            color={isDark ? '#7AB3FF' : '#253883'}
+          />
+          <Text style={styles.importButtonText}>Descargar con código</Text>
+        </PressableFeedback>
+        <PressableFeedback
+          onPress={() => setCodeDialog({ variant: 'choir-join' })}
+          style={styles.importButton}
+        >
+          <PressableFeedback.Highlight />
+          <MaterialIcons
+            name="headphones"
+            size={20}
+            color={isDark ? '#7AB3FF' : '#253883'}
+          />
+          <Text style={styles.importButtonText}>Unirse a un coro</Text>
         </PressableFeedback>
       </View>
-    );
-  }
-
-  const ListCountHeader = () => (
-    <View style={styles.countHeader}>
-      <Text style={styles.selectionCount}>
-        {selectedSongs.length}{' '}
-        {selectedSongs.length === 1 ? 'canción' : 'canciones'}
-      </Text>
     </View>
   );
 
+  const renderHeaderBar = () => {
+    const transposedCount = selectedSongs.filter(
+      (s) => s.transpose !== 0,
+    ).length;
+    return (
+      <View>
+        <ChoirSessionBanner />
+        <View style={styles.summaryRow}>
+          <View>
+            <Text style={styles.selectionCount}>
+              {selectedSongs.length}{' '}
+              {selectedSongs.length === 1 ? 'canción' : 'canciones'}
+              {transposedCount > 0
+                ? ` · ${transposedCount} con tono cambiado`
+                : ''}
+            </Text>
+            {lastUploadCode ? (
+              <Text style={styles.subInfo}>
+                ☁️ Subida con código {lastUploadCode}
+              </Text>
+            ) : null}
+          </View>
+          {selectedSongs.length > 1 ? (
+            <View style={styles.viewToggle}>
+              <TouchableOpacity
+                onPress={() => setViewMode('category')}
+                style={[
+                  styles.viewToggleBtn,
+                  viewMode === 'category' && styles.viewToggleBtnActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.viewToggleText,
+                    viewMode === 'category' && styles.viewToggleTextActive,
+                  ]}
+                >
+                  Categoría
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => setViewMode('manual')}
+                style={[
+                  styles.viewToggleBtn,
+                  viewMode === 'manual' && styles.viewToggleBtnActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.viewToggleText,
+                    viewMode === 'manual' && styles.viewToggleTextActive,
+                  ]}
+                >
+                  Orden libre
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+        </View>
+      </View>
+    );
+  };
+
+  const renderCategoryGroup = ({ item }: { item: CategorizedSongs }) => (
+    <View style={styles.categoryContainer}>
+      <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
+      {item.data.map((song) => {
+        const isNow = choir.session?.current?.filename === song.filename;
+        return (
+          <PlaylistRow
+            key={song.filename}
+            song={song}
+            transpose={song.transpose}
+            isNowPlaying={isNow}
+            onPress={() => handleSongPress(song)}
+            onRemove={() => removeSong(song.filename)}
+          />
+        );
+      })}
+    </View>
+  );
+
+  const renderManualItem = ({
+    item,
+    index,
+  }: {
+    item: (typeof flatSelectedSongs)[number];
+    index: number;
+  }) => {
+    const isNow = choir.session?.current?.filename === item.filename;
+    return (
+      <PlaylistRow
+        song={item}
+        transpose={item.transpose}
+        position={index + 1}
+        showReorderControls
+        canMoveUp={index > 0}
+        canMoveDown={index < flatSelectedSongs.length - 1}
+        onMoveUp={() => handleMoveUp(item.filename)}
+        onMoveDown={() => handleMoveDown(item.filename)}
+        isNowPlaying={isNow}
+        onPress={() => handleSongPress(item)}
+        onRemove={() => removeSong(item.filename)}
+      />
+    );
+  };
+
+  const isEmpty = selectedSongs.length === 0;
+
   return (
     <View style={styles.container}>
-      <FlatList
-        data={categorizedSelectedSongs}
-        renderItem={renderCategory}
-        keyExtractor={(item) => item.categoryTitle}
-        ListHeaderComponent={<ListCountHeader />}
-        contentContainerStyle={styles.listContentContainer}
-        contentInsetAdjustmentBehavior="automatic"
-        showsVerticalScrollIndicator={false}
+      {isEmpty ? (
+        <>
+          <ChoirSessionBanner />
+          {renderEmptyState()}
+        </>
+      ) : viewMode === 'manual' ? (
+        <FlatList
+          data={flatSelectedSongs}
+          renderItem={renderManualItem}
+          keyExtractor={(it) => it.filename}
+          ListHeaderComponent={renderHeaderBar()}
+          contentContainerStyle={styles.listContentContainer}
+          contentInsetAdjustmentBehavior="automatic"
+          showsVerticalScrollIndicator={false}
+        />
+      ) : (
+        <FlatList
+          data={categorized}
+          renderItem={renderCategoryGroup}
+          keyExtractor={(it) => it.categoryKey}
+          ListHeaderComponent={renderHeaderBar()}
+          contentContainerStyle={styles.listContentContainer}
+          contentInsetAdjustmentBehavior="automatic"
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+
+      <PlaylistActionsSheet
+        visible={showActions}
+        actions={sheetActions}
+        onClose={() => setShowActions(false)}
+        title={
+          choir.mode !== 'off'
+            ? `Coro ${choir.code} · ${choir.mode === 'master' ? 'Maestro' : 'Esclavo'}`
+            : 'Acciones'
+        }
       />
 
-      {/* Export modal — native RN Modal works reliably on web, iOS and Android.
-          The previous heroui Dialog had inconsistent input focus and overlay
-          behaviour on web that prevented downloads from firing. */}
+      {codeDialog ? (
+        <CodeInputDialog
+          visible
+          variant={codeDialog.variant}
+          initialCode={codeDialog.initial}
+          onClose={() => setCodeDialog(null)}
+          onSubmit={async (code) => {
+            const fn = submitForVariant(codeDialog.variant);
+            try {
+              await fn(code);
+            } catch (e: any) {
+              if (e?.message === '__handled__') return;
+              throw e;
+            }
+          }}
+        />
+      ) : null}
+
+      {confirmDialog ? (
+        <ConfirmChoiceDialog
+          visible
+          title={confirmDialog.title}
+          description={confirmDialog.description}
+          actions={confirmDialog.actions}
+          onClose={() => setConfirmDialog(null)}
+        />
+      ) : null}
+
+      {/* Modal de exportar a archivo (nombre del .mcm). */}
       <Modal
-        visible={showExportModal}
+        visible={showExportFileModal}
         transparent
         animationType="fade"
-        onRequestClose={() => setShowExportModal(false)}
+        onRequestClose={() => setShowExportFileModal(false)}
       >
-        <TouchableWithoutFeedback onPress={() => setShowExportModal(false)}>
+        <TouchableWithoutFeedback onPress={() => setShowExportFileModal(false)}>
           <View style={styles.modalBackdrop}>
             <TouchableWithoutFeedback>
               <View style={styles.modalCard}>
@@ -580,22 +1252,22 @@ const SelectedSongsScreen: React.FC = () => {
                   selectTextOnFocus
                   style={styles.modalInput}
                   onSubmitEditing={() => {
-                    if (exportFileName.trim()) handleConfirmExport();
+                    if (exportFileName.trim()) handleConfirmExportFile();
                   }}
                   returnKeyType="done"
                 />
                 <Text style={styles.modalNote}>
-                  Se exportará como archivo .mcm
+                  Se exportará como archivo .mcm (incluye tono y orden)
                 </Text>
                 <View style={styles.modalButtons}>
                   <TouchableOpacity
-                    onPress={() => setShowExportModal(false)}
+                    onPress={() => setShowExportFileModal(false)}
                     style={[styles.modalBtn, styles.modalBtnSecondary]}
                   >
                     <Text style={styles.modalBtnSecondaryText}>Cancelar</Text>
                   </TouchableOpacity>
                   <TouchableOpacity
-                    onPress={handleConfirmExport}
+                    onPress={handleConfirmExportFile}
                     disabled={!exportFileName.trim()}
                     style={[
                       styles.modalBtn,
@@ -622,18 +1294,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       flex: 1,
       backgroundColor: isDark ? '#1C1C1E' : '#F2F2F7',
     },
-    countHeader: {
-      paddingHorizontal: 20,
-      paddingTop: 12,
-      paddingBottom: 4,
-    },
-    selectionCount: {
-      fontSize: 13,
-      fontWeight: '700',
-      color: isDark ? '#8E8E93' : '#6B6B70',
-      letterSpacing: 0.6,
-      textTransform: 'uppercase',
-    },
     headerActions: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -646,6 +1306,61 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       borderRadius: 18,
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    summaryRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 20,
+      paddingTop: 12,
+      paddingBottom: 8,
+      gap: 8,
+    },
+    selectionCount: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: isDark ? '#8E8E93' : '#6B6B70',
+      letterSpacing: 0.5,
+      textTransform: 'uppercase',
+    },
+    subInfo: {
+      fontSize: 12,
+      color: isDark ? '#7AB3FF' : '#253883',
+      marginTop: 3,
+      fontWeight: '600',
+    },
+    viewToggle: {
+      flexDirection: 'row',
+      backgroundColor: isDark ? '#2C2C2E' : '#E5E5EA',
+      borderRadius: 8,
+      padding: 2,
+    },
+    viewToggleBtn: {
+      paddingVertical: 6,
+      paddingHorizontal: 10,
+      borderRadius: 6,
+    },
+    viewToggleBtnActive: {
+      backgroundColor: isDark ? '#1A2744' : '#FFFFFF',
+      ...Platform.select({
+        web: { boxShadow: '0 1px 3px rgba(0,0,0,0.1)' },
+        default: {
+          shadowColor: '#000',
+          shadowOpacity: 0.1,
+          shadowOffset: { width: 0, height: 1 },
+          shadowRadius: 2,
+          elevation: 1,
+        },
+      }),
+    },
+    viewToggleText: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: isDark ? '#AEAEB2' : '#636366',
+    },
+    viewToggleTextActive: {
+      color: isDark ? '#7AB3FF' : '#253883',
+      fontWeight: '700',
     },
     listContentContainer: {
       paddingBottom: Platform.OS === 'ios' ? 100 : 24,
@@ -738,7 +1453,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       borderRadius: radii.lg,
       backgroundColor: isDark ? '#1A2744' : '#E8F0FE',
       gap: 8,
-      marginBottom: Platform.OS === 'ios' ? 100 : 20,
     },
     importButtonText: {
       fontSize: 16,
@@ -759,9 +1473,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       borderRadius: 18,
       padding: 22,
       ...Platform.select({
-        web: {
-          boxShadow: '0 12px 40px rgba(0,0,0,0.25)',
-        },
+        web: { boxShadow: '0 12px 40px rgba(0,0,0,0.25)' },
         default: {
           shadowColor: '#000',
           shadowOpacity: 0.25,

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -161,15 +161,20 @@ const SelectedSongsScreen: React.FC = () => {
     }
   }, []);
 
-  // Auto-import si llegamos con ?p=XXXX en web (deep link).
+  // Auto-import / auto-join si llegamos con ?p=XXXX o ?c=YYYY en web (deep link).
   const autoImportAttempted = useRef(false);
   useEffect(() => {
     if (autoImportAttempted.current) return;
     const params: any = (route?.params as any) || {};
-    const code = params.p ?? params.code;
-    if (typeof code === 'string' && /^\d{4}$/.test(code)) {
+    const playlistCode = params.p ?? params.code;
+    const choirCode = params.c;
+
+    if (typeof playlistCode === 'string' && /^\d{4}$/.test(playlistCode)) {
       autoImportAttempted.current = true;
-      void handleDownloadFromCloud(code);
+      void handleDownloadFromCloud(playlistCode);
+    } else if (typeof choirCode === 'string' && /^\d{4}$/.test(choirCode)) {
+      autoImportAttempted.current = true;
+      void handleJoinChoir(choirCode);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -604,9 +609,45 @@ const SelectedSongsScreen: React.FC = () => {
 
   const showUploadSuccess = useCallback(
     (code: string) => {
-      const url = `${WEB_BASE_URL}/cancionero/seleccionadas?p=${code}`;
+      const url = `${WEB_BASE_URL}/playlist?p=${code}`;
       setConfirmDialog({
         title: `¡Subida! Código ${code}`,
+        description: `Compártelo o copia el enlace:\n${url}`,
+        actions: [
+          {
+            label: 'Copiar enlace',
+            variant: 'primary',
+            onPress: () => {
+              void Clipboard.setStringAsync(url);
+              toast.show({ label: 'Enlace copiado' });
+              setConfirmDialog(null);
+            },
+          },
+          {
+            label: 'Copiar solo el código',
+            variant: 'secondary',
+            onPress: () => {
+              void Clipboard.setStringAsync(code);
+              toast.show({ label: 'Código copiado' });
+              setConfirmDialog(null);
+            },
+          },
+          {
+            label: 'Cerrar',
+            variant: 'secondary',
+            onPress: () => setConfirmDialog(null),
+          },
+        ],
+      });
+    },
+    [toast],
+  );
+
+  const showChoirSuccess = useCallback(
+    (code: string) => {
+      const url = `${WEB_BASE_URL}/coro?c=${code}`;
+      setConfirmDialog({
+        title: `¡Coro iniciado! Código ${code}`,
         description: `Compártelo o copia el enlace:\n${url}`,
         actions: [
           {
@@ -711,7 +752,7 @@ const SelectedSongsScreen: React.FC = () => {
                 setConfirmDialog(null);
                 try {
                   await choir.startAsMaster(code, selectedSongs);
-                  toast.show({ label: `Sesión coro iniciada: ${code}` });
+                  showChoirSuccess(code);
                 } catch (e: any) {
                   toast.show({ label: e?.message ?? 'Error al iniciar' });
                 }
@@ -736,9 +777,9 @@ const SelectedSongsScreen: React.FC = () => {
       }
       await choir.startAsMaster(code, selectedSongs);
       setCodeDialog(null);
-      toast.show({ label: `Sesión coro iniciada: ${code}` });
+      showChoirSuccess(code);
     },
-    [choir, selectedSongs, toast],
+    [choir, selectedSongs, toast, showChoirSuccess],
   );
 
   const handleJoinChoir = useCallback(

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -798,15 +798,33 @@ const SelectedSongsScreen: React.FC = () => {
           Platform.OS === 'windows' ||
           Platform.OS === 'macos'
             ? 'Copiar lista al portapapeles'
-            : 'Compartir lista como texto',
-        description: 'Mensaje con título, tono y autor',
+            : 'Compartir mensaje con las canciones',
+        description: 'Texto con canción, tono y número',
         onPress: handleShareText,
+      },
+      {
+        id: 'upload-cloud',
+        icon: 'cloud-upload',
+        label: 'Compartir Playlist (código 4 dígitos)',
+        description: lastUploadCode
+          ? `Código actual: ${lastUploadCode}`
+          : 'Cualquiera con el código podrá importarla',
+        onPress: () => setCodeDialog({ variant: 'cloud-upload' }),
+        separator: true,
+      },
+      {
+        id: 'download-cloud',
+        icon: 'cloud-download',
+        label: 'Importar Playlist',
+        description: 'Introduce el código de 4 dígitos que te han pasado',
+
+        onPress: () => setCodeDialog({ variant: 'cloud-download' }),
       },
       {
         id: 'export-file',
         icon: 'file-upload',
         label: 'Exportar a archivo (.mcm)',
-        description: 'Incluye el tono cambiado y el orden personalizado',
+        // description: 'Incluye el tono cambiado y el orden personalizado',
         onPress: handleStartExportFile,
         separator: true,
       },
@@ -816,22 +834,6 @@ const SelectedSongsScreen: React.FC = () => {
         label: 'Importar desde archivo',
         onPress: handleImportFile,
       },
-      {
-        id: 'upload-cloud',
-        icon: 'cloud-upload',
-        label: 'Subir a la nube (código 4 dígitos)',
-        description: lastUploadCode
-          ? `Subida actual: ${lastUploadCode}`
-          : 'Cualquiera con el código podrá importarla',
-        onPress: () => setCodeDialog({ variant: 'cloud-upload' }),
-        separator: true,
-      },
-      {
-        id: 'download-cloud',
-        icon: 'cloud-download',
-        label: 'Descargar desde la nube',
-        onPress: () => setCodeDialog({ variant: 'cloud-download' }),
-      },
     ];
 
     if (lastUploadCode) {
@@ -839,7 +841,7 @@ const SelectedSongsScreen: React.FC = () => {
         {
           id: 'change-cloud-code',
           icon: 'edit',
-          label: 'Cambiar código de la nube',
+          label: 'Cambiar código de la playlist',
           description: `Actual: ${lastUploadCode}`,
           onPress: () =>
             setCodeDialog({
@@ -850,7 +852,7 @@ const SelectedSongsScreen: React.FC = () => {
         {
           id: 'delete-cloud',
           icon: 'cloud-off',
-          label: 'Borrar de la nube',
+          label: 'Borrar playlist de la nube',
           variant: 'danger',
           onPress: handleDeleteFromCloud,
         },
@@ -862,7 +864,7 @@ const SelectedSongsScreen: React.FC = () => {
         {
           id: 'choir-start',
           icon: 'campaign',
-          label: 'Iniciar sesión de coro (maestro)',
+          label: 'Iniciar sesión de coro (ser líder)',
           description:
             'Otros dispositivos te siguen con un código de 4 dígitos',
           onPress: () => setCodeDialog({ variant: 'choir-start' }),
@@ -872,6 +874,7 @@ const SelectedSongsScreen: React.FC = () => {
           id: 'choir-join',
           icon: 'headphones',
           label: 'Unirse a sesión de coro',
+          description: 'Introduces un código y sigues las canciones del líder',
           onPress: () => setCodeDialog({ variant: 'choir-join' }),
         },
       );
@@ -881,7 +884,7 @@ const SelectedSongsScreen: React.FC = () => {
           id: 'choir-change-code',
           icon: 'edit',
           label: 'Cambiar código del coro',
-          description: `Actual: ${choir.code}${choir.mode === 'slave' ? ' (solo maestro puede cambiarlo)' : ''}`,
+          description: `Actual: ${choir.code}${choir.mode === 'slave' ? ' (solo el líder puede cambiarlo)' : ''}`,
           onPress: () =>
             setCodeDialog({
               variant: 'change-code',
@@ -1012,18 +1015,6 @@ const SelectedSongsScreen: React.FC = () => {
       </View>
       <View style={{ gap: 10, marginBottom: Platform.OS === 'ios' ? 100 : 20 }}>
         <PressableFeedback
-          onPress={handleImportFile}
-          style={styles.importButton}
-        >
-          <PressableFeedback.Highlight />
-          <MaterialIcons
-            name="file-download"
-            size={20}
-            color={isDark ? '#7AB3FF' : '#253883'}
-          />
-          <Text style={styles.importButtonText}>Importar desde archivo</Text>
-        </PressableFeedback>
-        <PressableFeedback
           onPress={() => setCodeDialog({ variant: 'cloud-download' })}
           style={styles.importButton}
         >
@@ -1033,7 +1024,9 @@ const SelectedSongsScreen: React.FC = () => {
             size={20}
             color={isDark ? '#7AB3FF' : '#253883'}
           />
-          <Text style={styles.importButtonText}>Descargar con código</Text>
+          <Text style={styles.importButtonText}>
+            Importar playlist con código
+          </Text>
         </PressableFeedback>
         <PressableFeedback
           onPress={() => setCodeDialog({ variant: 'choir-join' })}
@@ -1045,7 +1038,19 @@ const SelectedSongsScreen: React.FC = () => {
             size={20}
             color={isDark ? '#7AB3FF' : '#253883'}
           />
-          <Text style={styles.importButtonText}>Unirse a un coro</Text>
+          <Text style={styles.importButtonText}>Unirme a un coro</Text>
+        </PressableFeedback>
+        <PressableFeedback
+          onPress={handleImportFile}
+          style={styles.importButton}
+        >
+          <PressableFeedback.Highlight />
+          <MaterialIcons
+            name="file-download"
+            size={20}
+            color={isDark ? '#7AB3FF' : '#253883'}
+          />
+          <Text style={styles.importButtonText}>Importar desde archivo</Text>
         </PressableFeedback>
       </View>
     </View>
@@ -1055,6 +1060,12 @@ const SelectedSongsScreen: React.FC = () => {
     const transposedCount = selectedSongs.filter(
       (s) => s.transpose !== 0,
     ).length;
+    /* Eliminado este trozo
+                  {transposedCount > 0
+                ? ` · ${transposedCount} con tono cambiado`
+                : ''} 
+                
+                */
     return (
       <View>
         <ChoirSessionBanner />
@@ -1063,13 +1074,10 @@ const SelectedSongsScreen: React.FC = () => {
             <Text style={styles.selectionCount}>
               {selectedSongs.length}{' '}
               {selectedSongs.length === 1 ? 'canción' : 'canciones'}
-              {transposedCount > 0
-                ? ` · ${transposedCount} con tono cambiado`
-                : ''}
             </Text>
             {lastUploadCode ? (
               <Text style={styles.subInfo}>
-                ☁️ Subida con código {lastUploadCode}
+                ☁️ Guardada con código {lastUploadCode}
               </Text>
             ) : null}
           </View>
@@ -1088,7 +1096,7 @@ const SelectedSongsScreen: React.FC = () => {
                     viewMode === 'category' && styles.viewToggleTextActive,
                   ]}
                 >
-                  Categoría
+                  Por categoría
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -1104,7 +1112,7 @@ const SelectedSongsScreen: React.FC = () => {
                     viewMode === 'manual' && styles.viewToggleTextActive,
                   ]}
                 >
-                  Orden libre
+                  Orden ajustado
                 </Text>
               </TouchableOpacity>
             </View>
@@ -1257,7 +1265,7 @@ const SelectedSongsScreen: React.FC = () => {
                   returnKeyType="done"
                 />
                 <Text style={styles.modalNote}>
-                  Se exportará como archivo .mcm (incluye tono y orden)
+                  Se exportará como archivo .mcm para compartirlo
                 </Text>
                 <View style={styles.modalButtons}>
                   <TouchableOpacity

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -9,9 +9,11 @@ import SongControls from '../../components/SongControls';
 import { RouteProp, NavigationProp } from '@react-navigation/native';
 import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSelectedSongs } from '../../contexts/SelectedSongsContext';
+import { useChoirSession } from '../../contexts/ChoirSessionContext';
 import { IconSymbol } from '../../components/ui/IconSymbol';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useColorScheme } from '../../hooks/useColorScheme';
+import ChoirSessionBanner from '../../components/playlist/ChoirSessionBanner';
 import * as Clipboard from 'expo-clipboard';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
@@ -58,7 +60,14 @@ export default function SongDetailScreen({
     source,
     firebaseCategory,
   } = route.params;
-  const { addSong, removeSong, isSongSelected } = useSelectedSongs();
+  const {
+    addSong,
+    removeSong,
+    isSongSelected,
+    getSelectedSong,
+    setTranspose: setSelectionTranspose,
+  } = useSelectedSongs();
+  const choir = useChoirSession();
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const insets = useSafeAreaInsets();
@@ -73,7 +82,24 @@ export default function SongDetailScreen({
 
   const [isFileLoading, setIsFileLoading] = useState(true);
   const [originalChordPro, setOriginalChordPro] = useState<string | null>(null);
-  const [currentTranspose, setCurrentTranspose] = useState(0);
+  // Si la canción está en la selección, su `transpose` vive en el contexto
+  // (single source of truth). Si no, usamos este estado local efímero.
+  const selectedMeta = getSelectedSong(filename);
+  const [localTranspose, setLocalTranspose] = useState(0);
+  // En modo coro:
+  //  - el MAESTRO publica el transpose visible (local o seleccionado).
+  //  - el ESCLAVO usa el transpose del maestro salvo que tenga override.
+  const masterCurrent = choir.session?.current;
+  const slaveTransposeFromChoir =
+    choir.mode === 'slave' && masterCurrent?.filename === filename
+      ? (choir.overrideTranspose ?? masterCurrent.transpose)
+      : null;
+  const currentTranspose =
+    slaveTransposeFromChoir !== null
+      ? slaveTransposeFromChoir
+      : selectedMeta
+        ? selectedMeta.transpose
+        : localTranspose;
 
   const slideAnim = useRef(new Animated.Value(0)).current;
   const screenWidth = Dimensions.get('window').width;
@@ -151,7 +177,33 @@ export default function SongDetailScreen({
       setOriginalChordPro(null);
       setIsFileLoading(false);
     }
+    // Al cambiar de canción reseteamos el transpose efímero local.
+    setLocalTranspose(0);
   }, [filename, content]);
+
+  // Modo coro - MAESTRO: cuando entro a una canción, lo publico para los
+  // esclavos junto con todos los metadatos para que la puedan renderizar
+  // sin tener que buscarla en su cantoral local.
+  useEffect(() => {
+    if (choir.mode !== 'master' || !filename) return;
+    void choir.publishCurrent({
+      filename,
+      transpose: currentTranspose,
+      screen: 'detail',
+      title: _navScreenTitle,
+      author,
+      songKey: key,
+      capo,
+      content,
+      firebaseCategory,
+    });
+    // Solo al montar / cambiar de canción, no en cada cambio de transpose
+    // (eso lo hace explícitamente handleSetTranspose).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [choir.mode, filename]);
+
+  // (la navegación del esclavo se gestiona en `cancionero.tsx` mediante
+  //  un observador del contexto coro que opera sobre el navigator del stack)
 
   const handleToggleChords = () =>
     setSettings({ chordsVisible: !chordsVisible });
@@ -159,7 +211,27 @@ export default function SongDetailScreen({
     let newTranspose = semitones;
     if (newTranspose >= 12 || newTranspose <= -12)
       newTranspose = newTranspose % 12;
-    setCurrentTranspose(newTranspose);
+
+    if (slaveTransposeFromChoir !== null) {
+      // Esclavo: cambiar tono = override local (no afecta a la sesión remota).
+      choir.setOverrideTranspose(newTranspose);
+      return;
+    }
+    if (selectedMeta) {
+      // Persistir en la selección.
+      setSelectionTranspose(filename, newTranspose);
+    } else {
+      setLocalTranspose(newTranspose);
+    }
+    // Si soy maestro, publico el cambio aunque la canción no esté seleccionada
+    // (el maestro puede abrir cualquier canción del cantoral).
+    if (choir.mode === 'master') {
+      void choir.publishCurrent({
+        filename,
+        transpose: newTranspose,
+        screen: 'detail',
+      });
+    }
   };
   const handleSetFontSize = (newSizeEm: number) =>
     setSettings({ fontSize: newSizeEm });
@@ -260,6 +332,7 @@ export default function SongDetailScreen({
       ]}
     >
       {isIOS && <View style={{ height: insets.top + 52 }} />}
+      <ChoirSessionBanner />
       <SongDisplay
         songHtml={songHtml}
         isLoading={isFileLoading || isSongProcessing || isLoadingSettings}

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -12,6 +12,8 @@ import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useSettings } from '../contexts/SettingsContext';
 import { convertChord } from '../utils/chordNotation';
+import { transposeKey, transposeLabel } from '../utils/transposeKey';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 // Type for song data
 interface Song {
@@ -33,7 +35,8 @@ interface SongListItemProps {
 
 const SongListItem: React.FC<SongListItemProps> = React.memo(
   function SongListItem({ song, onPress, isSearchAllMode = false }) {
-    const { addSong, removeSong, isSongSelected } = useSelectedSongs();
+    const { addSong, removeSong, isSongSelected, getSelectedSong } =
+      useSelectedSongs();
     const { settings } = useSettings();
     const { notation } = settings;
     const scheme = useColorScheme();
@@ -41,6 +44,10 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
     const isDark = scheme === 'dark';
     const swipeableRow = useRef<Swipeable>(null);
     const isSelected = isSongSelected(song.filename);
+    const selectedMeta = isSelected
+      ? getSelectedSong(song.filename)
+      : undefined;
+    const selectedTranspose = selectedMeta?.transpose ?? 0;
     const backgroundColorAnim = useRef(
       new Animated.Value(isSelected ? 1 : 0),
     ).current;
@@ -207,11 +214,38 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
                 </View>
               ) : null}
               {song.key ? (
-                <View style={styles.keyPill}>
-                  <Text style={styles.keyText}>
-                    {convertChord(song.key.toUpperCase(), notation)}
-                  </Text>
-                </View>
+                selectedTranspose !== 0 ? (
+                  <View style={styles.toneTransposedWrap}>
+                    <Text style={styles.toneOriginalStriked}>
+                      {convertChord(song.key.toUpperCase(), notation)}
+                    </Text>
+                    <MaterialIcons
+                      name="arrow-forward"
+                      size={12}
+                      color={isDark ? '#8E8E93' : '#8E8E93'}
+                    />
+                    <View style={styles.keyPillTransposed}>
+                      <Text style={styles.keyTextTransposed}>
+                        {convertChord(
+                          transposeKey(
+                            song.key.toUpperCase(),
+                            selectedTranspose,
+                          ),
+                          notation,
+                        )}
+                      </Text>
+                      <Text style={styles.transposeBadge}>
+                        {transposeLabel(selectedTranspose)}
+                      </Text>
+                    </View>
+                  </View>
+                ) : (
+                  <View style={styles.keyPill}>
+                    <Text style={styles.keyText}>
+                      {convertChord(song.key.toUpperCase(), notation)}
+                    </Text>
+                  </View>
+                )
               ) : null}
             </View>
           </TouchableOpacity>
@@ -322,6 +356,42 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       fontSize: 13,
       fontWeight: '700',
       color: isDark ? '#7AB3FF' : '#253883',
+    },
+    toneTransposedWrap: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    toneOriginalStriked: {
+      fontSize: 12,
+      fontWeight: '500',
+      color: isDark ? '#636366' : '#A0A0A8',
+      textDecorationLine: 'line-through',
+    },
+    keyPillTransposed: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      paddingHorizontal: 7,
+      paddingVertical: 3,
+      borderRadius: 6,
+      backgroundColor: '#FFF4DA',
+      borderWidth: 1,
+      borderColor: '#F4C11E',
+    },
+    keyTextTransposed: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: '#7A5A00',
+    },
+    transposeBadge: {
+      fontSize: 10,
+      fontWeight: '800',
+      color: '#9D5C00',
+      fontVariant: ['tabular-nums'],
+      backgroundColor: 'rgba(255,255,255,0.7)',
+      paddingHorizontal: 3,
+      borderRadius: 3,
     },
     rightAction: {
       backgroundColor: '#34C759',

--- a/mcm-app/components/playlist/ChoirSessionBanner.tsx
+++ b/mcm-app/components/playlist/ChoirSessionBanner.tsx
@@ -14,8 +14,11 @@ import {
   StyleSheet,
   TouchableOpacity,
   Platform,
+  Share,
 } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useToast } from 'heroui-native';
 import { useChoirSession } from '@/contexts/ChoirSessionContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { transposeLabel } from '@/utils/transposeKey';
@@ -39,8 +42,25 @@ const ChoirSessionBanner: React.FC<Props> = ({ floating, topOffset = 0 }) => {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const styles = useMemo(() => createStyles(isDark), [isDark]);
+  const { toast } = useToast();
 
   if (mode === 'off' || !code) return null;
+
+  const handleShare = () => {
+    const url = `https://mcm.expo.app/coro?c=${code}`;
+    const desktopLike =
+      Platform.OS === 'web' ||
+      Platform.OS === 'windows' ||
+      Platform.OS === 'macos';
+    if (desktopLike) {
+      void Clipboard.setStringAsync(url);
+      toast.show({ label: 'Enlace copiado al portapapeles' });
+    } else {
+      Share.share({ message: `Únete al coro con este enlace:\n${url}` }).catch(
+        () => {},
+      );
+    }
+  };
 
   const masterTranspose = session?.current?.transpose ?? 0;
   const isOverriding = overrideTranspose !== null;
@@ -73,7 +93,7 @@ const ChoirSessionBanner: React.FC<Props> = ({ floating, topOffset = 0 }) => {
         </View>
         <View style={styles.textBlock}>
           <Text style={styles.role}>
-            {mode === 'master' ? 'Maestro de coro' : 'Coro'} · {code}
+            {mode === 'master' ? 'Líder de coro' : 'Coro'} · {code}
           </Text>
           <Text style={styles.detail}>
             {session?.current ? (
@@ -92,6 +112,13 @@ const ChoirSessionBanner: React.FC<Props> = ({ floating, topOffset = 0 }) => {
       </View>
 
       <View style={styles.right}>
+        <TouchableOpacity
+          style={styles.leaveBtn}
+          onPress={handleShare}
+          hitSlop={6}
+        >
+          <MaterialIcons name="share" size={16} color="#fff" />
+        </TouchableOpacity>
         {mode === 'slave' && session?.current ? (
           isOverriding ? (
             <TouchableOpacity

--- a/mcm-app/components/playlist/ChoirSessionBanner.tsx
+++ b/mcm-app/components/playlist/ChoirSessionBanner.tsx
@@ -1,0 +1,207 @@
+/**
+ * Banner persistente del modo Coro. Se muestra en SongDetailScreen
+ * (y desde cualquier sitio donde lo añadamos). Indica:
+ *   - el código activo,
+ *   - el rol (maestro o esclavo),
+ *   - el tono que está dictando el maestro (si hay canción actual),
+ *   - botón "Usar mi tono" para que el esclavo se desincronice del tono,
+ *   - botón "Salir" / "Cerrar sesión".
+ */
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useChoirSession } from '@/contexts/ChoirSessionContext';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { transposeLabel } from '@/utils/transposeKey';
+
+interface Props {
+  /** Si true, el banner se muestra en posición fija arriba (no en flujo). */
+  floating?: boolean;
+  /** Margen superior cuando es floating (típicamente insets.top). */
+  topOffset?: number;
+}
+
+const ChoirSessionBanner: React.FC<Props> = ({ floating, topOffset = 0 }) => {
+  const {
+    mode,
+    code,
+    session,
+    overrideTranspose,
+    setOverrideTranspose,
+    leave,
+  } = useChoirSession();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+
+  if (mode === 'off' || !code) return null;
+
+  const masterTranspose = session?.current?.transpose ?? 0;
+  const isOverriding = overrideTranspose !== null;
+  const effectiveTranspose = isOverriding
+    ? overrideTranspose!
+    : masterTranspose;
+
+  return (
+    <View
+      style={[
+        styles.banner,
+        floating
+          ? {
+              position: 'absolute',
+              top: topOffset,
+              left: 8,
+              right: 8,
+              zIndex: 50,
+            }
+          : undefined,
+      ]}
+    >
+      <View style={styles.left}>
+        <View style={styles.icon}>
+          <MaterialIcons
+            name={mode === 'master' ? 'campaign' : 'headphones'}
+            size={16}
+            color="#fff"
+          />
+        </View>
+        <View style={styles.textBlock}>
+          <Text style={styles.role}>
+            {mode === 'master' ? 'Maestro de coro' : 'Coro'} · {code}
+          </Text>
+          <Text style={styles.detail}>
+            {session?.current ? (
+              <>
+                Tono:{' '}
+                {effectiveTranspose === 0
+                  ? 'original'
+                  : `${transposeLabel(effectiveTranspose)} st`}
+                {isOverriding ? ' (local)' : ''}
+              </>
+            ) : (
+              <>Sin canción aún</>
+            )}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.right}>
+        {mode === 'slave' && session?.current ? (
+          isOverriding ? (
+            <TouchableOpacity
+              style={styles.actionBtn}
+              onPress={() => setOverrideTranspose(null)}
+            >
+              <MaterialIcons name="sync" size={16} color="#fff" />
+              <Text style={styles.actionText}>Sincronizar</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              style={styles.actionBtn}
+              onPress={() => setOverrideTranspose(masterTranspose)}
+            >
+              <MaterialIcons name="tune" size={16} color="#fff" />
+              <Text style={styles.actionText}>Mi tono</Text>
+            </TouchableOpacity>
+          )
+        ) : null}
+        <TouchableOpacity
+          style={styles.leaveBtn}
+          onPress={() => leave()}
+          hitSlop={6}
+        >
+          <MaterialIcons name="close" size={18} color="#fff" />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    banner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      backgroundColor: '#253883',
+      borderRadius: 12,
+      paddingVertical: 8,
+      paddingHorizontal: 12,
+      marginHorizontal: 12,
+      marginTop: 6,
+      gap: 8,
+      ...Platform.select({
+        web: { boxShadow: '0 2px 10px rgba(37,56,131,0.35)' },
+        default: {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.18,
+          shadowRadius: 6,
+          elevation: 4,
+        },
+      }),
+    },
+    left: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      flex: 1,
+    },
+    icon: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: 'rgba(255,255,255,0.18)',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    textBlock: {
+      flex: 1,
+    },
+    role: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: '#fff',
+      letterSpacing: 0.2,
+    },
+    detail: {
+      fontSize: 12,
+      color: 'rgba(255,255,255,0.85)',
+      marginTop: 1,
+    },
+    right: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+    },
+    actionBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      paddingVertical: 5,
+      paddingHorizontal: 9,
+      borderRadius: 8,
+      backgroundColor: 'rgba(255,255,255,0.18)',
+    },
+    actionText: {
+      color: '#fff',
+      fontSize: 12,
+      fontWeight: '700',
+    },
+    leaveBtn: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: 'rgba(255,255,255,0.18)',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+  });
+
+export default ChoirSessionBanner;

--- a/mcm-app/components/playlist/CodeInputDialog.tsx
+++ b/mcm-app/components/playlist/CodeInputDialog.tsx
@@ -50,7 +50,7 @@ interface Props {
    * rechaza, se muestra el `message` del error en rojo y el modal sigue
    * abierto para que reintente o cambie el código.
    */
-  onSubmit: (code: string) => Promise<void>;
+  onSubmit: (code: string, name?: string) => Promise<void>;
 }
 
 interface VariantCopy {
@@ -58,15 +58,17 @@ interface VariantCopy {
   description: string;
   primaryLabel: string;
   showSuggestButtons: boolean;
+  askForName?: boolean;
 }
 
 const COPY: Record<CodeDialogVariant, VariantCopy> = {
   'cloud-upload': {
     title: 'Subir playlist a la nube',
     description:
-      'Cualquiera con este código de 4 dígitos podrá importar tu playlist.',
+      'Dale un nombre (opcional) y elige un código de 4 dígitos. Cualquiera con el código podrá importar tu playlist.',
     primaryLabel: 'Subir',
     showSuggestButtons: true,
+    askForName: true,
   },
   'cloud-download': {
     title: 'Descargar playlist',
@@ -109,6 +111,7 @@ const CodeInputDialog: React.FC<Props> = ({
   const copy = COPY[variant];
 
   const [code, setCode] = useState<string>('');
+  const [name, setName] = useState<string>('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -128,6 +131,28 @@ const CodeInputDialog: React.FC<Props> = ({
     } else {
       setCode('');
     }
+
+    // Auto-completar un nombre chulo por defecto para la nube
+    if (variant === 'cloud-upload') {
+      const monthNames = [
+        'ene',
+        'feb',
+        'mar',
+        'abr',
+        'may',
+        'jun',
+        'jul',
+        'ago',
+        'sep',
+        'oct',
+        'nov',
+        'dic',
+      ];
+      const now = new Date();
+      setName(`Playlist ${now.getDate()} ${monthNames[now.getMonth()]}`);
+    } else {
+      setName('');
+    }
   }, [visible, variant, initialCode]);
 
   const valid = isValidCode(code);
@@ -137,7 +162,7 @@ const CodeInputDialog: React.FC<Props> = ({
     setSubmitting(true);
     setError(null);
     try {
-      await onSubmit(code);
+      await onSubmit(code, name.trim() || undefined);
     } catch (e: any) {
       setError(e?.message ?? 'Algo salió mal');
       setSubmitting(false);
@@ -170,6 +195,28 @@ const CodeInputDialog: React.FC<Props> = ({
               <Text style={styles.title}>{copy.title}</Text>
               <Text style={styles.description}>{copy.description}</Text>
 
+              {copy.askForName && (
+                <View style={styles.nameRow}>
+                  <Text style={styles.inputLabel}>Nombre</Text>
+                  <TextInput
+                    value={name}
+                    onChangeText={setName}
+                    placeholder="Ej. Cantos domingo"
+                    placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
+                    style={styles.nameInput}
+                    editable={!submitting}
+                  />
+                </View>
+              )}
+
+              <Text
+                style={[
+                  styles.inputLabel,
+                  copy.askForName && { marginTop: 12 },
+                ]}
+              >
+                Código (4 dígitos)
+              </Text>
               <View style={styles.codeRow}>
                 {/* Para máxima fiabilidad cross-platform (web + RN) usamos un
                     único TextInput de N dígitos en lugar de N TextInputs
@@ -315,6 +362,28 @@ const createStyles = (isDark: boolean) =>
       alignItems: 'center',
       justifyContent: 'center',
       marginBottom: 14,
+      marginTop: 6,
+    },
+    nameRow: {
+      marginBottom: 8,
+    },
+    inputLabel: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      marginBottom: 6,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    nameInput: {
+      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      paddingVertical: 14,
+      fontSize: 16,
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      borderWidth: 1.5,
+      borderColor: isDark ? '#48484A' : '#D1D1D6',
     },
     hiddenInput: {
       position: 'absolute',

--- a/mcm-app/components/playlist/CodeInputDialog.tsx
+++ b/mcm-app/components/playlist/CodeInputDialog.tsx
@@ -1,0 +1,416 @@
+/**
+ * Diálogo reutilizable para introducir / generar un código corto
+ * (4 dígitos por defecto). Lo usamos en 4 flujos:
+ *
+ *   - Subir playlist a la nube  (variant="cloud-upload")
+ *   - Descargar desde la nube   (variant="cloud-download")
+ *   - Iniciar sesión coro       (variant="choir-start")
+ *   - Unirse a sesión coro      (variant="choir-join")
+ *
+ * El componente no sabe nada del backend: el caller decide qué hacer con
+ * el código vía `onSubmit`. Devolver una promesa permite mostrar un
+ * estado "cargando" durante la operación.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Platform,
+  ActivityIndicator,
+  TextInput,
+} from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import {
+  CODE_LENGTH,
+  generateRandomCode,
+  isValidCode,
+  todayCode,
+} from '@/utils/playlistCodes';
+
+export type CodeDialogVariant =
+  | 'cloud-upload'
+  | 'cloud-download'
+  | 'choir-start'
+  | 'choir-join'
+  | 'change-code';
+
+interface Props {
+  visible: boolean;
+  variant: CodeDialogVariant;
+  /** Código inicial sugerido. Si no se pasa, se autogenera para "upload" / "start". */
+  initialCode?: string;
+  onClose: () => void;
+  /**
+   * Se llama cuando el usuario pulsa el botón principal. Si la promesa
+   * rechaza, se muestra el `message` del error en rojo y el modal sigue
+   * abierto para que reintente o cambie el código.
+   */
+  onSubmit: (code: string) => Promise<void>;
+}
+
+interface VariantCopy {
+  title: string;
+  description: string;
+  primaryLabel: string;
+  showSuggestButtons: boolean;
+}
+
+const COPY: Record<CodeDialogVariant, VariantCopy> = {
+  'cloud-upload': {
+    title: 'Subir playlist a la nube',
+    description:
+      'Cualquiera con este código de 4 dígitos podrá importar tu playlist.',
+    primaryLabel: 'Subir',
+    showSuggestButtons: true,
+  },
+  'cloud-download': {
+    title: 'Descargar playlist',
+    description: 'Introduce el código de 4 dígitos que te han compartido.',
+    primaryLabel: 'Descargar',
+    showSuggestButtons: false,
+  },
+  'choir-start': {
+    title: 'Iniciar sesión de coro',
+    description:
+      'Tu dispositivo será el maestro. Los demás se conectarán con este código.',
+    primaryLabel: 'Iniciar',
+    showSuggestButtons: true,
+  },
+  'choir-join': {
+    title: 'Unirse al coro',
+    description: 'Introduce el código que el maestro está usando.',
+    primaryLabel: 'Unirse',
+    showSuggestButtons: false,
+  },
+  'change-code': {
+    title: 'Cambiar código',
+    description: 'Elige un nuevo código para esta sesión.',
+    primaryLabel: 'Cambiar',
+    showSuggestButtons: true,
+  },
+};
+
+const CodeInputDialog: React.FC<Props> = ({
+  visible,
+  variant,
+  initialCode,
+  onClose,
+  onSubmit,
+}) => {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+  const copy = COPY[variant];
+
+  const [code, setCode] = useState<string>('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Al abrir, sembrar valor inicial.
+  useEffect(() => {
+    if (!visible) return;
+    setError(null);
+    setSubmitting(false);
+    if (initialCode && isValidCode(initialCode)) {
+      setCode(initialCode);
+    } else if (
+      variant === 'cloud-upload' ||
+      variant === 'choir-start' ||
+      variant === 'change-code'
+    ) {
+      setCode(generateRandomCode());
+    } else {
+      setCode('');
+    }
+  }, [visible, variant, initialCode]);
+
+  const valid = isValidCode(code);
+
+  const handleSubmit = async () => {
+    if (!valid || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(code);
+    } catch (e: any) {
+      setError(e?.message ?? 'Algo salió mal');
+      setSubmitting(false);
+    }
+  };
+
+  const handleChangeText = (txt: string) => {
+    const digits = txt.replace(/\D/g, '').slice(0, CODE_LENGTH);
+    setCode(digits);
+    if (error) setError(null);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <TouchableWithoutFeedback
+        onPress={() => {
+          if (!submitting) onClose();
+        }}
+      >
+        <View style={styles.backdrop}>
+          <TouchableWithoutFeedback>
+            <View style={styles.card}>
+              <Text style={styles.title}>{copy.title}</Text>
+              <Text style={styles.description}>{copy.description}</Text>
+
+              <View style={styles.codeRow}>
+                {/* Para máxima fiabilidad cross-platform (web + RN) usamos un
+                    único TextInput de N dígitos en lugar de N TextInputs
+                    separados. Visualmente lo presentamos con celdas. */}
+                <TextInput
+                  value={code}
+                  onChangeText={handleChangeText}
+                  keyboardType="number-pad"
+                  inputMode="numeric"
+                  autoFocus
+                  maxLength={CODE_LENGTH}
+                  selectTextOnFocus
+                  style={styles.hiddenInput}
+                  editable={!submitting}
+                  onSubmitEditing={handleSubmit}
+                  returnKeyType="done"
+                />
+                <View style={styles.cells} pointerEvents="none">
+                  {Array.from({ length: CODE_LENGTH }).map((_, i) => {
+                    const char = code[i] ?? '';
+                    const active = i === code.length;
+                    return (
+                      <View
+                        key={i}
+                        style={[
+                          styles.cell,
+                          active && !submitting && styles.cellActive,
+                          !!char && styles.cellFilled,
+                        ]}
+                      >
+                        <Text style={styles.cellText}>{char}</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+
+              {copy.showSuggestButtons && (
+                <View style={styles.suggestRow}>
+                  <TouchableOpacity
+                    style={styles.suggestBtn}
+                    onPress={() => setCode(generateRandomCode())}
+                    disabled={submitting}
+                  >
+                    <MaterialIcons
+                      name="casino"
+                      size={16}
+                      color={isDark ? '#7AB3FF' : '#253883'}
+                    />
+                    <Text style={styles.suggestText}>Aleatorio</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={styles.suggestBtn}
+                    onPress={() => setCode(todayCode())}
+                    disabled={submitting}
+                  >
+                    <MaterialIcons
+                      name="event"
+                      size={16}
+                      color={isDark ? '#7AB3FF' : '#253883'}
+                    />
+                    <Text style={styles.suggestText}>Hoy (DDMM)</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+
+              <View style={styles.buttons}>
+                <TouchableOpacity
+                  style={[styles.btn, styles.btnSecondary]}
+                  onPress={onClose}
+                  disabled={submitting}
+                >
+                  <Text style={styles.btnSecondaryText}>Cancelar</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.btn,
+                    styles.btnPrimary,
+                    (!valid || submitting) && styles.btnDisabled,
+                  ]}
+                  onPress={handleSubmit}
+                  disabled={!valid || submitting}
+                >
+                  {submitting ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text style={styles.btnPrimaryText}>
+                      {copy.primaryLabel}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.45)',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 20,
+    },
+    card: {
+      width: '100%',
+      maxWidth: 420,
+      backgroundColor: isDark ? '#2C2C2E' : '#FFFFFF',
+      borderRadius: 18,
+      padding: 22,
+      ...Platform.select({
+        web: { boxShadow: '0 12px 40px rgba(0,0,0,0.25)' },
+        default: {
+          shadowColor: '#000',
+          shadowOpacity: 0.25,
+          shadowRadius: 20,
+          shadowOffset: { width: 0, height: 8 },
+          elevation: 12,
+        },
+      }),
+    },
+    title: {
+      fontSize: 19,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      marginBottom: 6,
+    },
+    description: {
+      fontSize: 14,
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      marginBottom: 18,
+      lineHeight: 20,
+    },
+    codeRow: {
+      position: 'relative',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 14,
+    },
+    hiddenInput: {
+      position: 'absolute',
+      width: '100%',
+      height: 56,
+      opacity: 0.01,
+      color: 'transparent',
+      // En web, dejamos un caret invisible para no ver doble cursor.
+      ...(Platform.OS === 'web' ? ({ caretColor: 'transparent' } as any) : {}),
+      fontSize: 1,
+    },
+    cells: {
+      flexDirection: 'row',
+      gap: 10,
+    },
+    cell: {
+      width: 52,
+      height: 60,
+      borderRadius: 12,
+      borderWidth: 1.5,
+      borderColor: isDark ? '#48484A' : '#D1D1D6',
+      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cellFilled: {
+      borderColor: isDark ? '#7AB3FF' : '#253883',
+    },
+    cellActive: {
+      borderColor: isDark ? '#7AB3FF' : '#253883',
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    cellText: {
+      fontSize: 26,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      fontVariant: ['tabular-nums'],
+    },
+    suggestRow: {
+      flexDirection: 'row',
+      gap: 8,
+      marginBottom: 14,
+      justifyContent: 'center',
+    },
+    suggestBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingVertical: 8,
+      paddingHorizontal: 12,
+      borderRadius: 8,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    suggestText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: isDark ? '#7AB3FF' : '#253883',
+    },
+    error: {
+      color: '#FF453A',
+      fontSize: 13,
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    buttons: {
+      flexDirection: 'row',
+      gap: 10,
+      justifyContent: 'flex-end',
+      marginTop: 4,
+    },
+    btn: {
+      paddingVertical: 11,
+      paddingHorizontal: 18,
+      borderRadius: 10,
+      minWidth: 110,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    btnSecondary: {
+      backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : '#F2F2F7',
+    },
+    btnSecondaryText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    btnPrimary: {
+      backgroundColor: '#253883',
+    },
+    btnPrimaryText: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: '#FFFFFF',
+    },
+    btnDisabled: {
+      opacity: 0.45,
+    },
+  });
+
+export default CodeInputDialog;

--- a/mcm-app/components/playlist/CodeInputDialog.tsx
+++ b/mcm-app/components/playlist/CodeInputDialog.tsx
@@ -77,13 +77,14 @@ const COPY: Record<CodeDialogVariant, VariantCopy> = {
   'choir-start': {
     title: 'Iniciar sesión de coro',
     description:
-      'Tu dispositivo será el maestro. Los demás se conectarán con este código.',
+      'Tu dispositivo será el director. Los demás se conectarán con este código.',
     primaryLabel: 'Iniciar',
     showSuggestButtons: true,
   },
   'choir-join': {
     title: 'Unirse al coro',
-    description: 'Introduce el código que el maestro está usando.',
+    description:
+      'Introduce el código proporcionado para seguir las canciones automáticamente.',
     primaryLabel: 'Unirse',
     showSuggestButtons: false,
   },

--- a/mcm-app/components/playlist/ConfirmChoiceDialog.tsx
+++ b/mcm-app/components/playlist/ConfirmChoiceDialog.tsx
@@ -1,0 +1,168 @@
+/**
+ * Diálogo con N opciones (1-3 acciones + cancelar). Lo usamos para:
+ *   - "Este código ya existe → sobrescribir / cambiar / cancelar"
+ *   - "Descargada → reemplazar tu lista / añadir / cancelar"
+ *   - Confirmaciones genéricas.
+ */
+import React, { useMemo } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Platform,
+} from 'react-native';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export interface ConfirmChoiceAction {
+  label: string;
+  onPress: () => void;
+  variant?: 'primary' | 'secondary' | 'danger';
+}
+
+interface Props {
+  visible: boolean;
+  title: string;
+  description?: string;
+  actions: ConfirmChoiceAction[];
+  onClose: () => void;
+}
+
+const ConfirmChoiceDialog: React.FC<Props> = ({
+  visible,
+  title,
+  description,
+  actions,
+  onClose,
+}) => {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.backdrop}>
+          <TouchableWithoutFeedback>
+            <View style={styles.card}>
+              <Text style={styles.title}>{title}</Text>
+              {description ? (
+                <Text style={styles.description}>{description}</Text>
+              ) : null}
+              <View style={styles.actions}>
+                {actions.map((a, i) => (
+                  <TouchableOpacity
+                    key={i}
+                    style={[
+                      styles.btn,
+                      a.variant === 'primary' && styles.btnPrimary,
+                      a.variant === 'danger' && styles.btnDanger,
+                      (!a.variant || a.variant === 'secondary') &&
+                        styles.btnSecondary,
+                    ]}
+                    onPress={a.onPress}
+                  >
+                    <Text
+                      style={[
+                        styles.btnText,
+                        a.variant === 'primary' && styles.btnPrimaryText,
+                        a.variant === 'danger' && styles.btnDangerText,
+                        (!a.variant || a.variant === 'secondary') &&
+                          styles.btnSecondaryText,
+                      ]}
+                    >
+                      {a.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.45)',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 20,
+    },
+    card: {
+      width: '100%',
+      maxWidth: 420,
+      backgroundColor: isDark ? '#2C2C2E' : '#FFFFFF',
+      borderRadius: 18,
+      padding: 22,
+      ...Platform.select({
+        web: { boxShadow: '0 12px 40px rgba(0,0,0,0.25)' },
+        default: {
+          shadowColor: '#000',
+          shadowOpacity: 0.25,
+          shadowRadius: 20,
+          shadowOffset: { width: 0, height: 8 },
+          elevation: 12,
+        },
+      }),
+    },
+    title: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      marginBottom: 8,
+    },
+    description: {
+      fontSize: 14,
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      lineHeight: 20,
+      marginBottom: 18,
+    },
+    actions: {
+      gap: 8,
+    },
+    btn: {
+      paddingVertical: 13,
+      paddingHorizontal: 18,
+      borderRadius: 10,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    btnText: {
+      fontSize: 15,
+      fontWeight: '600',
+    },
+    btnSecondary: {
+      backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : '#F2F2F7',
+    },
+    btnSecondaryText: {
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    btnPrimary: {
+      backgroundColor: '#253883',
+    },
+    btnPrimaryText: {
+      color: '#fff',
+      fontWeight: '700',
+    },
+    btnDanger: {
+      backgroundColor: isDark ? '#3A1517' : '#FFE5E4',
+    },
+    btnDangerText: {
+      color: '#FF453A',
+      fontWeight: '700',
+    },
+  });
+
+export default ConfirmChoiceDialog;

--- a/mcm-app/components/playlist/PlaylistActionsSheet.tsx
+++ b/mcm-app/components/playlist/PlaylistActionsSheet.tsx
@@ -1,0 +1,216 @@
+/**
+ * Menú principal de acciones de la pantalla "Seleccionadas". Reemplaza
+ * los 4 iconitos del header anterior por un único botón "…" que abre
+ * este menú. Permite muchas más acciones sin saturar.
+ */
+import React, { useMemo } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export interface PlaylistAction {
+  id: string;
+  icon: keyof typeof MaterialIcons.glyphMap;
+  label: string;
+  description?: string;
+  onPress: () => void;
+  variant?: 'normal' | 'danger';
+  /** Si true, se renderiza un separador visual ANTES de este item. */
+  separator?: boolean;
+  disabled?: boolean;
+}
+
+interface Props {
+  visible: boolean;
+  actions: PlaylistAction[];
+  onClose: () => void;
+  title?: string;
+}
+
+/**
+ * Implementado como modal de RN con un panel "bottom sheet" estático
+ * (sin gestos). Es suficiente para esta UX y evita pelearnos con la
+ * portabilidad del BottomSheet de heroui en web.
+ */
+const PlaylistActionsSheet: React.FC<Props> = ({
+  visible,
+  actions,
+  onClose,
+  title = 'Acciones',
+}) => {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.backdrop}>
+          <TouchableWithoutFeedback>
+            <View style={styles.sheet}>
+              <View style={styles.handle} />
+              <Text style={styles.title}>{title}</Text>
+              <ScrollView
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+                showsVerticalScrollIndicator={false}
+              >
+                {actions.map((a, i) => (
+                  <React.Fragment key={a.id}>
+                    {a.separator && i > 0 ? (
+                      <View style={styles.separator} />
+                    ) : null}
+                    <TouchableOpacity
+                      style={[styles.item, a.disabled && styles.itemDisabled]}
+                      onPress={() => {
+                        if (a.disabled) return;
+                        onClose();
+                        // Defer slightly so the modal can dismiss before the
+                        // action triggers another modal (avoids race on web).
+                        setTimeout(() => a.onPress(), 50);
+                      }}
+                      disabled={a.disabled}
+                    >
+                      <View
+                        style={[
+                          styles.iconWrap,
+                          a.variant === 'danger' && styles.iconWrapDanger,
+                        ]}
+                      >
+                        <MaterialIcons
+                          name={a.icon}
+                          size={22}
+                          color={
+                            a.variant === 'danger'
+                              ? '#FF453A'
+                              : isDark
+                                ? '#7AB3FF'
+                                : '#253883'
+                          }
+                        />
+                      </View>
+                      <View style={styles.itemText}>
+                        <Text
+                          style={[
+                            styles.itemLabel,
+                            a.variant === 'danger' && styles.itemLabelDanger,
+                          ]}
+                        >
+                          {a.label}
+                        </Text>
+                        {a.description ? (
+                          <Text style={styles.itemDescription}>
+                            {a.description}
+                          </Text>
+                        ) : null}
+                      </View>
+                    </TouchableOpacity>
+                  </React.Fragment>
+                ))}
+              </ScrollView>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'flex-end',
+    },
+    sheet: {
+      backgroundColor: isDark ? '#1C1C1E' : '#FFFFFF',
+      borderTopLeftRadius: 22,
+      borderTopRightRadius: 22,
+      paddingTop: 8,
+      paddingBottom: Platform.OS === 'ios' ? 36 : 24,
+      maxHeight: '85%',
+    },
+    handle: {
+      width: 40,
+      height: 5,
+      borderRadius: 3,
+      backgroundColor: isDark ? '#48484A' : '#D1D1D6',
+      alignSelf: 'center',
+      marginBottom: 8,
+    },
+    title: {
+      fontSize: 17,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      paddingHorizontal: 20,
+      paddingVertical: 8,
+    },
+    list: {
+      maxHeight: '100%',
+    },
+    listContent: {
+      paddingHorizontal: 8,
+      paddingBottom: 8,
+    },
+    item: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: 12,
+      gap: 14,
+    },
+    itemDisabled: {
+      opacity: 0.4,
+    },
+    iconWrap: {
+      width: 38,
+      height: 38,
+      borderRadius: 19,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    iconWrapDanger: {
+      backgroundColor: isDark ? '#3A1517' : '#FFE5E4',
+    },
+    itemText: {
+      flex: 1,
+    },
+    itemLabel: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    itemLabelDanger: {
+      color: '#FF453A',
+    },
+    itemDescription: {
+      fontSize: 13,
+      color: isDark ? '#8E8E93' : '#8E8E93',
+      marginTop: 2,
+    },
+    separator: {
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+      marginVertical: 6,
+      marginHorizontal: 20,
+    },
+  });
+
+export default PlaylistActionsSheet;

--- a/mcm-app/components/playlist/PlaylistRow.tsx
+++ b/mcm-app/components/playlist/PlaylistRow.tsx
@@ -1,0 +1,408 @@
+/**
+ * Fila de canción dentro de la pantalla "Seleccionadas".
+ *
+ * Diferencias con `SongListItem`:
+ *   - Muestra el tono TRANSPORTADO (tono original → tono final) si la
+ *     canción tiene `transpose != 0`.
+ *   - Tiene controles opcionales de reorden (↑ / ↓) en modo "Orden libre".
+ *   - Numerador opcional (posición 1, 2, 3...).
+ *   - Indicador opcional de "sonando ahora" (modo coro).
+ */
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Animated,
+} from 'react-native';
+import { Swipeable } from 'react-native-gesture-handler';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { IconSymbol } from '@/components/ui/IconSymbol';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { useSettings } from '@/contexts/SettingsContext';
+import { convertChord } from '@/utils/chordNotation';
+import { transposeKey, transposeLabel } from '@/utils/transposeKey';
+
+interface Song {
+  title: string;
+  filename: string;
+  author?: string;
+  key?: string;
+  capo?: number;
+}
+
+interface Props {
+  song: Song;
+  transpose: number;
+  /** Si se indica, se muestra como prefijo (#1, #2…). */
+  position?: number;
+  /** Solo modo "Orden libre". */
+  showReorderControls?: boolean;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  onPress: () => void;
+  onRemove: () => void;
+  /** Marca esta canción como la actual en una sesión de coro. */
+  isNowPlaying?: boolean;
+}
+
+const PlaylistRow: React.FC<Props> = ({
+  song,
+  transpose,
+  position,
+  showReorderControls,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onPress,
+  onRemove,
+  isNowPlaying,
+}) => {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+  const { settings } = useSettings();
+  const { notation } = settings;
+
+  const cleanTitle = song.title.replace(/^\d+\.\s*/, '');
+  const originalKey = song.key ? song.key.toUpperCase() : '';
+  const targetKey =
+    transpose && originalKey
+      ? transposeKey(originalKey, transpose)
+      : originalKey;
+
+  const transposeBadge = transposeLabel(transpose);
+
+  const renderLeftActions = (
+    _progress: Animated.AnimatedInterpolation<number>,
+    dragX: Animated.AnimatedInterpolation<number>,
+  ) => {
+    const trans = dragX.interpolate({
+      inputRange: [0, 100],
+      outputRange: [-100, 0],
+      extrapolate: 'clamp',
+    });
+    return (
+      <TouchableOpacity style={styles.leftAction} onPress={onRemove}>
+        <Animated.View
+          style={[styles.actionContent, { transform: [{ translateX: trans }] }]}
+        >
+          <IconSymbol name="minus.circle" size={22} color="#fff" />
+          <Text style={styles.actionText}>Quitar</Text>
+        </Animated.View>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <Swipeable
+      renderLeftActions={renderLeftActions}
+      onSwipeableOpen={(direction, swipeable) => {
+        if (direction === 'left') {
+          swipeable.close();
+          onRemove();
+        }
+      }}
+    >
+      <View style={[styles.outer, isNowPlaying && styles.outerNowPlaying]}>
+        <TouchableOpacity
+          onPress={onPress}
+          style={styles.inner}
+          activeOpacity={0.6}
+        >
+          <View style={styles.leftSection}>
+            {position !== undefined ? (
+              <View style={styles.numberWrap}>
+                <Text style={styles.numberText}>{position}</Text>
+              </View>
+            ) : isNowPlaying ? (
+              <View style={[styles.numberWrap, styles.numberWrapPlaying]}>
+                <MaterialIcons name="graphic-eq" size={16} color="#34C759" />
+              </View>
+            ) : (
+              <View style={styles.dotPlaceholder} />
+            )}
+
+            <View style={styles.songInfoContainer}>
+              <Text
+                style={styles.songTitle}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {cleanTitle}
+              </Text>
+              {song.author ? (
+                <Text
+                  style={styles.authorText}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {song.author}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+
+          <View style={styles.rightSection}>
+            {song.capo && song.capo > 0 ? (
+              <View style={styles.capoPill}>
+                <Text style={styles.capoText}>{`C${song.capo}`}</Text>
+              </View>
+            ) : null}
+
+            {originalKey ? (
+              transpose !== 0 ? (
+                <View style={styles.toneTransposedWrap}>
+                  <Text style={styles.toneOriginalStriked}>
+                    {convertChord(originalKey, notation)}
+                  </Text>
+                  <MaterialIcons
+                    name="arrow-forward"
+                    size={12}
+                    color={isDark ? '#8E8E93' : '#8E8E93'}
+                  />
+                  <View style={styles.keyPillTransposed}>
+                    <Text style={styles.keyTextTransposed}>
+                      {convertChord(targetKey, notation)}
+                    </Text>
+                    <Text style={styles.transposeBadge}>{transposeBadge}</Text>
+                  </View>
+                </View>
+              ) : (
+                <View style={styles.keyPill}>
+                  <Text style={styles.keyText}>
+                    {convertChord(originalKey, notation)}
+                  </Text>
+                </View>
+              )
+            ) : null}
+          </View>
+        </TouchableOpacity>
+
+        {showReorderControls ? (
+          <View style={styles.reorderRow}>
+            <TouchableOpacity
+              style={[
+                styles.reorderBtn,
+                !canMoveUp && styles.reorderBtnDisabled,
+              ]}
+              onPress={onMoveUp}
+              disabled={!canMoveUp}
+              hitSlop={6}
+            >
+              <MaterialIcons
+                name="keyboard-arrow-up"
+                size={22}
+                color={
+                  canMoveUp
+                    ? isDark
+                      ? '#7AB3FF'
+                      : '#253883'
+                    : isDark
+                      ? '#48484A'
+                      : '#C7C7CC'
+                }
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                styles.reorderBtn,
+                !canMoveDown && styles.reorderBtnDisabled,
+              ]}
+              onPress={onMoveDown}
+              disabled={!canMoveDown}
+              hitSlop={6}
+            >
+              <MaterialIcons
+                name="keyboard-arrow-down"
+                size={22}
+                color={
+                  canMoveDown
+                    ? isDark
+                      ? '#7AB3FF'
+                      : '#253883'
+                    : isDark
+                      ? '#48484A'
+                      : '#C7C7CC'
+                }
+              />
+            </TouchableOpacity>
+          </View>
+        ) : null}
+      </View>
+    </Swipeable>
+  );
+};
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    outer: {
+      backgroundColor: isDark ? '#2C2C2E' : '#fff',
+      flexDirection: 'row',
+      alignItems: 'stretch',
+    },
+    outerNowPlaying: {
+      backgroundColor: isDark ? '#1A3320' : '#E8F5E9',
+    },
+    inner: {
+      flex: 1,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+    },
+    leftSection: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginRight: 12,
+      gap: 10,
+    },
+    numberWrap: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    numberWrapPlaying: {
+      backgroundColor: isDark ? '#1A3320' : '#D7F1DA',
+    },
+    numberText: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: isDark ? '#7AB3FF' : '#253883',
+      fontVariant: ['tabular-nums'],
+    },
+    dotPlaceholder: {
+      width: 6,
+      height: 6,
+      borderRadius: 3,
+      backgroundColor: '#34C759',
+      marginHorizontal: 11,
+    },
+    songInfoContainer: {
+      flex: 1,
+    },
+    songTitle: {
+      fontSize: 16,
+      color: isDark ? '#FFFFFF' : '#1C1C1E',
+      fontWeight: '500',
+      letterSpacing: -0.2,
+    },
+    authorText: {
+      fontSize: 13,
+      color: isDark ? '#AEAEB2' : '#8E8E93',
+      fontStyle: 'italic',
+      marginTop: 3,
+    },
+    rightSection: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 5,
+    },
+    capoPill: {
+      paddingHorizontal: 6,
+      paddingVertical: 3,
+      borderRadius: 5,
+      backgroundColor: isDark ? '#3A3A3C' : '#EBEBEB',
+    },
+    capoText: {
+      fontSize: 11,
+      fontWeight: '600',
+      color: isDark ? '#AEAEB2' : '#636366',
+      fontVariant: ['tabular-nums'],
+    },
+    keyPill: {
+      paddingHorizontal: 8,
+      paddingVertical: 3,
+      borderRadius: 6,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    keyText: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: isDark ? '#7AB3FF' : '#253883',
+    },
+    toneTransposedWrap: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    toneOriginalStriked: {
+      fontSize: 12,
+      fontWeight: '500',
+      color: isDark ? '#636366' : '#A0A0A8',
+      textDecorationLine: 'line-through',
+    },
+    keyPillTransposed: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      paddingHorizontal: 8,
+      paddingVertical: 3,
+      borderRadius: 6,
+      backgroundColor: '#FFF4DA',
+      borderWidth: 1,
+      borderColor: '#F4C11E',
+    },
+    keyTextTransposed: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: '#7A5A00',
+    },
+    transposeBadge: {
+      fontSize: 11,
+      fontWeight: '800',
+      color: '#9D5C00',
+      fontVariant: ['tabular-nums'],
+      backgroundColor: 'rgba(255,255,255,0.7)',
+      paddingHorizontal: 4,
+      borderRadius: 4,
+    },
+    reorderRow: {
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 8,
+      paddingVertical: 6,
+      gap: 2,
+      borderLeftWidth: StyleSheet.hairlineWidth,
+      borderLeftColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+    },
+    reorderBtn: {
+      width: 32,
+      height: 24,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    reorderBtnDisabled: {
+      opacity: 0.4,
+    },
+    leftAction: {
+      backgroundColor: '#FF453A',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: 100,
+    },
+    actionContent: {
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    actionText: {
+      color: '#fff',
+      fontSize: 12,
+      fontWeight: '600',
+      marginTop: 4,
+    },
+  });
+
+export default PlaylistRow;

--- a/mcm-app/contexts/ChoirSessionContext.tsx
+++ b/mcm-app/contexts/ChoirSessionContext.tsx
@@ -244,7 +244,7 @@ export const ChoirSessionProvider: React.FC<{ children: ReactNode }> = ({
     async (newCode: string) => {
       if (!code) throw new Error('No hay sesión activa');
       if (mode !== 'master') {
-        throw new Error('Solo el maestro puede cambiar el código');
+        throw new Error('Solo el líder puede cambiar el código');
       }
       await changeChoirSessionCode(code, newCode);
       setCode(newCode);

--- a/mcm-app/contexts/ChoirSessionContext.tsx
+++ b/mcm-app/contexts/ChoirSessionContext.tsx
@@ -1,0 +1,298 @@
+/**
+ * Estado global del "modo Coro". Tres modos:
+ *
+ *  - 'off'    → no hay sesión activa
+ *  - 'master' → este dispositivo dirige (publica) los cambios
+ *  - 'slave'  → este dispositivo sigue al maestro
+ *
+ * El maestro publica `current { filename, transpose }` y los esclavos lo
+ * leen en tiempo real. Cada esclavo puede activar `overrideTranspose` para
+ * ignorar el tono del maestro y usar el suyo localmente (sin afectar a la
+ * sesión remota).
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  ReactNode,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  ChoirCurrentSong,
+  ChoirSession,
+  closeChoirSession,
+  createChoirSession,
+  publishChoirCurrent,
+  publishChoirPlaylist,
+  subscribeChoirSession,
+  changeChoirSessionCode,
+} from '@/services/choirSessionService';
+import type { SelectedSong } from '@/contexts/SelectedSongsContext';
+
+export type ChoirMode = 'off' | 'master' | 'slave';
+
+interface ChoirSessionContextValue {
+  mode: ChoirMode;
+  code: string | null;
+  session: ChoirSession | null;
+  /** Si el esclavo pulsa "usar mi tono", aquí se guarda su override local. */
+  overrideTranspose: number | null;
+  deviceId: string;
+
+  startAsMaster: (
+    code: string,
+    playlist: SelectedSong[],
+    opts?: { name?: string },
+  ) => Promise<void>;
+  joinAsSlave: (code: string) => Promise<void>;
+  leave: () => Promise<void>;
+  /** Solo maestro. Publica la canción actual. */
+  publishCurrent: (
+    current: Omit<ChoirCurrentSong, 'updatedAt'>,
+  ) => Promise<void>;
+  /** Solo maestro. Publica la playlist (al subir / reordenar). */
+  publishPlaylist: (playlist: SelectedSong[]) => Promise<void>;
+  /** Solo esclavo. Activa/desactiva su transpose local. */
+  setOverrideTranspose: (semitones: number | null) => void;
+  changeCode: (newCode: string) => Promise<void>;
+}
+
+const ChoirSessionContext = createContext<ChoirSessionContextValue | undefined>(
+  undefined,
+);
+
+const DEVICE_ID_KEY = '@mcm_device_id';
+const SESSION_PERSIST_KEY = '@mcm_choir_session_v1';
+
+interface PersistedSession {
+  mode: 'master' | 'slave';
+  code: string;
+}
+
+function genDeviceId(): string {
+  // Sin dependencias: combinación de timestamp + aleatorio.
+  return (
+    Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10)
+  );
+}
+
+export const ChoirSessionProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [deviceId, setDeviceId] = useState<string>('');
+  const [mode, setMode] = useState<ChoirMode>('off');
+  const [code, setCode] = useState<string | null>(null);
+  const [session, setSession] = useState<ChoirSession | null>(null);
+  const [overrideTranspose, setOverrideTranspose] = useState<number | null>(
+    null,
+  );
+  const unsubRef = useRef<(() => void) | null>(null);
+
+  // Cargar deviceId persistente.
+  useEffect(() => {
+    (async () => {
+      try {
+        let id = await AsyncStorage.getItem(DEVICE_ID_KEY);
+        if (!id) {
+          id = genDeviceId();
+          await AsyncStorage.setItem(DEVICE_ID_KEY, id);
+        }
+        setDeviceId(id);
+      } catch (e) {
+        console.error('deviceId persist error', e);
+        setDeviceId(genDeviceId());
+      }
+    })();
+  }, []);
+
+  // Restaurar sesión guardada al iniciar.
+  useEffect(() => {
+    if (!deviceId) return;
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(SESSION_PERSIST_KEY);
+        if (!raw) return;
+        const parsed = JSON.parse(raw) as PersistedSession;
+        if (
+          parsed?.code &&
+          (parsed.mode === 'master' || parsed.mode === 'slave')
+        ) {
+          setMode(parsed.mode);
+          setCode(parsed.code);
+        }
+      } catch (e) {
+        console.error('choir session restore error', e);
+      }
+    })();
+  }, [deviceId]);
+
+  // Persistir la sesión en cuanto cambia.
+  useEffect(() => {
+    if (mode === 'off' || !code) {
+      AsyncStorage.removeItem(SESSION_PERSIST_KEY).catch(() => {});
+      return;
+    }
+    const payload: PersistedSession = {
+      mode: mode as 'master' | 'slave',
+      code,
+    };
+    AsyncStorage.setItem(SESSION_PERSIST_KEY, JSON.stringify(payload)).catch(
+      () => {},
+    );
+  }, [mode, code]);
+
+  // Suscripción a Firebase mientras haya sesión activa.
+  useEffect(() => {
+    unsubRef.current?.();
+    unsubRef.current = null;
+    setSession(null);
+    if (!code || mode === 'off') return;
+    try {
+      unsubRef.current = subscribeChoirSession(
+        code,
+        (s) => {
+          setSession(s);
+          if (!s) {
+            // El maestro la borró → todos a 'off'.
+            setMode('off');
+            setCode(null);
+            setOverrideTranspose(null);
+          }
+        },
+        (err) => {
+          console.error('choir session subscribe error', err);
+        },
+      );
+    } catch (e) {
+      console.error('choir subscribe error', e);
+    }
+    return () => {
+      unsubRef.current?.();
+      unsubRef.current = null;
+    };
+  }, [code, mode]);
+
+  const startAsMaster = useCallback<ChoirSessionContextValue['startAsMaster']>(
+    async (newCode, playlist, opts) => {
+      await createChoirSession(
+        newCode,
+        { deviceId, name: opts?.name },
+        playlist,
+      );
+      setMode('master');
+      setCode(newCode);
+      setOverrideTranspose(null);
+    },
+    [deviceId],
+  );
+
+  const joinAsSlave = useCallback<ChoirSessionContextValue['joinAsSlave']>(
+    async (newCode) => {
+      // No verificamos existencia explícitamente: la suscripción se
+      // encargará de avisar (session === null) y la UI lo manejará.
+      setMode('slave');
+      setCode(newCode);
+      setOverrideTranspose(null);
+    },
+    [],
+  );
+
+  const leave = useCallback(async () => {
+    const prevMode = mode;
+    const prevCode = code;
+    setMode('off');
+    setCode(null);
+    setOverrideTranspose(null);
+    if (prevMode === 'master' && prevCode) {
+      try {
+        await closeChoirSession(prevCode);
+      } catch (e) {
+        console.error('Error cerrando sesión coro', e);
+      }
+    }
+  }, [mode, code]);
+
+  const publishCurrent = useCallback(
+    async (current: Omit<ChoirCurrentSong, 'updatedAt'>) => {
+      if (mode !== 'master' || !code) return;
+      try {
+        await publishChoirCurrent(code, current);
+      } catch (e) {
+        console.error('publishCurrent error', e);
+      }
+    },
+    [mode, code],
+  );
+
+  const publishPlaylist = useCallback(
+    async (playlist: SelectedSong[]) => {
+      if (mode !== 'master' || !code) return;
+      try {
+        await publishChoirPlaylist(code, playlist);
+      } catch (e) {
+        console.error('publishPlaylist error', e);
+      }
+    },
+    [mode, code],
+  );
+
+  const changeCode = useCallback(
+    async (newCode: string) => {
+      if (!code) throw new Error('No hay sesión activa');
+      if (mode !== 'master') {
+        throw new Error('Solo el maestro puede cambiar el código');
+      }
+      await changeChoirSessionCode(code, newCode);
+      setCode(newCode);
+    },
+    [code, mode],
+  );
+
+  const value = useMemo<ChoirSessionContextValue>(
+    () => ({
+      mode,
+      code,
+      session,
+      overrideTranspose,
+      deviceId,
+      startAsMaster,
+      joinAsSlave,
+      leave,
+      publishCurrent,
+      publishPlaylist,
+      setOverrideTranspose,
+      changeCode,
+    }),
+    [
+      mode,
+      code,
+      session,
+      overrideTranspose,
+      deviceId,
+      startAsMaster,
+      joinAsSlave,
+      leave,
+      publishCurrent,
+      publishPlaylist,
+      changeCode,
+    ],
+  );
+
+  return (
+    <ChoirSessionContext.Provider value={value}>
+      {children}
+    </ChoirSessionContext.Provider>
+  );
+};
+
+export const useChoirSession = (): ChoirSessionContextValue => {
+  const ctx = useContext(ChoirSessionContext);
+  if (!ctx) {
+    throw new Error('useChoirSession must be used within ChoirSessionProvider');
+  }
+  return ctx;
+};

--- a/mcm-app/contexts/SelectedSongsContext.tsx
+++ b/mcm-app/contexts/SelectedSongsContext.tsx
@@ -1,62 +1,256 @@
-import React, { createContext, useState, useContext, ReactNode, useMemo, useCallback } from 'react';
+import React, {
+  createContext,
+  useState,
+  useContext,
+  ReactNode,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// Define the shape of the context value
-interface SelectedSongsContextType {
-  selectedSongs: string[];
-  addSong: (filename: string) => void;
-  removeSong: (filename: string) => void;
-  isSongSelected: (filename: string) => boolean;
-  clearSelection: () => void;
+/**
+ * Representa una canción seleccionada por el usuario en su playlist actual.
+ *
+ *  - `transpose`: semitonos sobre el tono original (positivo sube, negativo
+ *    baja). Se persiste por canción dentro de la selección. Si el usuario
+ *    abre la canción desde fuera de la selección, este valor no aplica
+ *    (la pantalla de detalle vuelve a un transpose efímero local).
+ *  - `order`: posición global asignada cuando el usuario reordena
+ *    libremente. En modo "por categoría" se ignora.
+ *  - `categoryHint`: clave de la categoría original (p. ej. "entrada").
+ *    Se rellena cuando se conoce y se usa como agrupador por defecto y
+ *    como pista para el agrupado tras una importación.
+ */
+export interface SelectedSong {
+  filename: string;
+  transpose: number;
+  order: number;
+  categoryHint?: string;
+  addedAt: number;
 }
 
-// Create the context with a default undefined value
+/** Forma persistida en AsyncStorage. */
+interface StoredPlaylist {
+  version: 2;
+  songs: SelectedSong[];
+}
+
+const STORAGE_KEY = '@mcm_playlist_v2';
+const LEGACY_STORAGE_KEY = '@mcm_selected_songs_v1';
+
+interface SelectedSongsContextType {
+  /** Lista de canciones seleccionadas, ya ordenada por `order` ascendente. */
+  selectedSongs: SelectedSong[];
+  /** Filenames en el mismo orden, para compatibilidad con código existente. */
+  selectedFilenames: string[];
+  /** Carga inicial desde AsyncStorage en curso. */
+  isHydrated: boolean;
+
+  isSongSelected: (filename: string) => boolean;
+  getSelectedSong: (filename: string) => SelectedSong | undefined;
+
+  addSong: (
+    filename: string,
+    opts?: { transpose?: number; categoryHint?: string },
+  ) => void;
+  removeSong: (filename: string) => void;
+  clearSelection: () => void;
+  setTranspose: (filename: string, transpose: number) => void;
+
+  /** Mueve la canción `filename` a la posición destino `toIndex` (0-based). */
+  moveSong: (filename: string, toIndex: number) => void;
+  /** Reemplaza completamente la playlist (importar, sincronización coro…). */
+  replaceAll: (songs: SelectedSong[]) => void;
+}
+
 const SelectedSongsContext = createContext<
   SelectedSongsContextType | undefined
 >(undefined);
 
-// Define the props for the provider
 interface SelectedSongsProviderProps {
   children: ReactNode;
 }
 
-// Create the provider component
+/** Reordena `order` para que sean enteros consecutivos empezando en 0. */
+function normalizeOrder(songs: SelectedSong[]): SelectedSong[] {
+  return [...songs]
+    .sort((a, b) => a.order - b.order || a.addedAt - b.addedAt)
+    .map((s, i) => ({ ...s, order: i }));
+}
+
 export const SelectedSongsProvider: React.FC<SelectedSongsProviderProps> = ({
   children,
 }) => {
-  const [selectedSongs, setSelectedSongs] = useState<string[]>([]);
+  const [selectedSongs, setSelectedSongsState] = useState<SelectedSong[]>([]);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const hydrationDone = useRef(false);
 
-  const selectedSongsSet = useMemo(() => new Set(selectedSongs), [selectedSongs]);
-
-  const addSong = useCallback((filename: string) => {
-    setSelectedSongs((prevSelectedSongs) => {
-      if (!prevSelectedSongs.includes(filename)) {
-        return [...prevSelectedSongs, filename];
+  // Hidratar desde AsyncStorage en el primer render.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as StoredPlaylist;
+          if (parsed && parsed.version === 2 && Array.isArray(parsed.songs)) {
+            if (!cancelled) {
+              setSelectedSongsState(normalizeOrder(parsed.songs));
+            }
+          }
+        } else {
+          // Migración tolerante desde el formato antiguo (array de strings).
+          const legacy = await AsyncStorage.getItem(LEGACY_STORAGE_KEY);
+          if (legacy) {
+            try {
+              const arr = JSON.parse(legacy);
+              if (Array.isArray(arr)) {
+                const now = Date.now();
+                const migrated: SelectedSong[] = arr.map(
+                  (filename: string, i: number) => ({
+                    filename,
+                    transpose: 0,
+                    order: i,
+                    addedAt: now + i,
+                  }),
+                );
+                if (!cancelled) {
+                  setSelectedSongsState(migrated);
+                }
+              }
+            } catch {
+              // ignorar
+            }
+            await AsyncStorage.removeItem(LEGACY_STORAGE_KEY);
+          }
+        }
+      } catch (e) {
+        console.error('Error hidratando playlist seleccionada', e);
+      } finally {
+        if (!cancelled) {
+          hydrationDone.current = true;
+          setIsHydrated(true);
+        }
       }
-      return prevSelectedSongs;
-    });
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
+  // Persistencia tras cada cambio (ya hidratada).
+  useEffect(() => {
+    if (!hydrationDone.current) return;
+    const stored: StoredPlaylist = { version: 2, songs: selectedSongs };
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored)).catch((e) => {
+      console.error('Error guardando playlist seleccionada', e);
+    });
+  }, [selectedSongs]);
+
+  const selectedSongsMap = useMemo(() => {
+    const m = new Map<string, SelectedSong>();
+    selectedSongs.forEach((s) => m.set(s.filename, s));
+    return m;
+  }, [selectedSongs]);
+
+  const selectedFilenames = useMemo(
+    () => selectedSongs.map((s) => s.filename),
+    [selectedSongs],
+  );
+
+  const isSongSelected = useCallback(
+    (filename: string) => selectedSongsMap.has(filename),
+    [selectedSongsMap],
+  );
+
+  const getSelectedSong = useCallback(
+    (filename: string) => selectedSongsMap.get(filename),
+    [selectedSongsMap],
+  );
+
+  const addSong = useCallback<SelectedSongsContextType['addSong']>(
+    (filename, opts) => {
+      setSelectedSongsState((prev) => {
+        if (prev.some((s) => s.filename === filename)) return prev;
+        const next: SelectedSong = {
+          filename,
+          transpose: opts?.transpose ?? 0,
+          order: prev.length,
+          categoryHint: opts?.categoryHint,
+          addedAt: Date.now(),
+        };
+        return [...prev, next];
+      });
+    },
+    [],
+  );
+
   const removeSong = useCallback((filename: string) => {
-    setSelectedSongs((prevSelectedSongs) =>
-      prevSelectedSongs.filter((song) => song !== filename),
+    setSelectedSongsState((prev) =>
+      normalizeOrder(prev.filter((s) => s.filename !== filename)),
     );
   }, []);
 
-  const isSongSelected = useCallback((filename: string): boolean => {
-    return selectedSongsSet.has(filename);
-  }, [selectedSongsSet]);
-
   const clearSelection = useCallback(() => {
-    setSelectedSongs([]);
+    setSelectedSongsState([]);
   }, []);
 
-  const contextValue = useMemo(() => ({
-    selectedSongs,
-    addSong,
-    removeSong,
-    isSongSelected,
-    clearSelection,
-  }), [selectedSongs, addSong, removeSong, isSongSelected, clearSelection]);
+  const setTranspose = useCallback((filename: string, transpose: number) => {
+    // Normalizamos a (-11..+11). Octavas completas no aportan nada.
+    let t = transpose;
+    if (t >= 12 || t <= -12) t = t % 12;
+    setSelectedSongsState((prev) =>
+      prev.map((s) => (s.filename === filename ? { ...s, transpose: t } : s)),
+    );
+  }, []);
+
+  const moveSong = useCallback((filename: string, toIndex: number) => {
+    setSelectedSongsState((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const fromIndex = sorted.findIndex((s) => s.filename === filename);
+      if (fromIndex < 0) return prev;
+      const clamped = Math.max(0, Math.min(toIndex, sorted.length - 1));
+      if (clamped === fromIndex) return prev;
+      const [moved] = sorted.splice(fromIndex, 1);
+      sorted.splice(clamped, 0, moved);
+      return sorted.map((s, i) => ({ ...s, order: i }));
+    });
+  }, []);
+
+  const replaceAll = useCallback((songs: SelectedSong[]) => {
+    setSelectedSongsState(normalizeOrder(songs));
+  }, []);
+
+  const contextValue = useMemo<SelectedSongsContextType>(
+    () => ({
+      selectedSongs,
+      selectedFilenames,
+      isHydrated,
+      isSongSelected,
+      getSelectedSong,
+      addSong,
+      removeSong,
+      clearSelection,
+      setTranspose,
+      moveSong,
+      replaceAll,
+    }),
+    [
+      selectedSongs,
+      selectedFilenames,
+      isHydrated,
+      isSongSelected,
+      getSelectedSong,
+      addSong,
+      removeSong,
+      clearSelection,
+      setTranspose,
+      moveSong,
+      replaceAll,
+    ],
+  );
 
   return (
     <SelectedSongsContext.Provider value={contextValue}>
@@ -65,7 +259,6 @@ export const SelectedSongsProvider: React.FC<SelectedSongsProviderProps> = ({
   );
 };
 
-// Custom hook to use the SelectedSongsContext
 export const useSelectedSongs = (): SelectedSongsContextType => {
   const context = useContext(SelectedSongsContext);
   if (context === undefined) {

--- a/mcm-app/hooks/useIncomingPlaylist.ts
+++ b/mcm-app/hooks/useIncomingPlaylist.ts
@@ -31,8 +31,21 @@ export function useIncomingPlaylist(onImport: ImportCallback) {
       });
 
       const parsed = JSON.parse(content);
+      let filenames: string[] | null = null;
       if (Array.isArray(parsed) && parsed.length > 0) {
-        onImportRef.current(parsed);
+        filenames = parsed;
+      } else if (
+        parsed &&
+        parsed.version === 2 &&
+        Array.isArray(parsed.songs) &&
+        parsed.songs.length > 0
+      ) {
+        filenames = (parsed.songs as { filename: string }[])
+          .map((s) => s.filename)
+          .filter(Boolean);
+      }
+      if (filenames && filenames.length > 0) {
+        onImportRef.current(filenames);
       }
     } catch (err) {
       console.error('Error handling incoming playlist file:', err);

--- a/mcm-app/services/choirSessionService.ts
+++ b/mcm-app/services/choirSessionService.ts
@@ -1,0 +1,194 @@
+/**
+ * "Modo Coro": un dispositivo maestro publica la canción que está mirando
+ * (y su tono) y N dispositivos esclavos la siguen en tiempo real.
+ *
+ * Estructura en Firebase Realtime Database:
+ *
+ *   /choirSessions/{code} = {
+ *     v: 1,
+ *     master: { deviceId, name?, lastSeen },
+ *     playlist: SelectedSong[],
+ *     current: { filename, transpose, screen?, updatedAt } | null,
+ *     createdAt, updatedAt, lastActivity, expiresAt
+ *   }
+ *
+ * Sin permisos: cualquiera con el código puede leer y escribir. Se asume
+ * un grupo de confianza pequeño (20 dispositivos máx.) y baja frecuencia.
+ */
+import {
+  getDatabase,
+  ref,
+  get,
+  set,
+  update,
+  remove,
+  onValue,
+  off,
+} from 'firebase/database';
+import { getFirebaseApp } from '@/hooks/firebaseApp';
+import type { SelectedSong } from '@/contexts/SelectedSongsContext';
+import { CODE_LENGTH, isValidCode } from '@/utils/playlistCodes';
+
+const ROOT = 'choirSessions';
+const TWO_WEEKS_MS = 1000 * 60 * 60 * 24 * 14;
+
+export interface ChoirCurrentSong {
+  filename: string;
+  /** Semitonos sobre el tono original. */
+  transpose: number;
+  /** Marcador opcional: 'detail' (por defecto) o 'fullscreen'. */
+  screen?: 'detail' | 'fullscreen';
+  updatedAt: number;
+  // Metadatos para que el esclavo pueda renderizar la canción sin tener
+  // que buscarla en su cantoral local (puede ser una canción que ni
+  // siquiera está en su selección).
+  title?: string;
+  author?: string;
+  songKey?: string;
+  capo?: number;
+  content?: string;
+  firebaseCategory?: string;
+}
+
+export interface ChoirSessionMaster {
+  deviceId: string;
+  name?: string;
+  lastSeen: number;
+}
+
+export interface ChoirSession {
+  v: 1;
+  master: ChoirSessionMaster;
+  playlist: SelectedSong[];
+  current: ChoirCurrentSong | null;
+  createdAt: number;
+  updatedAt: number;
+  lastActivity: number;
+  expiresAt: number;
+}
+
+function getRef(code: string) {
+  if (!isValidCode(code)) {
+    throw new Error(`Código inválido (deben ser ${CODE_LENGTH} dígitos)`);
+  }
+  const db = getDatabase(getFirebaseApp());
+  return ref(db, `${ROOT}/${code}`);
+}
+
+/** ¿Existe ya una sesión de coro con ese código? */
+export async function choirSessionExists(code: string): Promise<boolean> {
+  const snap = await get(getRef(code));
+  return snap.exists();
+}
+
+/** Lee la sesión asociada a `code` o devuelve null si no existe. */
+export async function fetchChoirSession(
+  code: string,
+): Promise<ChoirSession | null> {
+  const snap = await get(getRef(code));
+  if (!snap.exists()) return null;
+  return snap.val() as ChoirSession;
+}
+
+/**
+ * Crea o reemplaza la sesión de coro `code` con la playlist y maestro dados.
+ * Si ya existe, se sobrescribe (caller debe haber confirmado).
+ */
+export async function createChoirSession(
+  code: string,
+  master: { deviceId: string; name?: string },
+  playlist: SelectedSong[],
+): Promise<ChoirSession> {
+  const now = Date.now();
+  const payload: ChoirSession = {
+    v: 1,
+    master: {
+      deviceId: master.deviceId,
+      name: master.name,
+      lastSeen: now,
+    },
+    playlist,
+    current: null,
+    createdAt: now,
+    updatedAt: now,
+    lastActivity: now,
+    expiresAt: now + TWO_WEEKS_MS,
+  };
+  await set(getRef(code), payload);
+  return payload;
+}
+
+/** Cambia la playlist publicada por el maestro. */
+export async function publishChoirPlaylist(
+  code: string,
+  playlist: SelectedSong[],
+): Promise<void> {
+  const now = Date.now();
+  await update(getRef(code), {
+    playlist,
+    updatedAt: now,
+    lastActivity: now,
+    expiresAt: now + TWO_WEEKS_MS,
+    'master/lastSeen': now,
+  });
+}
+
+/** Cambia la "canción actual" que el maestro está mostrando. */
+export async function publishChoirCurrent(
+  code: string,
+  current: Omit<ChoirCurrentSong, 'updatedAt'>,
+): Promise<void> {
+  const now = Date.now();
+  await update(getRef(code), {
+    current: { ...current, updatedAt: now },
+    updatedAt: now,
+    lastActivity: now,
+    expiresAt: now + TWO_WEEKS_MS,
+    'master/lastSeen': now,
+  });
+}
+
+/** Suscripción en tiempo real. Devuelve la función `unsubscribe`. */
+export function subscribeChoirSession(
+  code: string,
+  onChange: (session: ChoirSession | null) => void,
+  onError?: (err: Error) => void,
+): () => void {
+  const r = getRef(code);
+  const handler = onValue(
+    r,
+    (snap) => {
+      onChange(snap.exists() ? (snap.val() as ChoirSession) : null);
+    },
+    (err) => onError?.(err),
+  );
+  return () => off(r, 'value', handler);
+}
+
+/** Borra la sesión (cierre manual por el maestro). */
+export async function closeChoirSession(code: string): Promise<void> {
+  await remove(getRef(code));
+}
+
+/**
+ * Mueve la sesión de `oldCode` a `newCode`. Falla si `newCode` está ocupado.
+ */
+export async function changeChoirSessionCode(
+  oldCode: string,
+  newCode: string,
+): Promise<ChoirSession> {
+  if (oldCode === newCode) {
+    const cur = await fetchChoirSession(oldCode);
+    if (!cur) throw new Error('La sesión ya no existe');
+    return cur;
+  }
+  if (await choirSessionExists(newCode)) {
+    throw new Error('El nuevo código ya está en uso');
+  }
+  const cur = await fetchChoirSession(oldCode);
+  if (!cur) throw new Error('La sesión original ya no existe');
+  const moved: ChoirSession = { ...cur, updatedAt: Date.now() };
+  await set(getRef(newCode), moved);
+  await remove(getRef(oldCode));
+  return moved;
+}

--- a/mcm-app/services/choirSessionService.ts
+++ b/mcm-app/services/choirSessionService.ts
@@ -114,7 +114,8 @@ export async function createChoirSession(
     lastActivity: now,
     expiresAt: now + TWO_WEEKS_MS,
   };
-  await set(getRef(code), payload);
+  const cleanPayload = JSON.parse(JSON.stringify(payload));
+  await set(getRef(code), cleanPayload);
   return payload;
 }
 
@@ -124,13 +125,14 @@ export async function publishChoirPlaylist(
   playlist: SelectedSong[],
 ): Promise<void> {
   const now = Date.now();
-  await update(getRef(code), {
+  const updatePayload = {
     playlist,
     updatedAt: now,
     lastActivity: now,
     expiresAt: now + TWO_WEEKS_MS,
     'master/lastSeen': now,
-  });
+  };
+  await update(getRef(code), JSON.parse(JSON.stringify(updatePayload)));
 }
 
 /** Cambia la "canción actual" que el maestro está mostrando. */
@@ -139,13 +141,14 @@ export async function publishChoirCurrent(
   current: Omit<ChoirCurrentSong, 'updatedAt'>,
 ): Promise<void> {
   const now = Date.now();
-  await update(getRef(code), {
+  const updatePayload = {
     current: { ...current, updatedAt: now },
     updatedAt: now,
     lastActivity: now,
     expiresAt: now + TWO_WEEKS_MS,
     'master/lastSeen': now,
-  });
+  };
+  await update(getRef(code), JSON.parse(JSON.stringify(updatePayload)));
 }
 
 /** Suscripción en tiempo real. Devuelve la función `unsubscribe`. */
@@ -188,7 +191,7 @@ export async function changeChoirSessionCode(
   const cur = await fetchChoirSession(oldCode);
   if (!cur) throw new Error('La sesión original ya no existe');
   const moved: ChoirSession = { ...cur, updatedAt: Date.now() };
-  await set(getRef(newCode), moved);
+  await set(getRef(newCode), JSON.parse(JSON.stringify(moved)));
   await remove(getRef(oldCode));
   return moved;
 }

--- a/mcm-app/services/cloudPlaylistService.ts
+++ b/mcm-app/services/cloudPlaylistService.ts
@@ -74,7 +74,8 @@ export async function uploadCloudPlaylist(
     updatedAt: now,
     expiresAt: now + SIX_MONTHS_MS,
   };
-  await set(getRef(code), payload);
+  const cleanPayload = JSON.parse(JSON.stringify(payload));
+  await set(getRef(code), cleanPayload);
   return payload;
 }
 

--- a/mcm-app/services/cloudPlaylistService.ts
+++ b/mcm-app/services/cloudPlaylistService.ts
@@ -1,0 +1,110 @@
+/**
+ * Subida / descarga de playlists a Firebase Realtime Database bajo un código
+ * corto de 4 dígitos. Sin permisos: cualquiera con el código puede leerla,
+ * sobrescribirla o borrarla.
+ *
+ * Las playlists incluyen `expiresAt` con +6 meses sobre el momento de
+ * creación; la purga real se hace por backend más adelante.
+ */
+import { getDatabase, ref, get, set, remove } from 'firebase/database';
+import { getFirebaseApp } from '@/hooks/firebaseApp';
+import type { SelectedSong } from '@/contexts/SelectedSongsContext';
+import { CODE_LENGTH, isValidCode } from '@/utils/playlistCodes';
+
+const ROOT = 'playlistShares';
+const SIX_MONTHS_MS = 1000 * 60 * 60 * 24 * 30 * 6;
+
+export interface CloudPlaylist {
+  v: 2;
+  songs: SelectedSong[];
+  name?: string;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number;
+}
+
+function getRef(code: string) {
+  if (!isValidCode(code)) {
+    throw new Error(`Código inválido (deben ser ${CODE_LENGTH} dígitos)`);
+  }
+  const db = getDatabase(getFirebaseApp());
+  return ref(db, `${ROOT}/${code}`);
+}
+
+/** ¿Existe ya una playlist con ese código? */
+export async function cloudPlaylistExists(code: string): Promise<boolean> {
+  const snap = await get(getRef(code));
+  return snap.exists();
+}
+
+/** Lee la playlist asociada a `code` o devuelve null si no existe. */
+export async function fetchCloudPlaylist(
+  code: string,
+): Promise<CloudPlaylist | null> {
+  const snap = await get(getRef(code));
+  if (!snap.exists()) return null;
+  const val = snap.val() as CloudPlaylist;
+  // Limpieza "perezosa": si está caducada, la borramos y simulamos no existir.
+  if (val.expiresAt && Date.now() > val.expiresAt) {
+    try {
+      await remove(getRef(code));
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+  return val;
+}
+
+/**
+ * Sube `songs` bajo `code`. Si `code` ya existe, sobrescribe.
+ * Si quieres prevenir colisiones, llama antes a {@link cloudPlaylistExists}.
+ */
+export async function uploadCloudPlaylist(
+  code: string,
+  songs: SelectedSong[],
+  opts?: { name?: string; createdAt?: number },
+): Promise<CloudPlaylist> {
+  const now = Date.now();
+  const payload: CloudPlaylist = {
+    v: 2,
+    songs,
+    name: opts?.name,
+    createdAt: opts?.createdAt ?? now,
+    updatedAt: now,
+    expiresAt: now + SIX_MONTHS_MS,
+  };
+  await set(getRef(code), payload);
+  return payload;
+}
+
+/** Borra la playlist asociada a `code`. */
+export async function deleteCloudPlaylist(code: string): Promise<void> {
+  await remove(getRef(code));
+}
+
+/**
+ * Mueve la playlist de `oldCode` a `newCode`. Preserva createdAt.
+ * Si `newCode` ya existe, lanza error (el caller decide qué hacer).
+ */
+export async function changeCloudPlaylistCode(
+  oldCode: string,
+  newCode: string,
+): Promise<CloudPlaylist> {
+  if (oldCode === newCode) {
+    const cur = await fetchCloudPlaylist(oldCode);
+    if (!cur) throw new Error('La playlist ya no existe');
+    return cur;
+  }
+  if (await cloudPlaylistExists(newCode)) {
+    throw new Error('El nuevo código ya está en uso');
+  }
+  const cur = await fetchCloudPlaylist(oldCode);
+  if (!cur) throw new Error('La playlist original ya no existe');
+  const moved = await uploadCloudPlaylist(newCode, cur.songs, {
+    name: cur.name,
+    createdAt: cur.createdAt,
+  });
+  await deleteCloudPlaylist(oldCode);
+  return moved;
+}

--- a/mcm-app/utils/pendingCloudPlaylist.ts
+++ b/mcm-app/utils/pendingCloudPlaylist.ts
@@ -6,18 +6,33 @@
  * lo perdemos y eso está bien — la URL ya no contiene el parámetro tras
  * el redirect.
  */
-let pending: string | null = null;
+let pendingPlaylist: string | null = null;
+let pendingChoir: string | null = null;
 
 export function setPendingCloudPlaylistCode(code: string | null) {
-  pending = code;
+  pendingPlaylist = code;
 }
 
 export function consumePendingCloudPlaylistCode(): string | null {
-  const code = pending;
-  pending = null;
+  const code = pendingPlaylist;
+  pendingPlaylist = null;
   return code;
 }
 
 export function peekPendingCloudPlaylistCode(): string | null {
-  return pending;
+  return pendingPlaylist;
+}
+
+export function setPendingChoirCode(code: string | null) {
+  pendingChoir = code;
+}
+
+export function consumePendingChoirCode(): string | null {
+  const code = pendingChoir;
+  pendingChoir = null;
+  return code;
+}
+
+export function peekPendingChoirCode(): string | null {
+  return pendingChoir;
 }

--- a/mcm-app/utils/pendingCloudPlaylist.ts
+++ b/mcm-app/utils/pendingCloudPlaylist.ts
@@ -1,0 +1,23 @@
+/**
+ * Mini-cola in-memory para pasar un código de playlist en la nube desde
+ * el deep link (`/playlist?p=1234`) hasta la pantalla SelectedSongs.
+ *
+ * Se consume una sola vez. No persiste en disco: si el usuario recarga,
+ * lo perdemos y eso está bien — la URL ya no contiene el parámetro tras
+ * el redirect.
+ */
+let pending: string | null = null;
+
+export function setPendingCloudPlaylistCode(code: string | null) {
+  pending = code;
+}
+
+export function consumePendingCloudPlaylistCode(): string | null {
+  const code = pending;
+  pending = null;
+  return code;
+}
+
+export function peekPendingCloudPlaylistCode(): string | null {
+  return pending;
+}

--- a/mcm-app/utils/playlistCodes.ts
+++ b/mcm-app/utils/playlistCodes.ts
@@ -1,0 +1,35 @@
+/**
+ * Códigos numéricos cortos usados tanto para "playlists en la nube"
+ * (subir/descargar) como para "sesiones de coro" (maestro/esclavos).
+ *
+ * Hoy son de 4 dígitos. Para ampliar a 6 u 8 basta cambiar `CODE_LENGTH`.
+ */
+export const CODE_LENGTH = 4;
+
+/** Regex que valida un código completo (exactamente N dígitos). */
+export const CODE_REGEX = new RegExp(`^\\d{${CODE_LENGTH}}$`);
+
+/** ¿Es un código bien formado? */
+export function isValidCode(code: string): boolean {
+  return CODE_REGEX.test(code);
+}
+
+/** Devuelve un código aleatorio de N dígitos (con padding de ceros). */
+export function generateRandomCode(): string {
+  const max = 10 ** CODE_LENGTH;
+  const n = Math.floor(Math.random() * max);
+  return String(n).padStart(CODE_LENGTH, '0');
+}
+
+/**
+ * Sugerencia "fecha de hoy" como código memorable (DDMM con N=4).
+ * Si N > 4 añade YY o YYYY al final hasta completar.
+ */
+export function todayCode(): string {
+  const now = new Date();
+  const dd = String(now.getDate()).padStart(2, '0');
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const yyyy = String(now.getFullYear());
+  const base = `${dd}${mm}${yyyy}`;
+  return base.slice(0, CODE_LENGTH).padEnd(CODE_LENGTH, '0');
+}

--- a/mcm-app/utils/transposeKey.ts
+++ b/mcm-app/utils/transposeKey.ts
@@ -1,0 +1,45 @@
+/**
+ * Calcula el tono resultante tras aplicar `semitones` a la nota original.
+ *
+ * Usa ChordSheetJS internamente para evitar duplicar la tabla cromática
+ * (y para que coincida exactamente con la transposición real que aplica
+ * `useSongProcessor`).
+ */
+import { ChordProParser, ChordLyricsPair } from 'chordsheetjs';
+
+const cache = new Map<string, string>();
+
+export function transposeKey(
+  originalKey: string | undefined | null,
+  semitones: number,
+): string {
+  if (!originalKey) return '';
+  const k = originalKey.toUpperCase();
+  if (!semitones) return k;
+
+  const cacheKey = `${k}|${semitones}`;
+  const hit = cache.get(cacheKey);
+  if (hit) return hit;
+
+  try {
+    const tmp = new ChordProParser().parse(`{key: ${k}}\n[${k}]`);
+    const transposed = tmp.transpose(semitones);
+    if (transposed.lines.length > 0 && transposed.lines[0].items.length > 0) {
+      const item = transposed.lines[0].items[0];
+      if (item instanceof ChordLyricsPair && item.chords) {
+        const out = item.chords.toUpperCase();
+        cache.set(cacheKey, out);
+        return out;
+      }
+    }
+  } catch (e) {
+    console.warn('transposeKey error', e);
+  }
+  return k;
+}
+
+/** Etiqueta humana corta del transporte: "+2", "-3", "" si 0. */
+export function transposeLabel(semitones: number): string {
+  if (!semitones) return '';
+  return semitones > 0 ? `+${semitones}` : `${semitones}`;
+}


### PR DESCRIPTION
Reforma completa del sistema de "Seleccionadas" siguiendo las 4 piezas
acordadas con el equipo:

- Modelo nuevo SelectedSong[] con transpose persistido por canción, orden
  arrastrable y persistencia AsyncStorage (`@mcm_playlist_v2`). Migración
  tolerante desde el formato anterior (array de strings).

- Exportar/importar archivo .mcm v2 que incluye tono y orden, e importación
  tolerante con v1. Texto compartido reflejando el tono transportado.

- Subir/descargar playlists desde Firebase RTDB con código de 4 dígitos
  bajo /playlistShares/{code} (ampliable a 6/8 cambiando CODE_LENGTH). Si
  el código está ocupado, se pregunta: sobrescribir / cambiar / cancelar.
  URL compartible https://mcm.expo.app/playlist?p=1234 con autoimport.
  `expiresAt` a 6 meses (purga real para Cloud Function futura).

- Modo Coro: un dispositivo maestro publica `current { filename, transpose,
  metadatos }` en /choirSessions/{code} en tiempo real; los esclavos se
  suscriben y navegan automáticamente a SongDetail. Cada esclavo puede
  pulsar "Mi tono" para desincronizar el transpose localmente. La sesión
  persiste si el maestro cierra la app y expira a las 2 semanas. Banner
  persistente con código, rol, tono activo y salir/cerrar.

UI rediseñada: header con botón único "…" que abre menú con todas las
acciones (estilo bottom-sheet), vista doble "Por categoría / Orden libre"
con controles ↑↓, diálogo OTP visual de 4 dígitos con sugerencias
"Aleatorio" y "Hoy (DDMM)", confirmador multi-acción reutilizable, pill
de tono con original tachado + final + badge "+N" en SongListItem y en
las filas de la playlist.