### PR TITLE
fix: prevent transparent screens during swipe-back in Cantoral stack

### DIFF
--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -437,7 +437,7 @@ export default function Calendario() {
             }}
           >
             <Calendar
-              key={calendarKey}
+              key={`${calendarKey}-${scheme ?? 'light'}`}
               current={selectedDate}
               onDayPress={(day) => {
                 if (day.dateString !== selectedDate) {
@@ -450,7 +450,10 @@ export default function Calendario() {
               markedDates={markedDates}
               markingType="multi-period"
               firstDay={1}
-              style={styles.calendar}
+              style={[
+                styles.calendar,
+                { backgroundColor: isDark ? '#1C1C1E' : '#F2F2F7' },
+              ]}
               theme={{
                 calendarBackground: isDark ? '#1C1C1E' : '#F2F2F7',
                 dayTextColor: isDark ? '#FFFFFF' : '#1C1C1E',

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -65,16 +65,28 @@ export default function CancioneroTab() {
   const choir = useChoirSession();
 
   useEffect(() => {
-    const unsubscribe = navigation
+    // When this tab gains focus coming from another tab, reset the stack.
+    const unsubscribeFocus = navigation.addListener('focus' as any, () => {
+      if (stackNavRef.current?.canGoBack()) {
+        stackNavRef.current.popToTop();
+      }
+    });
+
+    // When the user taps this tab while already on it, prevent the default
+    // scroll-to-top behavior and pop to root instead.
+    const unsubscribeTabPress = navigation
       .getParent()
       ?.addListener('tabPress' as any, (e: any) => {
-        if (stackNavRef.current?.canGoBack()) {
+        if ((navigation as any).isFocused?.() && stackNavRef.current?.canGoBack()) {
           e.preventDefault?.();
           stackNavRef.current.popToTop();
         }
       });
 
-    return unsubscribe;
+    return () => {
+      unsubscribeFocus();
+      unsubscribeTabPress?.();
+    };
   }, [navigation]);
 
   // Modo coro - ESCLAVO: cuando el maestro cambia la canción actual,

--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Platform, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 import CategoriesScreen from '../screens/CategoriesScreen';
 import SongListScreen from '../screens/SongListScreen';
@@ -58,6 +59,7 @@ export default function CancioneroTab() {
   const stackNavRef = useRef<any>(null);
   const insets = useSafeAreaInsets();
   const webStatusBarHeight = isWeb ? insets.top : undefined;
+  const scheme = useColorScheme();
 
   const navigation = useNavigation();
   const choir = useChoirSession();
@@ -147,6 +149,12 @@ export default function CancioneroTab() {
             headerShadowVisible: false,
             headerBackTitle: 'Volver',
             headerBackButtonDisplayMode: 'minimal' as const,
+            // Prevents screens from appearing transparent during swipe-back
+            // gestures. headerTransparent:true makes the card itself transparent
+            // so we must set an explicit background on the content area.
+            contentStyle: isIOS
+              ? { backgroundColor: scheme === 'dark' ? '#1C1C1E' : '#F2F2F7' }
+              : undefined,
           };
         }}
       >

--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -147,16 +147,29 @@ export default function MasTab() {
   const navigation = useNavigation();
 
   useEffect(() => {
-    const unsubscribe = navigation
+    // When this tab gains focus coming from another tab, reset the stack.
+    // We do NOT call e.preventDefault here so the tab switch happens normally.
+    const unsubscribeFocus = navigation.addListener('focus' as any, () => {
+      if (stackNavRef.current?.canGoBack()) {
+        stackNavRef.current.popToTop();
+      }
+    });
+
+    // When the user taps this tab while already on it, prevent the default
+    // scroll-to-top behavior and pop to root instead.
+    const unsubscribeTabPress = navigation
       .getParent()
       ?.addListener('tabPress' as any, (e: any) => {
-        if (stackNavRef.current?.canGoBack()) {
+        if ((navigation as any).isFocused?.() && stackNavRef.current?.canGoBack()) {
           e.preventDefault?.();
           stackNavRef.current.popToTop();
         }
       });
 
-    return unsubscribe;
+    return () => {
+      unsubscribeFocus();
+      unsubscribeTabPress?.();
+    };
   }, [navigation]);
 
   return (

--- a/mcm-app/app/screens/ComidaScreen.tsx
+++ b/mcm-app/app/screens/ComidaScreen.tsx
@@ -52,7 +52,7 @@ export default function ComidaScreen() {
   const navigation = useNavigation<Nav>();
   const scheme = useColorScheme();
   const event = useCurrentEvent();
-  const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const styles = React.useMemo(() => createStyles(scheme ?? 'light'), [scheme]);
   const { width, height } = useWindowDimensions();
   const containerPadding = spacing.md;
   const gap = spacing.md;

--- a/mcm-app/app/screens/ComidaWebScreen.tsx
+++ b/mcm-app/app/screens/ComidaWebScreen.tsx
@@ -115,7 +115,7 @@ export default function ComidaWebScreen() {
         />
         {isLoading && (
           <View style={styles.loadingContainer}>
-            <Spinner size="lg" color={ThemeColors[scheme].tint} />
+            <Spinner size="lg" color={ThemeColors[scheme ?? 'light'].tint} />
           </View>
         )}
       </View>
@@ -130,7 +130,7 @@ export default function ComidaWebScreen() {
         startInLoadingState={true}
         renderLoading={() => (
           <View style={styles.loadingContainer}>
-            <Spinner size="lg" color={ThemeColors[scheme].tint} />
+            <Spinner size="lg" color={ThemeColors[scheme ?? 'light'].tint} />
           </View>
         )}
         onLoadEnd={onLoadEnd}

--- a/mcm-app/app/screens/MonitoresWebScreen.tsx
+++ b/mcm-app/app/screens/MonitoresWebScreen.tsx
@@ -3,6 +3,7 @@ import { Platform, View, StyleSheet } from 'react-native';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 import { Spinner } from 'heroui-native';
 import { useToast } from '@/contexts/AppToastContext';
+import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import iframeStyles from '../../styles/comunica.module.css';
 
@@ -72,6 +73,8 @@ const INJECTED_JAVASCRIPT = `
 export default function MonitoresWebScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
 
   const onLoadEnd = () => {
     setIsLoading(false);
@@ -166,7 +169,7 @@ export default function MonitoresWebScreen() {
           onLoad={onLoadEnd}
         />
         {isLoading && (
-          <View style={styles.loadingContainer}>
+          <View style={[styles.loadingContainer, { backgroundColor: isDark ? 'rgba(0,0,0,0.8)' : 'rgba(255,255,255,0.8)' }]}>
             <Spinner />
           </View>
         )}
@@ -184,7 +187,7 @@ export default function MonitoresWebScreen() {
         injectedJavaScript={INJECTED_JAVASCRIPT}
         onMessage={() => {}}
         renderLoading={() => (
-          <View style={styles.loadingContainer}>
+          <View style={[styles.loadingContainer, { backgroundColor: isDark ? 'rgba(0,0,0,0.8)' : 'rgba(255,255,255,0.8)' }]}>
             <Spinner />
           </View>
         )}
@@ -212,7 +215,6 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgba(255, 255, 255, 0.8)',
   },
   // Estilos para web: eliminamos márgenes y aprovechamos todo el espacio
   containerWeb: {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -1117,7 +1117,9 @@ const SelectedSongsScreen: React.FC = () => {
   // --- Header ---------------------------------------------------------------
 
   const headerIconColor =
-    Platform.OS === 'ios' || Platform.OS === 'web' ? '#1a1a1a' : '#fff';
+    Platform.OS === 'ios' || Platform.OS === 'web'
+      ? isDark ? '#ffffff' : '#1a1a1a'
+      : '#fff';
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -26,7 +26,7 @@ export default function SongFullscreenScreen({
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
   const { settings } = useSettings();
   const { chordsVisible, fontSize, fontFamily, notation } = settings;
 

--- a/mcm-app/app/screens/WordleScreen.tsx
+++ b/mcm-app/app/screens/WordleScreen.tsx
@@ -45,8 +45,9 @@ const EMOJIS = ['😀', '😁', '😊', '😎', '🤩', '🥳'];
 export default function WordleScreen() {
   const navigation = useNavigation();
   const scheme = useColorScheme();
-  const theme = Colors[scheme];
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const theme = Colors[scheme ?? 'light'];
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(theme, isDark), [theme, isDark]);
   const emoji = useMemo(
     () => EMOJIS[Math.floor(Math.random() * EMOJIS.length)],
     [],
@@ -653,7 +654,7 @@ export default function WordleScreen() {
   );
 }
 
-const createStyles = (theme: typeof Colors.light) =>
+const createStyles = (theme: typeof Colors.light, isDark: boolean) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -716,7 +717,7 @@ const createStyles = (theme: typeof Colors.light) =>
       paddingHorizontal: Platform.OS === 'web' ? 8 : 12,
       marginHorizontal: 3,
       borderRadius: 8,
-      backgroundColor: theme.background === '#2C2C2E' ? '#555' : '#d3d6da',
+      backgroundColor: isDark ? '#555' : '#d3d6da',
       minWidth: Platform.OS === 'web' ? 28 : 32,
       justifyContent: 'center',
       alignItems: 'center',

--- a/mcm-app/components/AddToHomeBanner.tsx
+++ b/mcm-app/components/AddToHomeBanner.tsx
@@ -38,7 +38,7 @@ export default function AddToHomeScreenPrompt() {
   }, []);
 
   if (!visible) return null;
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   const handleInstall = () => {
     if (installEvent) {

--- a/mcm-app/components/AppFeedbackModal.tsx
+++ b/mcm-app/components/AppFeedbackModal.tsx
@@ -83,7 +83,7 @@ export default function AppFeedbackModal({
 }: AppFeedbackModalProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
   const { profile } = useUserProfile();
   const resolved = useResolvedProfileConfig();
   const [selectedCategory, setSelectedCategory] =

--- a/mcm-app/components/BottomSheet.tsx
+++ b/mcm-app/components/BottomSheet.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { BottomSheet as HeroBottomSheet } from 'heroui-native';
-import { UIColors } from '@/constants/colors';
+import { UIColors, Colors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 interface BottomSheetProps {
   visible: boolean;
@@ -22,6 +23,9 @@ export default function BottomSheet({
   onClose,
   children,
 }: BottomSheetProps) {
+  const scheme = useColorScheme();
+  const bgColor = Colors[scheme ?? 'light'].background;
+
   return (
     <HeroBottomSheet
       isOpen={visible}
@@ -31,7 +35,9 @@ export default function BottomSheet({
     >
       <HeroBottomSheet.Portal>
         <HeroBottomSheet.Overlay style={styles.overlay} />
-        <HeroBottomSheet.Content>{children}</HeroBottomSheet.Content>
+        <HeroBottomSheet.Content style={{ backgroundColor: bgColor }}>
+          {children}
+        </HeroBottomSheet.Content>
       </HeroBottomSheet.Portal>
     </HeroBottomSheet>
   );

--- a/mcm-app/components/ReportBugsModal.tsx
+++ b/mcm-app/components/ReportBugsModal.tsx
@@ -49,7 +49,7 @@ export default function ReportBugsModal({
 }: ReportBugsModalProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
   const { profile } = useUserProfile();
   const resolved = useResolvedProfileConfig();
   const [bugDescription, setBugDescription] = useState('');

--- a/mcm-app/components/SecretPanelModal.tsx
+++ b/mcm-app/components/SecretPanelModal.tsx
@@ -34,7 +34,7 @@ const FullBottomSheet = ({
   children: React.ReactNode;
 }) => {
   const scheme = useColorScheme();
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   return (
     <Modal
@@ -102,7 +102,7 @@ export default function SecretPanelModal({
   onSuccess,
 }: SecretPanelModalProps) {
   const scheme = useColorScheme();
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [password, setPassword] = useState('');

--- a/mcm-app/components/SettingsPanel.tsx
+++ b/mcm-app/components/SettingsPanel.tsx
@@ -289,58 +289,66 @@ export default function SettingsPanel({ visible, onClose }: Props) {
             </View>
           </View>
 
-          {/* ── Sección: Debug ── */}
-          <Text
-            style={[
-              styles.sectionLabel,
-              { color: theme.icon, marginTop: spacing.md },
-            ]}
-          >
-            DEPURACIÓN
-          </Text>
-          <PressableFeedback
-            style={[
-              styles.surface,
-              styles.surfaceClickable,
-              { backgroundColor: surfaceBg },
-            ]}
-            onPress={async () => {
-              try {
-                const projectId =
-                  Constants?.expoConfig?.extra?.eas?.projectId ??
-                  Constants?.easConfig?.projectId;
-                const Notifications = await import('expo-notifications');
-                const { data } = await Notifications.getExpoPushTokenAsync(
-                  projectId ? { projectId } : undefined,
-                );
-                await Clipboard.setStringAsync(data);
-                toast.show({
-                  variant: 'success',
-                  label: 'Expo Token copiado al portapapeles',
-                });
-              } catch (err) {
-                toast.show({
-                  variant: 'danger',
-                  label: 'Error obteniendo token: ' + String(err),
-                });
-              }
-            }}
-            accessibilityRole="button"
-          >
-            <PressableFeedback.Highlight />
-            <View style={[styles.surfaceRow, { flex: 1 }]}>
-              <MaterialIcons name="bug-report" size={20} color={theme.icon} />
-              <Text style={[styles.surfaceLabel, { color: theme.text }]}>
-                Copiar Expo Push Token
+          {/* ── Sección: Debug (solo en desarrollo) ── */}
+          {__DEV__ && (
+            <>
+              <Text
+                style={[
+                  styles.sectionLabel,
+                  { color: theme.icon, marginTop: spacing.md },
+                ]}
+              >
+                DEPURACIÓN
               </Text>
-            </View>
-            <MaterialIcons
-              name="content-copy"
-              size={20}
-              color={theme.icon}
-              style={{ opacity: 0.4 }}
-            />
-          </PressableFeedback>
+              <PressableFeedback
+                style={[
+                  styles.surface,
+                  styles.surfaceClickable,
+                  { backgroundColor: surfaceBg },
+                ]}
+                onPress={async () => {
+                  try {
+                    const projectId =
+                      Constants?.expoConfig?.extra?.eas?.projectId ??
+                      Constants?.easConfig?.projectId;
+                    const Notifications = await import('expo-notifications');
+                    const { data } = await Notifications.getExpoPushTokenAsync(
+                      projectId ? { projectId } : undefined,
+                    );
+                    await Clipboard.setStringAsync(data);
+                    toast.show({
+                      variant: 'success',
+                      label: 'Expo Token copiado al portapapeles',
+                    });
+                  } catch (err) {
+                    toast.show({
+                      variant: 'danger',
+                      label: 'Error obteniendo token: ' + String(err),
+                    });
+                  }
+                }}
+                accessibilityRole="button"
+              >
+                <PressableFeedback.Highlight />
+                <View style={[styles.surfaceRow, { flex: 1 }]}>
+                  <MaterialIcons
+                    name="bug-report"
+                    size={20}
+                    color={theme.icon}
+                  />
+                  <Text style={[styles.surfaceLabel, { color: theme.text }]}>
+                    Copiar Expo Push Token
+                  </Text>
+                </View>
+                <MaterialIcons
+                  name="content-copy"
+                  size={20}
+                  color={theme.icon}
+                  style={{ opacity: 0.4 }}
+                />
+              </PressableFeedback>
+            </>
+          )}
         </View>
       </BottomSheet>
 

--- a/mcm-app/components/SongFontPanel.tsx
+++ b/mcm-app/components/SongFontPanel.tsx
@@ -35,7 +35,7 @@ export default function SongFontPanel({
 }: Props) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   const reset = () => {
     onSetFontSize(DEFAULT_FONT_SIZE_EM);

--- a/mcm-app/components/SuggestSongModal.tsx
+++ b/mcm-app/components/SuggestSongModal.tsx
@@ -36,7 +36,7 @@ export default function SuggestSongModal({
 }: SuggestSongModalProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
   const { profile } = useUserProfile();
   const resolved = useResolvedProfileConfig();
 

--- a/mcm-app/components/TransposePanel.tsx
+++ b/mcm-app/components/TransposePanel.tsx
@@ -30,7 +30,7 @@ export default function TransposePanel({
 }: Props) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   const TransposeButton = ({
     label,

--- a/mcm-app/components/VersionDisplay.tsx
+++ b/mcm-app/components/VersionDisplay.tsx
@@ -8,7 +8,7 @@ import { Colors } from '@/constants/colors';
 export const VersionDisplay: React.FC<{ style?: any }> = ({ style }) => {
   const [updateInfo, setUpdateInfo] = useState<string>('');
   const scheme = useColorScheme();
-  const theme = Colors[scheme];
+  const theme = Colors[scheme ?? 'light'];
 
   useEffect(() => {
     const getUpdateInfo = async () => {


### PR DESCRIPTION
headerTransparent:true on iOS makes the native stack card itself
transparent — both the current and previous screens are visible
through each other during the swipe-back gesture. Adding contentStyle
with an explicit opaque background fixes the overlap while preserving
the glass blur header effect (headerBlurEffect still works with
headerTransparent:true).

https://claude.ai/code/session_015vq4P99a7VPGaGG59TUDAt