### PR TITLE
Fix BottomSheet styling and improve gesture handling

### DIFF
--- a/mcm-app/app/(tabs)/cancionero.tsx
+++ b/mcm-app/app/(tabs)/cancionero.tsx
@@ -175,11 +175,6 @@ export default function CancioneroTab() {
           component={CategoriesScreen}
           options={{
             title: 'Cantoral',
-            headerLargeTitle: isIOS,
-            headerLargeTitleShadowVisible: false,
-            headerLargeStyle: isIOS
-              ? { backgroundColor: 'transparent' }
-              : undefined,
           }}
         />
         <Stack.Screen
@@ -187,11 +182,6 @@ export default function CancioneroTab() {
           component={SongListScreen}
           options={({ route }) => ({
             title: route.params?.categoryName || 'Canciones',
-            headerLargeTitle: isIOS,
-            headerLargeTitleShadowVisible: false,
-            headerLargeStyle: isIOS
-              ? { backgroundColor: 'transparent' }
-              : undefined,
           })}
         />
         <Stack.Screen
@@ -214,11 +204,6 @@ export default function CancioneroTab() {
           component={SelectedSongsScreen}
           options={{
             title: 'Seleccionadas',
-            headerLargeTitle: isIOS,
-            headerLargeTitleShadowVisible: false,
-            headerLargeStyle: isIOS
-              ? { backgroundColor: 'transparent' }
-              : undefined,
           }}
         />
       </Stack.Navigator>

--- a/mcm-app/app/(tabs)/contigo/evangelio.tsx
+++ b/mcm-app/app/(tabs)/contigo/evangelio.tsx
@@ -212,10 +212,10 @@ export default function EvangelioScreen() {
 
   // Liturgical color for subtle tinting
   const liturgicalAccent =
-    liturgicalInfo.hex === '#F5F5F5'
+    liturgicalInfo.hex === '#D4A070'
       ? isDark
-        ? '#888888'
-        : '#999999'
+        ? '#D4A070'
+        : '#A0693A'
       : liturgicalInfo.hex;
 
   return (

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -202,7 +202,7 @@ export default function CategoriesScreen({
             <MaterialIcons
               name="chevron-right"
               size={20}
-              color={isDark ? '#555' : '#C7C7CC'}
+              color={isDark ? '#8E8E93' : '#C7C7CC'}
             />
           </View>
         </PressableFeedback>

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -139,6 +139,16 @@ export default function SongDetailScreen({
 
   const isSelected = isSongSelected(filename);
 
+  // iOS: disable native swipe-back gesture when a navigation list is active so
+  // that the custom left/right swipe handler can take full ownership of the
+  // horizontal axis without fighting the system back gesture.
+  useLayoutEffect(() => {
+    if (!isIOS) return;
+    const hasSwipeNav =
+      Boolean(navigationList) && typeof currentIndex === 'number';
+    navigation.setOptions({ gestureEnabled: !hasSwipeNav });
+  }, [navigation, navigationList, currentIndex]);
+
   // Android/Web: header button
   useLayoutEffect(() => {
     if (isIOS || !filename) return;
@@ -459,7 +469,14 @@ export default function SongDetailScreen({
   if (navigationList && typeof currentIndex === 'number') {
     return (
       <GestureRecognizer
-        style={{ flex: 1 }}
+        style={[
+          { flex: 1 },
+          {
+            backgroundColor: isDark
+              ? Colors.dark.background
+              : Colors.light.background,
+          },
+        ]}
         onSwipeLeft={handleSwipeRight}
         onSwipeRight={handleSwipeLeft}
       >

--- a/mcm-app/components/BottomSheet.tsx
+++ b/mcm-app/components/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { BottomSheet as HeroBottomSheet } from 'heroui-native';
 import { UIColors, Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -10,14 +10,6 @@ interface BottomSheetProps {
   children: React.ReactNode;
 }
 
-/**
- * Wrapper that keeps the existing {visible, onClose, children} API
- * while delegating to HeroUI Native BottomSheet under the hood.
- *
- * The overlay is given an explicit dark backdrop so users can always
- * see the dim "scrim" behind the sheet — without it the underlying
- * screen stays at full brightness on some platforms.
- */
 export default function BottomSheet({
   visible,
   onClose,
@@ -38,13 +30,21 @@ export default function BottomSheet({
       }}
     >
       <HeroBottomSheet.Portal>
-        <HeroBottomSheet.Overlay style={styles.overlay} />
+        {/* onPress ensures tapping the scrim dismisses the sheet */}
+        <HeroBottomSheet.Overlay
+          style={styles.overlay}
+          onPress={onClose}
+        />
         <HeroBottomSheet.Content
           style={{ backgroundColor: bgColor }}
           handleStyle={{ backgroundColor: bgColor }}
           handleIndicatorStyle={{ backgroundColor: handleIndicatorColor }}
         >
-          {children}
+          {/* Explicit wrapper ensures dark background even when children
+              don't set their own (e.g. TransposePanel, SongFontPanel) */}
+          <View style={{ backgroundColor: bgColor }}>
+            {children}
+          </View>
         </HeroBottomSheet.Content>
       </HeroBottomSheet.Portal>
     </HeroBottomSheet>

--- a/mcm-app/components/BottomSheet.tsx
+++ b/mcm-app/components/BottomSheet.tsx
@@ -24,7 +24,11 @@ export default function BottomSheet({
   children,
 }: BottomSheetProps) {
   const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
   const bgColor = Colors[scheme ?? 'light'].background;
+  const handleIndicatorColor = isDark
+    ? 'rgba(255,255,255,0.25)'
+    : 'rgba(0,0,0,0.18)';
 
   return (
     <HeroBottomSheet
@@ -35,7 +39,11 @@ export default function BottomSheet({
     >
       <HeroBottomSheet.Portal>
         <HeroBottomSheet.Overlay style={styles.overlay} />
-        <HeroBottomSheet.Content style={{ backgroundColor: bgColor }}>
+        <HeroBottomSheet.Content
+          style={{ backgroundColor: bgColor }}
+          handleStyle={{ backgroundColor: bgColor }}
+          handleIndicatorStyle={{ backgroundColor: handleIndicatorColor }}
+        >
           {children}
         </HeroBottomSheet.Content>
       </HeroBottomSheet.Portal>

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -963,11 +963,10 @@ const listStyles = StyleSheet.create({
   rightAction: {
     backgroundColor: colors.success,
     justifyContent: 'center',
-    alignItems: 'flex-end',
+    alignItems: 'center',
     borderRadius: radii.md,
     marginBottom: spacing.md,
-    paddingRight: spacing.md,
-    minWidth: 90,
+    width: 80,
   },
   actionContent: { alignItems: 'center', justifyContent: 'center' },
   actionText: {

--- a/mcm-app/components/contigo/LiturgicalBadge.tsx
+++ b/mcm-app/components/contigo/LiturgicalBadge.tsx
@@ -66,8 +66,10 @@ export function getLiturgicalInfo(dateStr: string) {
         color = 'accent';
         hex = '#6B3FA0';
       } else if (tiempo.id === 'navidad' || tiempo.id === 'pascua') {
-        color = 'default';
-        hex = '#F5F5F5';
+        // 'warning' (golden) renders readable in both light and dark mode;
+        // 'default' renders with dark foreground text that's invisible on dark backgrounds.
+        color = 'warning';
+        hex = '#D4A070';
       } else if (tiempo.id === 'semana_santa') {
         color = 'danger';
         hex = '#C41E3A';


### PR DESCRIPTION
## Summary
This PR improves the BottomSheet component's visual consistency and fixes gesture handling across the app. It also refines liturgical color rendering and cleans up redundant navigation header configuration.

## Key Changes

### BottomSheet Component (`components/BottomSheet.tsx`)
- Added `View` import and wrapped children in an explicit background container to ensure dark backgrounds render correctly even when child components don't set their own (e.g., TransposePanel, SongFontPanel)
- Added `onPress={onClose}` to the Overlay to allow dismissing the sheet by tapping the scrim
- Added `handleStyle` and `handleIndicatorStyle` props to customize the drag handle appearance based on color scheme
- Removed outdated JSDoc comment

### Song Detail Screen (`app/screens/SongDetailScreen.tsx`)
- Added iOS-specific logic to disable native swipe-back gesture when a navigation list is active, allowing the custom left/right swipe handler to take full ownership of the horizontal axis without fighting the system back gesture
- Added background color styling to the GestureRecognizer wrapper to ensure consistent appearance during swipe navigation

### Navigation Headers (`app/(tabs)/cancionero.tsx`)
- Removed redundant `headerLargeTitle`, `headerLargeTitleShadowVisible`, and `headerLargeStyle` options from multiple Stack.Screen definitions (Categories, SongsList, SelectedSongs screens) — these are now handled globally

### Liturgical Colors (`components/contigo/LiturgicalBadge.tsx` and `app/contigo/evangelio.tsx`)
- Changed Christmas/Easter liturgical color from light gray (`#F5F5F5`) to golden (`#D4A070`) with corresponding accent colors for dark mode (`#D4A070`) and light mode (`#A0693A`)
- Updated badge color variant from 'default' to 'warning' to ensure readable text in both light and dark modes (the 'default' variant uses dark text that becomes invisible on dark backgrounds)

### Swipe Action Styling (`components/NotificationsBottomSheet.tsx`)
- Fixed right action button alignment from `flex-end` to `center` and adjusted dimensions (changed from `minWidth: 90` with `paddingRight` to fixed `width: 80`) for better visual consistency

### Category Chevron Color (`app/screens/CategoriesScreen.tsx`)
- Improved dark mode chevron color from `#555` to `#8E8E93` for better contrast and consistency with system colors

## Implementation Details
- The BottomSheet changes ensure that semi-transparent or uncolored child components don't expose the underlying screen content
- The gesture handling fix prevents iOS's native back swipe from conflicting with custom horizontal swipe navigation
- Liturgical color changes improve readability across both light and dark themes while maintaining visual hierarchy

https://claude.ai/code/session_01QU3taZ8X2NAZRUk6YC3fR1