### PR TITLE
fix(ci): mover workflows OTA fuera de disabled/ para que se disparen

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,11 +1,13 @@
 name: Deploy Web on Production
 
-#DESACTIVADO TEMPORALMENTE - Reactivar descomentando la sección `on:`
 on:
   push:
-    branches:
-      - production
-# on: {}  # No triggers - workflow desactivado
+    branches: [production]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy-web:
@@ -27,7 +29,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcm-app/package-lock.json
+
+      - name: Verificar que EXPO_TOKEN existe
+        run: |
+          if [ -z "${EXPO_TOKEN}" ]; then
+            echo "::error::EXPO_TOKEN no está configurado en los secrets del repositorio"
+            exit 1
+          fi
 
       - name: Instalar dependencias
         working-directory: ./mcm-app

--- a/.github/workflows/ota-preview.yml
+++ b/.github/workflows/ota-preview.yml
@@ -1,13 +1,17 @@
-# .github/workflows/ota-production.yml
-name: OTA Production
+# .github/workflows/ota-preview.yml
+name: OTA Preview
 
 on:
   push:
-    branches: [ production ]
-# on: {}  # No triggers - workflow desactivado
+    branches: [preview]
+  workflow_dispatch:
+
+concurrency:
+  group: ota-preview
+  cancel-in-progress: false
 
 jobs:
-  publish-prod:
+  publish-preview:
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} # yamllint disable-line
@@ -22,26 +26,46 @@ jobs:
     steps:
       - name: Checkout código
         uses: actions/checkout@v4
-        
+        with:
+          fetch-depth: 1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcm-app/package-lock.json
+
+      - name: Verificar que EXPO_TOKEN existe
+        run: |
+          if [ -z "${EXPO_TOKEN}" ]; then
+            echo "::error::EXPO_TOKEN no está configurado en los secrets del repositorio"
+            exit 1
+          fi
+
       - name: Instalar EAS CLI
         run: npm install -g eas-cli@latest
-        
+
       - name: Instalar dependencias
         working-directory: ./mcm-app
         run: npm ci
-        
+
       - name: Verificar autenticación
         run: eas whoami
-        
-      - name: Publicar OTA en production
+
+      - name: Preparar mensaje de update
+        id: msg
+        run: |
+          COMMIT_MSG="$(git log -1 --pretty=%s)"
+          # Truncamos a 200 chars para que quepa en EAS Update
+          SHORT_MSG="${COMMIT_MSG:0:200}"
+          echo "message=🔎 ${SHORT_MSG} (${GITHUB_SHA:0:7})" >> "$GITHUB_OUTPUT"
+
+      - name: Publicar OTA en preview
         working-directory: ./mcm-app
         run: |
           eas update \
-            --branch production \
-            --message "🚀 OTA Production: ${{ github.sha }}" \
+            --branch preview \
+            --platform all \
+            --message "${{ steps.msg.outputs.message }}" \
             --non-interactive

--- a/.github/workflows/ota-production.yml
+++ b/.github/workflows/ota-production.yml
@@ -1,13 +1,17 @@
-# .github/workflows/ota-preview.yml
-name: OTA Preview
+# .github/workflows/ota-production.yml
+name: OTA Production
 
 on:
   push:
-    branches: [ preview ]
-# on: {}  # No triggers - workflow desactivado
+    branches: [production]
+  workflow_dispatch:
+
+concurrency:
+  group: ota-production
+  cancel-in-progress: false
 
 jobs:
-  publish-preview:
+  publish-prod:
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} # yamllint disable-line
@@ -22,26 +26,46 @@ jobs:
     steps:
       - name: Checkout código
         uses: actions/checkout@v4
-        
+        with:
+          fetch-depth: 1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mcm-app/package-lock.json
+
+      - name: Verificar que EXPO_TOKEN existe
+        run: |
+          if [ -z "${EXPO_TOKEN}" ]; then
+            echo "::error::EXPO_TOKEN no está configurado en los secrets del repositorio"
+            exit 1
+          fi
+
       - name: Instalar EAS CLI
         run: npm install -g eas-cli@latest
-        
+
       - name: Instalar dependencias
         working-directory: ./mcm-app
         run: npm ci
-        
+
       - name: Verificar autenticación
         run: eas whoami
-        
-      - name: Publicar OTA en preview
+
+      - name: Preparar mensaje de update
+        id: msg
+        run: |
+          COMMIT_MSG="$(git log -1 --pretty=%s)"
+          # Truncamos a 200 chars para que quepa en EAS Update
+          SHORT_MSG="${COMMIT_MSG:0:200}"
+          echo "message=🚀 ${SHORT_MSG} (${GITHUB_SHA:0:7})" >> "$GITHUB_OUTPUT"
+
+      - name: Publicar OTA en production
         working-directory: ./mcm-app
         run: |
           eas update \
-            --branch preview \
-            --message "🔎 OTA Preview: ${{ github.sha }}" \
+            --branch production \
+            --platform all \
+            --message "${{ steps.msg.outputs.message }}" \
             --non-interactive


### PR DESCRIPTION
GitHub Actions sólo escanea workflows directamente bajo .github/workflows/.
Aunque las secciones `on:` ya estaban activas (push a preview/production),
los workflows vivían en .github/workflows/disabled/ y nunca se ejecutaban,
así que los merges a esas ramas no lanzaban la OTA.

Cambios:
- Mover ota-preview.yml, ota-production.yml y deploy-web.yml a la raíz
  de .github/workflows/
- Bump Node 18 → 20 (Expo SDK 55 prefiere Node 20)
- Cache de npm en actions/setup-node@v4 (CI más rápido)
- Verificar que EXPO_TOKEN existe antes de seguir (mensaje de error claro)
- `eas update --platform all` explícito
- Mensaje de OTA con título del commit (más útil que sólo el SHA)
- `workflow_dispatch` para poder relanzar manualmente desde la UI
- `concurrency.group` para evitar pisarse updates en ráfagas de commits