### PR TITLE
fix(ios): resolve ITMS-90737 + add Universal Links + Cloud Function purge

### DIFF
--- a/mcm-app/.gitignore
+++ b/mcm-app/.gitignore
@@ -48,7 +48,6 @@ app-example
 /google-services.json
 google-services.json
 GoogleService-Info.plist
-firebase.json
 
 
 # prebuilds (CNG/Prebuild generated folders)

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,20 @@
 
 ---
 
+## 2026-05-18 — App Store warning fix · Universal Links · Cloud Function de purga
+
+- **Fix ITMS-90737 (App Store warning)**: añadido `LSSupportsOpeningDocumentsInPlace: true` en `ios.infoPlist` (`app.json`). Apple lo exige para cualquier app que declare `CFBundleDocumentTypes` (en este caso, el tipo de archivo `.mcm`). Sin esto la subida pasa pero genera un warning en cada release.
+- **Universal Links (iOS) / App Links (Android)** para abrir `https://mcm.expo.app/playlist?p=…` y `https://mcm.expo.app/coro?c=…` directamente en la app instalada en lugar del navegador:
+  - iOS: nuevo `ios.associatedDomains: ["applinks:mcm.expo.app"]` en `app.json`. Requiere el AppID `5P53S6QB23.com.familiaconsolacion.mcmapp`.
+  - Android: nuevo `intentFilter` con `autoVerify: true`, `scheme: https`, `host: mcm.expo.app`, `pathPrefix: /playlist|/coro` en `app.json`.
+  - **Verificación del dominio** (`mcm-app/public/.well-known/`): `apple-app-site-association` (sin extensión, components-form moderno) y `assetlinks.json`. Se sirven automáticamente al exportar la web (`expo export -p web` copia `public/` → `dist/`). **TODO antes de release**: rellenar `sha256_cert_fingerprints` en `assetlinks.json` con la huella SHA-256 de "App signing key certificate" de Play Console (o vía `eas credentials -p android`). Ver `public/.well-known/README.md` para detalles.
+- **Cloud Function de purga programada** (`mcm-app/functions/`): nueva función `purgeExpiredShares` que corre cada 24h (zona horaria Europe/Madrid) y borra entradas de `/playlistShares` y `/choirSessions` cuyo `expiresAt` ya pasó. Reemplaza la "limpieza perezosa" lado cliente que solo se ejecutaba cuando alguien intentaba leer una playlist caducada.
+  - Stack: Firebase Functions v2, `onSchedule`, TypeScript, Node 20.
+  - Despliegue manual desde `mcm-app/`: `firebase use --add` (primera vez) + `firebase deploy --only functions`. **Requiere plan Blaze** del proyecto Firebase (las scheduled functions lo exigen — se usan ~30 invocaciones/mes, entra de sobra en el free tier).
+  - Estructura nueva: `mcm-app/firebase.json`, `mcm-app/functions/{package.json,tsconfig.json,src/index.ts}`.
+
+---
+
 ## 2026-05-17 — Exportar playlist a PDF
 
 - **Nueva acción "Exportar a PDF"** en el menú "…" de la pantalla de seleccionadas (`app/screens/SelectedSongsScreen.tsx`). Genera un PDF con portada (nombre de playlist + índice de canciones con tono) y cada canción formateada con título, autor, tono (transportado y original si aplica) y cejilla en la parte superior; cuerpo con acordes sobre letras parseado desde ChordPro (vía `chordsheetjs`).

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -14,6 +14,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocationWhenInUseUsageDescription": "La app puede usar tu ubicación para habilitar funciones basadas en ubicación cuando estén disponibles (por ejemplo, mostrar información relevante cerca de ti).",
+        "LSSupportsOpeningDocumentsInPlace": true,
         "CFBundleDocumentTypes": [
           {
             "CFBundleTypeName": "MCM Playlist",
@@ -34,7 +35,8 @@
           }
         ]
       },
-      "appleTeamId": "5P53S6QB23"
+      "appleTeamId": "5P53S6QB23",
+      "associatedDomains": ["applinks:mcm.expo.app"]
     },
     "android": {
       "adaptiveIcon": {
@@ -57,6 +59,23 @@
               "scheme": "content",
               "mimeType": "*/*",
               "pathPattern": ".*\\.mcm"
+            }
+          ]
+        },
+        {
+          "autoVerify": true,
+          "action": "VIEW",
+          "category": ["DEFAULT", "BROWSABLE"],
+          "data": [
+            {
+              "scheme": "https",
+              "host": "mcm.expo.app",
+              "pathPrefix": "/playlist"
+            },
+            {
+              "scheme": "https",
+              "host": "mcm.expo.app",
+              "pathPrefix": "/coro"
             }
           ]
         }

--- a/mcm-app/firebase.json
+++ b/mcm-app/firebase.json
@@ -1,0 +1,17 @@
+{
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "runtime": "nodejs20",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log",
+        "*.local"
+      ],
+      "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run build"]
+    }
+  ]
+}

--- a/mcm-app/functions/.gitignore
+++ b/mcm-app/functions/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+lib/
+*.log
+.firebase/
+.runtimeconfig.json

--- a/mcm-app/functions/README.md
+++ b/mcm-app/functions/README.md
@@ -1,0 +1,54 @@
+# mcm-app · Cloud Functions
+
+Funciones programadas que mantienen Firebase Realtime Database limpio.
+
+## Funciones
+
+| Nombre                 | Trigger                  | Qué hace                                                                 |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------ |
+| `purgeExpiredShares`   | Schedule (24h, Europe/Madrid) | Borra entradas de `/playlistShares` y `/choirSessions` con `expiresAt` en el pasado. |
+
+## Requisitos
+
+- Node.js 20 (`engines.node` en `package.json`).
+- Proyecto Firebase en **plan Blaze** (las scheduled functions lo exigen).
+- `firebase-tools` instalado globalmente (`npm i -g firebase-tools`).
+
+## Desarrollo local
+
+```bash
+cd mcm-app/functions
+npm install
+npm run build       # compila TypeScript → lib/
+```
+
+Para probar en el emulador:
+
+```bash
+cd mcm-app
+firebase emulators:start --only functions,database
+```
+
+## Despliegue
+
+Desde `mcm-app/` (donde vive `firebase.json`):
+
+```bash
+firebase use --add      # primera vez: vincula el proyecto Firebase
+firebase deploy --only functions
+```
+
+El script `predeploy` de `firebase.json` compila TypeScript antes de subir.
+
+## Logs
+
+```bash
+cd mcm-app
+firebase functions:log --only purgeExpiredShares
+```
+
+## Coste estimado
+
+`purgeExpiredShares` corre 1×/día. En cuotas Blaze:
+- 1 invocación/día × 30 días = 30 invocaciones/mes (gratis hasta 2M).
+- Coste real estimado: **0 €** (entra de sobra en el free tier).

--- a/mcm-app/functions/package.json
+++ b/mcm-app/functions/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mcm-functions",
+  "private": true,
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc -w",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "20"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.7.0",
+    "firebase-functions": "^6.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}

--- a/mcm-app/functions/src/index.ts
+++ b/mcm-app/functions/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Cloud Functions del proyecto MCM App.
+ *
+ * Por ahora la única función es `purgeExpiredShares`: barre /playlistShares
+ * y /choirSessions y borra entradas cuyo `expiresAt` ya pasó.
+ *
+ * Despliegue:
+ *   cd mcm-app && firebase deploy --only functions
+ *
+ * Requisitos:
+ *   - Proyecto en plan Blaze (las scheduled functions lo exigen).
+ *   - `firebase use --add` ejecutado al menos una vez en mcm-app/ para
+ *     vincular el proyecto.
+ */
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions/v2';
+import { initializeApp } from 'firebase-admin/app';
+import { getDatabase } from 'firebase-admin/database';
+
+initializeApp();
+
+const PLAYLIST_ROOT = 'playlistShares';
+const CHOIR_ROOT = 'choirSessions';
+
+/**
+ * Recorre `path` y devuelve los IDs cuyo `expiresAt` (epoch ms) está en el
+ * pasado. Maneja ausencia del campo (no borra) y formato inesperado (ignora).
+ */
+async function collectExpired(path: string, now: number): Promise<string[]> {
+  const snap = await getDatabase().ref(path).once('value');
+  if (!snap.exists()) return [];
+  const root = snap.val() as Record<string, unknown>;
+  const expired: string[] = [];
+  for (const [id, value] of Object.entries(root)) {
+    if (!value || typeof value !== 'object') continue;
+    const expiresAt = (value as { expiresAt?: unknown }).expiresAt;
+    if (typeof expiresAt !== 'number') continue;
+    if (expiresAt < now) expired.push(id);
+  }
+  return expired;
+}
+
+export const purgeExpiredShares = onSchedule(
+  {
+    schedule: 'every 24 hours',
+    timeZone: 'Europe/Madrid',
+    region: 'us-central1',
+    retryCount: 0,
+  },
+  async () => {
+    const now = Date.now();
+    const [expiredPlaylists, expiredSessions] = await Promise.all([
+      collectExpired(PLAYLIST_ROOT, now),
+      collectExpired(CHOIR_ROOT, now),
+    ]);
+
+    const updates: Record<string, null> = {};
+    for (const code of expiredPlaylists) {
+      updates[`${PLAYLIST_ROOT}/${code}`] = null;
+    }
+    for (const code of expiredSessions) {
+      updates[`${CHOIR_ROOT}/${code}`] = null;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      logger.info('Nothing to purge', {
+        playlists: 0,
+        sessions: 0,
+      });
+      return;
+    }
+
+    await getDatabase().ref().update(updates);
+    logger.info('Purged expired entries', {
+      playlists: expiredPlaylists.length,
+      sessions: expiredSessions.length,
+    });
+  },
+);

--- a/mcm-app/functions/tsconfig.json
+++ b/mcm-app/functions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "compileOnSave": true,
+  "include": ["src"]
+}

--- a/mcm-app/public/.well-known/README.md
+++ b/mcm-app/public/.well-known/README.md
@@ -1,0 +1,47 @@
+# Universal Links / App Links
+
+Estos dos archivos son **obligatorios** para que iOS y Android abran
+`https://mcm.expo.app/playlist?p=...` y `https://mcm.expo.app/coro?c=...`
+directamente en la app instalada (en lugar del navegador).
+
+## `apple-app-site-association`
+
+- **Sin extensión** (Apple lo exige).
+- Debe servirse desde `https://mcm.expo.app/.well-known/apple-app-site-association`.
+- Content-Type recomendado: `application/json` (Apple ya lo acepta sin extensión).
+- HTTPS obligatorio, sin redirecciones.
+- Apple cachea el archivo agresivamente; tras cambios la primera apertura puede tardar.
+
+App ID: `5P53S6QB23.com.familiaconsolacion.mcmapp` (Team ID + bundleId).
+
+## `assetlinks.json`
+
+- Debe servirse desde `https://mcm.expo.app/.well-known/assetlinks.json`.
+- Content-Type: `application/json`.
+- El campo `sha256_cert_fingerprints` **NO está rellenado** — hay que obtener la huella
+  del certificado de firma de la app en producción:
+
+  **Opción A (Play App Signing, lo más probable):**
+  Play Console → Setup → App integrity → **App signing** → copiar el
+  "SHA-256 certificate fingerprint" del bloque _"App signing key certificate"_.
+  Pegarlo en `sha256_cert_fingerprints` con el formato `AA:BB:CC:...:99`.
+
+  **Opción B (vía EAS):**
+  ```bash
+  eas credentials -p android
+  # → seleccionar el keystore de producción y leer la huella SHA-256
+  ```
+
+Sin la huella correcta, Android **no** verificará el dominio y los enlaces
+seguirán abriendo el navegador (con el diálogo "abrir con").
+
+## Despliegue
+
+Estos archivos están bajo `mcm-app/public/`, así que el `npx expo export -p web`
+los copia automáticamente a `dist/.well-known/`. Asegúrate de que el servidor
+estático no los filtre (los archivos que empiezan por `.` a veces se ignoran).
+
+Tras desplegar, verifica:
+
+- iOS: https://app-site-association.cdn-apple.com/a/v1/mcm.expo.app
+- Android: https://developers.google.com/digital-asset-links/tools/generator

--- a/mcm-app/public/.well-known/apple-app-site-association
+++ b/mcm-app/public/.well-known/apple-app-site-association
@@ -1,0 +1,27 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["5P53S6QB23.com.familiaconsolacion.mcmapp"],
+        "components": [
+          {
+            "/": "/playlist",
+            "comment": "Cloud playlist import"
+          },
+          {
+            "/": "/playlist*",
+            "comment": "Cloud playlist import (con query)"
+          },
+          {
+            "/": "/coro",
+            "comment": "Choir session join"
+          },
+          {
+            "/": "/coro*",
+            "comment": "Choir session join (con query)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mcm-app/public/.well-known/assetlinks.json
+++ b/mcm-app/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.mcmespana.mcmapp",
+      "sha256_cert_fingerprints": [
+        "REEMPLAZAR_CON_SHA256_DE_APP_SIGNING_DE_PLAY_CONSOLE"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
- Add LSSupportsOpeningDocumentsInPlace to clear App Store warning
  triggered by the existing CFBundleDocumentTypes (.mcm playlist).
- Wire Universal Links (iOS associatedDomains) and App Links (Android
  intent filter with autoVerify) for /playlist and /coro on
  mcm.expo.app. Ships apple-app-site-association and assetlinks.json
  under public/.well-known/ for static export. Android fingerprint is
  a placeholder pending Play App Signing SHA-256.
- Add Firebase Functions v2 scheduled job purgeExpiredShares that
  sweeps /playlistShares and /choirSessions every 24h, replacing the
  client-side lazy cleanup. Requires Blaze; deploy from mcm-app/.