### PR TITLE
Redesign TransposePanel & SongFontPanel with card layout & improve fullscreen controls

### DIFF
--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,5 +1,14 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, Platform, Animated } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Platform,
+  Animated,
+  PanResponder,
+  GestureResponderEvent,
+  PanResponderGestureState,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RouteProp,
@@ -9,7 +18,7 @@ import {
 import { WebView } from 'react-native-webview';
 import { BlurView } from 'expo-blur';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { Slider, PressableFeedback } from 'heroui-native';
+import { PressableFeedback } from 'heroui-native';
 import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSongProcessor } from '../../hooks/useSongProcessor';
@@ -18,12 +27,114 @@ import { Colors } from '../../constants/colors';
 
 type SongFullscreenRouteProp = RouteProp<RootStackParamList, 'SongFullscreen'>;
 
-// Rango de velocidades del auto-scroll, en píxeles por tick (50ms = 20 ticks/s).
-// - MIN: lectura muy lenta a ritmo de canto (≈10 px/s).
-// - MAX: scroll rápido cuando ya conoces la letra (≈140 px/s).
 const MIN_SPEED_PPT = 0.5;
 const MAX_SPEED_PPT = 7;
 const TICK_MS = 50;
+
+// Vertical slider geometry
+const SLIDER_H = 130; // draggable range height (px)
+const THUMB_D = 22; // thumb diameter
+const DRAG_RANGE = SLIDER_H - THUMB_D;
+const TRACK_W = 3;
+
+/** Cross-platform vertical slider via PanResponder. value: 0..1 */
+function VerticalSlider({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  const valueRef = useRef(value);
+  const startRef = useRef(value);
+
+  useEffect(() => {
+    valueRef.current = value;
+  });
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: () => {
+        startRef.current = valueRef.current;
+      },
+      onPanResponderMove: (_evt: GestureResponderEvent, { dy }: PanResponderGestureState) => {
+        // dy > 0 = moved down = slower; top = fast (value 1)
+        const next = Math.max(0, Math.min(1, startRef.current - dy / DRAG_RANGE));
+        onChange(next);
+      },
+    }),
+  ).current;
+
+  const thumbTop = (1 - value) * DRAG_RANGE;
+
+  return (
+    <View
+      style={sliderStyles.container}
+      {...panResponder.panHandlers}
+      // Extra hit area so small thumbs are easy to grab
+      hitSlop={{ top: 8, bottom: 8, left: 14, right: 14 }}
+    >
+      {/* Track background */}
+      <View style={sliderStyles.trackBg} />
+      {/* Filled portion: from thumb down to bottom = the selected speed level */}
+      <View
+        style={[
+          sliderStyles.trackFill,
+          {
+            top: thumbTop + THUMB_D / 2,
+            height: value * DRAG_RANGE,
+          },
+        ]}
+      />
+      {/* Thumb */}
+      <View style={[sliderStyles.thumb, { top: thumbTop }]} />
+    </View>
+  );
+}
+
+const sliderStyles = StyleSheet.create({
+  container: {
+    width: THUMB_D,
+    height: SLIDER_H,
+  },
+  trackBg: {
+    position: 'absolute',
+    top: THUMB_D / 2,
+    bottom: THUMB_D / 2,
+    left: (THUMB_D - TRACK_W) / 2,
+    width: TRACK_W,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    borderRadius: TRACK_W / 2,
+  },
+  trackFill: {
+    position: 'absolute',
+    left: (THUMB_D - TRACK_W) / 2,
+    width: TRACK_W,
+    backgroundColor: 'rgba(255,255,255,0.8)',
+    borderRadius: TRACK_W / 2,
+  },
+  thumb: {
+    position: 'absolute',
+    left: 0,
+    width: THUMB_D,
+    height: THUMB_D,
+    borderRadius: THUMB_D / 2,
+    backgroundColor: '#FFFFFF',
+    ...Platform.select({
+      default: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.35,
+        shadowRadius: 3,
+        elevation: 3,
+      },
+    }),
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function SongFullscreenScreen({
   route,
@@ -51,20 +162,19 @@ export default function SongFullscreenScreen({
     notation,
     isFullscreen: true,
     isDark,
-    topInset: Math.max(insets.top, 16) + 56, // notch + close button
-    bottomInset: Math.max(insets.bottom, 16) + 96, // home indicator + play button
+    topInset: Math.max(insets.top, 16) + 56,
+    bottomInset: Math.max(insets.bottom, 16) + 96,
   });
 
   const webViewRef = useRef<WebView>(null);
   const divRef = useRef<HTMLDivElement | null>(null);
   const [autoScroll, setAutoScroll] = useState(false);
-  // Factor 0..1 del slider. La velocidad real interpola entre MIN y MAX.
   const [speedFactor, setSpeedFactor] = useState(0.35);
   const [controlsVisible, setControlsVisible] = useState(false);
   const controlsOpacity = useRef(new Animated.Value(0)).current;
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Fade-in entry animation
+  // Fade-in entry
   const fadeAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -106,9 +216,7 @@ export default function SongFullscreenScreen({
       MIN_SPEED_PPT + speedFactor * (MAX_SPEED_PPT - MIN_SPEED_PPT);
     const id = setInterval(() => {
       if (Platform.OS === 'web') {
-        if (divRef.current) {
-          divRef.current.scrollBy({ top: speedPpt });
-        }
+        divRef.current?.scrollBy({ top: speedPpt });
       } else {
         webViewRef.current?.injectJavaScript(
           `window.scrollBy(0,${speedPpt}); true;`,
@@ -118,7 +226,6 @@ export default function SongFullscreenScreen({
     return () => clearInterval(id);
   }, [autoScroll, speedFactor]);
 
-  // Limpieza del timer al desmontar
   useEffect(() => {
     return () => {
       if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
@@ -130,7 +237,6 @@ export default function SongFullscreenScreen({
   const closeTop = Math.max(insets.top, 12) + 8;
   const controlsBottom = Math.max(insets.bottom, 12) + 16;
 
-  // Etiqueta legible para la velocidad
   const speedLabel = (() => {
     if (speedFactor < 0.2) return 'Lento';
     if (speedFactor < 0.55) return 'Normal';
@@ -138,18 +244,17 @@ export default function SongFullscreenScreen({
     return 'Muy rápido';
   })();
 
-  const TranslucentBg = ({ style }: { style?: any }) =>
+  const TranslucentBg = ({ style }: { style?: object }) =>
     isIOS ? (
       <>
         <BlurView
           tint={isDark ? 'dark' : 'light'}
           intensity={60}
-          style={[StyleSheet.absoluteFill, styles.absFill, style]}
+          style={[StyleSheet.absoluteFill, style]}
         />
         <View
           style={[
             StyleSheet.absoluteFill,
-            styles.absFill,
             {
               backgroundColor: isDark
                 ? 'rgba(20,20,22,0.35)'
@@ -163,7 +268,6 @@ export default function SongFullscreenScreen({
       <View
         style={[
           StyleSheet.absoluteFill,
-          styles.absFill,
           isWeb
             ? ({
                 backgroundColor: isDark
@@ -189,9 +293,7 @@ export default function SongFullscreenScreen({
         { backgroundColor: theme.background, opacity: fadeAnim },
       ]}
     >
-      {/* Contenido — ocupa toda la pantalla; el padding superior/inferior
-          se aplica dentro del HTML (vía useSongProcessor) para que el
-          contenido pueda hacer scroll bajo los botones translúcidos. */}
+      {/* Song content — fills the screen; padding applied inside HTML */}
       <View style={styles.contentWrapper}>
         {isWeb ? (
           <div
@@ -219,68 +321,47 @@ export default function SongFullscreenScreen({
         accessibilityLabel="Cerrar pantalla completa"
       >
         <PressableFeedback.Scale />
-        <TranslucentBg style={{ borderRadius: 18 }} />
-        <MaterialIcons
-          name="close"
-          color={isDark ? '#FFFFFF' : '#FFFFFF'}
-          size={22}
-        />
+        <TranslucentBg style={{ borderRadius: 20 }} />
+        <MaterialIcons name="close" color="#FFFFFF" size={22} />
       </PressableFeedback>
 
-      {/* Controles inferiores — siempre translúcidos para no tapar texto. */}
+      {/* Controls cluster — bottom right, vertical stack */}
       <View
-        style={[
-          styles.controlsCluster,
-          { bottom: controlsBottom },
-        ]}
+        style={[styles.controlsCluster, { bottom: controlsBottom }]}
         pointerEvents="box-none"
       >
-        {/* Speed pill (slider + label) — aparece a la izquierda del play */}
+        {/* Speed slider — appears above play button when controls are visible */}
         {controlsVisible && (
           <Animated.View
-            style={[
-              styles.speedPill,
-              { opacity: controlsOpacity },
-            ]}
+            style={[styles.speedPill, { opacity: controlsOpacity }]}
             pointerEvents="auto"
           >
-            <TranslucentBg style={{ borderRadius: 22 }} />
+            <TranslucentBg style={{ borderRadius: 24 }} />
             <Text style={styles.speedLabel} numberOfLines={1}>
               {speedLabel}
             </Text>
-            <View style={styles.speedSliderWrap}>
-              <Slider
-                value={Math.round(speedFactor * 100)}
-                onChange={(v) => {
-                  setSpeedFactor((v as number) / 100);
-                  showControls();
-                }}
-                minValue={0}
-                maxValue={100}
-                step={1}
-                style={styles.speedSlider}
-              >
-                <Slider.Track>
-                  <Slider.Fill />
-                  <Slider.Thumb />
-                </Slider.Track>
-              </Slider>
-            </View>
+            <VerticalSlider
+              value={speedFactor}
+              onChange={(v) => {
+                setSpeedFactor(v);
+                showControls();
+              }}
+            />
           </Animated.View>
         )}
 
-        {/* Play / pause — siempre visible, translúcido */}
+        {/* Play / pause */}
         <PressableFeedback
           style={styles.playButton}
           onPress={() => {
-            setAutoScroll((s) => !s);
+            setAutoScroll((s: boolean) => !s);
             showControls();
           }}
           onLongPress={() => showControls()}
           accessibilityLabel={autoScroll ? 'Pausar scroll' : 'Iniciar scroll'}
         >
           <PressableFeedback.Scale />
-          <TranslucentBg style={{ borderRadius: 26 }} />
+          <TranslucentBg style={{ borderRadius: 28 }} />
           <MaterialIcons
             name={autoScroll ? 'pause' : 'play-arrow'}
             color="#FFFFFF"
@@ -306,10 +387,7 @@ const styles = StyleSheet.create({
   contentWrapper: {
     flex: 1,
   },
-  absFill: {
-    borderRadius: 22,
-  },
-  /* Close button — top right */
+  /* Close — top right */
   closeButton: {
     position: 'absolute',
     right: 16,
@@ -323,7 +401,7 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(255,255,255,0.22)',
     ...Platform.select({
-      web: { boxShadow: '0 2px 10px rgba(0,0,0,0.25)' },
+      web: { boxShadow: '0 2px 10px rgba(0,0,0,0.25)' } as any,
       default: {
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 2 },
@@ -333,16 +411,43 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  /* Bottom-right cluster: speed pill + play button */
+  /* Column cluster at bottom right */
   controlsCluster: {
     position: 'absolute',
     right: 16,
-    left: 16,
-    flexDirection: 'row',
+    flexDirection: 'column',
     alignItems: 'center',
-    justifyContent: 'flex-end',
     gap: 10,
     zIndex: 3,
+  },
+  /* Vertical speed slider pill */
+  speedPill: {
+    width: 52,
+    paddingTop: 10,
+    paddingBottom: 10,
+    borderRadius: 26,
+    alignItems: 'center',
+    gap: 8,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255,255,255,0.22)',
+    ...Platform.select({
+      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' } as any,
+      default: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.28,
+        shadowRadius: 10,
+        elevation: 7,
+      },
+    }),
+  },
+  speedLabel: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
   },
   /* Play / pause */
   playButton: {
@@ -355,7 +460,7 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(255,255,255,0.22)',
     ...Platform.select({
-      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' },
+      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' } as any,
       default: {
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 4 },
@@ -364,46 +469,5 @@ const styles = StyleSheet.create({
         elevation: 7,
       },
     }),
-  },
-  /* Speed pill */
-  speedPill: {
-    flexShrink: 1,
-    minWidth: 200,
-    maxWidth: 320,
-    height: 44,
-    borderRadius: 22,
-    paddingLeft: 14,
-    paddingRight: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    overflow: 'hidden',
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.22)',
-    ...Platform.select({
-      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.25)' },
-      default: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.22,
-        shadowRadius: 10,
-        elevation: 6,
-      },
-    }),
-  },
-  speedLabel: {
-    color: '#FFFFFF',
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.4,
-    minWidth: 64,
-  },
-  speedSliderWrap: {
-    flex: 1,
-    height: 32,
-    justifyContent: 'center',
-  },
-  speedSlider: {
-    width: '100%',
   },
 });

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { View, StyleSheet, Platform, Animated } from 'react-native';
+import { View, Text, StyleSheet, Platform, Animated } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RouteProp,
   useNavigation,
@@ -17,6 +18,13 @@ import { Colors } from '../../constants/colors';
 
 type SongFullscreenRouteProp = RouteProp<RootStackParamList, 'SongFullscreen'>;
 
+// Rango de velocidades del auto-scroll, en píxeles por tick (50ms = 20 ticks/s).
+// - MIN: lectura muy lenta a ritmo de canto (≈10 px/s).
+// - MAX: scroll rápido cuando ya conoces la letra (≈140 px/s).
+const MIN_SPEED_PPT = 0.5;
+const MAX_SPEED_PPT = 7;
+const TICK_MS = 50;
+
 export default function SongFullscreenScreen({
   route,
 }: {
@@ -27,6 +35,7 @@ export default function SongFullscreenScreen({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme];
+  const insets = useSafeAreaInsets();
   const { settings } = useSettings();
   const { chordsVisible, fontSize, fontFamily, notation } = settings;
 
@@ -42,16 +51,18 @@ export default function SongFullscreenScreen({
     notation,
     isFullscreen: true,
     isDark,
+    topInset: Math.max(insets.top, 16) + 56, // notch + close button
+    bottomInset: Math.max(insets.bottom, 16) + 96, // home indicator + play button
   });
 
   const webViewRef = useRef<WebView>(null);
   const divRef = useRef<HTMLDivElement | null>(null);
   const [autoScroll, setAutoScroll] = useState(false);
-  const [scrollSpeed, setScrollSpeed] = useState(0.25);
-  const maxSpeed = 3;
-  const [sliderVisible, setSliderVisible] = useState(false);
-  const sliderOpacity = useRef(new Animated.Value(0)).current;
-  const sliderTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Factor 0..1 del slider. La velocidad real interpola entre MIN y MAX.
+  const [speedFactor, setSpeedFactor] = useState(0.35);
+  const [controlsVisible, setControlsVisible] = useState(false);
+  const controlsOpacity = useRef(new Animated.Value(0)).current;
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Fade-in entry animation
   const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -61,25 +72,25 @@ export default function SongFullscreenScreen({
       duration: 400,
       useNativeDriver: true,
     }).start();
-  }, []);
+  }, [fadeAnim]);
 
-  const showSlider = useCallback(() => {
-    setSliderVisible(true);
-    Animated.timing(sliderOpacity, {
+  const showControls = useCallback(() => {
+    setControlsVisible(true);
+    Animated.timing(controlsOpacity, {
       toValue: 1,
-      duration: 200,
+      duration: 180,
       useNativeDriver: true,
     }).start();
 
-    if (sliderTimeoutRef.current) clearTimeout(sliderTimeoutRef.current);
-    sliderTimeoutRef.current = setTimeout(() => {
-      Animated.timing(sliderOpacity, {
+    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+    hideTimeoutRef.current = setTimeout(() => {
+      Animated.timing(controlsOpacity, {
         toValue: 0,
-        duration: 300,
+        duration: 280,
         useNativeDriver: true,
-      }).start(() => setSliderVisible(false));
-    }, 2000);
-  }, [sliderOpacity]);
+      }).start(() => setControlsVisible(false));
+    }, 2400);
+  }, [controlsOpacity]);
 
   useEffect(() => {
     const parent = navigation.getParent();
@@ -91,22 +102,85 @@ export default function SongFullscreenScreen({
 
   useEffect(() => {
     if (!autoScroll) return;
+    const speedPpt =
+      MIN_SPEED_PPT + speedFactor * (MAX_SPEED_PPT - MIN_SPEED_PPT);
     const id = setInterval(() => {
-      const delta = scrollSpeed * maxSpeed;
       if (Platform.OS === 'web') {
         if (divRef.current) {
-          divRef.current.scrollBy({ top: delta });
+          divRef.current.scrollBy({ top: speedPpt });
         }
       } else {
         webViewRef.current?.injectJavaScript(
-          `window.scrollBy(0,${delta}); true;`,
+          `window.scrollBy(0,${speedPpt}); true;`,
         );
       }
-    }, 50);
+    }, TICK_MS);
     return () => clearInterval(id);
-  }, [autoScroll, scrollSpeed]);
+  }, [autoScroll, speedFactor]);
+
+  // Limpieza del timer al desmontar
+  useEffect(() => {
+    return () => {
+      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+    };
+  }, []);
 
   const isIOS = Platform.OS === 'ios';
+  const isWeb = Platform.OS === 'web';
+  const closeTop = Math.max(insets.top, 12) + 8;
+  const controlsBottom = Math.max(insets.bottom, 12) + 16;
+
+  // Etiqueta legible para la velocidad
+  const speedLabel = (() => {
+    if (speedFactor < 0.2) return 'Lento';
+    if (speedFactor < 0.55) return 'Normal';
+    if (speedFactor < 0.85) return 'Rápido';
+    return 'Muy rápido';
+  })();
+
+  const TranslucentBg = ({ style }: { style?: any }) =>
+    isIOS ? (
+      <>
+        <BlurView
+          tint={isDark ? 'dark' : 'light'}
+          intensity={60}
+          style={[StyleSheet.absoluteFill, styles.absFill, style]}
+        />
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            styles.absFill,
+            {
+              backgroundColor: isDark
+                ? 'rgba(20,20,22,0.35)'
+                : 'rgba(0,0,0,0.22)',
+            },
+            style,
+          ]}
+        />
+      </>
+    ) : (
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          styles.absFill,
+          isWeb
+            ? ({
+                backgroundColor: isDark
+                  ? 'rgba(28,28,30,0.55)'
+                  : 'rgba(0,0,0,0.42)',
+                backdropFilter: 'blur(18px)',
+                WebkitBackdropFilter: 'blur(18px)',
+              } as any)
+            : {
+                backgroundColor: isDark
+                  ? 'rgba(40,40,42,0.82)'
+                  : 'rgba(0,0,0,0.62)',
+              },
+          style,
+        ]}
+      />
+    );
 
   return (
     <Animated.View
@@ -115,36 +189,11 @@ export default function SongFullscreenScreen({
         { backgroundColor: theme.background, opacity: fadeAnim },
       ]}
     >
-      {/* Close button — glass effect */}
-      <PressableFeedback
-        style={[
-          styles.closeButton,
-          !isIOS &&
-            (isDark
-              ? styles.closeButtonDarkFallback
-              : styles.closeButtonFallback),
-        ]}
-        onPress={() => navigation.goBack()}
-        accessibilityLabel="Cerrar pantalla completa"
-      >
-        <PressableFeedback.Scale />
-        {isIOS && (
-          <BlurView
-            tint={isDark ? 'dark' : 'light'}
-            intensity={72}
-            style={[StyleSheet.absoluteFill, styles.blurFill]}
-          />
-        )}
-        <MaterialIcons
-          name="close"
-          color={isDark ? '#EBEBF0' : '#fff'}
-          size={20}
-        />
-      </PressableFeedback>
-
-      {/* Song content with horizontal breathing room */}
+      {/* Contenido — ocupa toda la pantalla; el padding superior/inferior
+          se aplica dentro del HTML (vía useSongProcessor) para que el
+          contenido pueda hacer scroll bajo los botones translúcidos. */}
       <View style={styles.contentWrapper}>
-        {Platform.OS === 'web' ? (
+        {isWeb ? (
           <div
             ref={divRef}
             style={webContainerStyle as any}
@@ -155,77 +204,90 @@ export default function SongFullscreenScreen({
             ref={webViewRef}
             originWhitelist={['*']}
             source={{ html: songHtml }}
-            style={{ flex: 1 }}
+            style={{ flex: 1, backgroundColor: 'transparent' }}
             showsVerticalScrollIndicator={false}
+            contentInsetAdjustmentBehavior="never"
+            automaticallyAdjustContentInsets={false}
           />
         )}
       </View>
 
-      {/* Vertical speed slider — liquid glass */}
-      {sliderVisible && (
-        <Animated.View
-          style={[
-            styles.sliderWrapper,
-            !isIOS && styles.sliderWrapperFallback,
-            { opacity: sliderOpacity },
-          ]}
-        >
-          {isIOS && (
-            <BlurView
-              tint={isDark ? 'dark' : 'light'}
-              intensity={72}
-              style={[StyleSheet.absoluteFill, styles.blurFill]}
-            />
-          )}
-          <Slider
-            value={Math.round(scrollSpeed * 100)}
-            onChange={(v) => {
-              setScrollSpeed((v as number) / 100);
-              showSlider();
-            }}
-            minValue={0}
-            maxValue={100}
-            step={1}
-            orientation="vertical"
-            style={styles.sliderControl}
-          >
-            <Slider.Track>
-              <Slider.Fill />
-              <Slider.Thumb />
-            </Slider.Track>
-          </Slider>
-        </Animated.View>
-      )}
-
-      {/* Play / pause button — liquid glass, semi-transparent when active */}
+      {/* Close button — top right */}
       <PressableFeedback
-        style={[
-          styles.scrollButton,
-          !isIOS &&
-            (isDark
-              ? styles.scrollButtonDarkFallback
-              : styles.scrollButtonFallback),
-          autoScroll && styles.scrollButtonActive,
-        ]}
-        onPress={() => {
-          setAutoScroll((s) => !s);
-          showSlider();
-        }}
+        style={[styles.closeButton, { top: closeTop }]}
+        onPress={() => navigation.goBack()}
+        accessibilityLabel="Cerrar pantalla completa"
       >
         <PressableFeedback.Scale />
-        {isIOS && (
-          <BlurView
-            tint={isDark ? 'dark' : 'light'}
-            intensity={72}
-            style={[StyleSheet.absoluteFill, styles.blurFill]}
-          />
-        )}
+        <TranslucentBg style={{ borderRadius: 18 }} />
         <MaterialIcons
-          name={autoScroll ? 'pause' : 'play-arrow'}
-          color={isDark ? '#EBEBF0' : '#fff'}
-          size={26}
+          name="close"
+          color={isDark ? '#FFFFFF' : '#FFFFFF'}
+          size={22}
         />
       </PressableFeedback>
+
+      {/* Controles inferiores — siempre translúcidos para no tapar texto. */}
+      <View
+        style={[
+          styles.controlsCluster,
+          { bottom: controlsBottom },
+        ]}
+        pointerEvents="box-none"
+      >
+        {/* Speed pill (slider + label) — aparece a la izquierda del play */}
+        {controlsVisible && (
+          <Animated.View
+            style={[
+              styles.speedPill,
+              { opacity: controlsOpacity },
+            ]}
+            pointerEvents="auto"
+          >
+            <TranslucentBg style={{ borderRadius: 22 }} />
+            <Text style={styles.speedLabel} numberOfLines={1}>
+              {speedLabel}
+            </Text>
+            <View style={styles.speedSliderWrap}>
+              <Slider
+                value={Math.round(speedFactor * 100)}
+                onChange={(v) => {
+                  setSpeedFactor((v as number) / 100);
+                  showControls();
+                }}
+                minValue={0}
+                maxValue={100}
+                step={1}
+                style={styles.speedSlider}
+              >
+                <Slider.Track>
+                  <Slider.Fill />
+                  <Slider.Thumb />
+                </Slider.Track>
+              </Slider>
+            </View>
+          </Animated.View>
+        )}
+
+        {/* Play / pause — siempre visible, translúcido */}
+        <PressableFeedback
+          style={styles.playButton}
+          onPress={() => {
+            setAutoScroll((s) => !s);
+            showControls();
+          }}
+          onLongPress={() => showControls()}
+          accessibilityLabel={autoScroll ? 'Pausar scroll' : 'Iniciar scroll'}
+        >
+          <PressableFeedback.Scale />
+          <TranslucentBg style={{ borderRadius: 26 }} />
+          <MaterialIcons
+            name={autoScroll ? 'pause' : 'play-arrow'}
+            color="#FFFFFF"
+            size={28}
+          />
+        </PressableFeedback>
+      </View>
     </Animated.View>
   );
 }
@@ -234,7 +296,6 @@ const webContainerStyle = {
   width: '100%',
   height: '100%',
   overflowY: 'auto',
-  paddingHorizontal: 12,
   boxSizing: 'border-box',
 } as unknown as React.CSSProperties;
 
@@ -244,113 +305,105 @@ const styles = StyleSheet.create({
   },
   contentWrapper: {
     flex: 1,
-    marginHorizontal: 12,
-    marginTop: 8,
   },
-  blurFill: {
-    borderRadius: 20,
+  absFill: {
+    borderRadius: 22,
   },
-  /* Close button — top left */
+  /* Close button — top right */
   closeButton: {
     position: 'absolute',
-    left: 16,
-    top: Platform.OS === 'ios' ? 54 : 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    right: 16,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
-    zIndex: 3,
+    zIndex: 4,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.2)',
+    borderColor: 'rgba(255,255,255,0.22)',
     ...Platform.select({
-      web: { boxShadow: '0 2px 10px rgba(0,0,0,0.2)' },
+      web: { boxShadow: '0 2px 10px rgba(0,0,0,0.25)' },
       default: {
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.2,
+        shadowOpacity: 0.25,
         shadowRadius: 6,
-        elevation: 4,
+        elevation: 5,
       },
     }),
   },
-  closeButtonFallback: {
-    backgroundColor: 'rgba(0,0,0,0.72)',
-  },
-  closeButtonDarkFallback: {
-    backgroundColor: 'rgba(60,60,60,0.82)',
-  },
-  /* Scroll button */
-  scrollButton: {
+  /* Bottom-right cluster: speed pill + play button */
+  controlsCluster: {
     position: 'absolute',
-    right: 20,
-    bottom: 36,
-    width: 52,
-    height: 52,
-    borderRadius: 26,
+    right: 16,
+    left: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 10,
+    zIndex: 3,
+  },
+  /* Play / pause */
+  playButton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
-    zIndex: 2,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.2)',
+    borderColor: 'rgba(255,255,255,0.22)',
     ...Platform.select({
-      web: { boxShadow: '0 4px 16px rgba(0,0,0,0.25)' },
+      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' },
       default: {
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.25,
+        shadowOpacity: 0.28,
+        shadowRadius: 10,
+        elevation: 7,
+      },
+    }),
+  },
+  /* Speed pill */
+  speedPill: {
+    flexShrink: 1,
+    minWidth: 200,
+    maxWidth: 320,
+    height: 44,
+    borderRadius: 22,
+    paddingLeft: 14,
+    paddingRight: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255,255,255,0.22)',
+    ...Platform.select({
+      web: { boxShadow: '0 4px 18px rgba(0,0,0,0.25)' },
+      default: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.22,
         shadowRadius: 10,
         elevation: 6,
       },
     }),
   },
-  scrollButtonFallback: {
-    backgroundColor: 'rgba(0,0,0,0.72)',
+  speedLabel: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    minWidth: 64,
   },
-  scrollButtonDarkFallback: {
-    backgroundColor: 'rgba(60,60,60,0.82)',
-  },
-  scrollButtonActive: {
-    opacity: 0.6,
-  },
-  /* Vertical slider */
-  sliderWrapper: {
-    position: 'absolute',
-    right: 20,
-    bottom: 104, // 36 (button bottom) + 52 (button height) + 16 (gap)
-    width: 44,
-    height: 180,
-    borderRadius: 22,
-    overflow: 'hidden',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.18)',
-    zIndex: 2,
-    ...Platform.select({
-      web: {
-        boxShadow: '0 4px 20px rgba(0,0,0,0.2)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-        backgroundColor: 'rgba(0,0,0,0.45)',
-      },
-      default: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.2,
-        shadowRadius: 10,
-        elevation: 5,
-      },
-    }),
-  },
-  sliderWrapperFallback: {
-    backgroundColor: 'rgba(0,0,0,0.65)',
-  },
-  sliderControl: {
+  speedSliderWrap: {
     flex: 1,
+    height: 32,
+    justifyContent: 'center',
+  },
+  speedSlider: {
     width: '100%',
-    paddingVertical: 14,
   },
 });

--- a/mcm-app/components/SongFontPanel.tsx
+++ b/mcm-app/components/SongFontPanel.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Platform } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BottomSheet from './BottomSheet';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -24,6 +25,9 @@ interface Props {
   onSetFontFamily: (family: string) => void;
 }
 
+const MIN_SIZE = 0.6;
+const MAX_SIZE = 2.0;
+
 export default function SongFontPanel({
   visible,
   onClose,
@@ -36,200 +40,495 @@ export default function SongFontPanel({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme];
+  const insets = useSafeAreaInsets();
 
-  const reset = () => {
+  const defaultFamily = availableFonts[0]?.cssValue ?? currentFontFamily;
+  const isSizeModified =
+    Math.abs(currentFontSize - DEFAULT_FONT_SIZE_EM) > 0.001;
+  const isFontModified = currentFontFamily !== defaultFamily;
+
+  const resetAll = () => {
     onSetFontSize(DEFAULT_FONT_SIZE_EM);
-    if (availableFonts[0]) {
-      onSetFontFamily(availableFonts[0].cssValue);
-    }
+    onSetFontFamily(defaultFamily);
   };
+  const resetSize = () => onSetFontSize(DEFAULT_FONT_SIZE_EM);
+  const resetFont = () => onSetFontFamily(defaultFamily);
 
-  const increase = () => onSetFontSize(currentFontSize + 0.1);
-  const decrease = () => onSetFontSize(Math.max(0.6, currentFontSize - 0.1));
+  const increase = () =>
+    onSetFontSize(Math.min(MAX_SIZE, currentFontSize + 0.1));
+  const decrease = () =>
+    onSetFontSize(Math.max(MIN_SIZE, currentFontSize - 0.1));
   const percentage = ((currentFontSize / DEFAULT_FONT_SIZE_EM) * 100).toFixed(
     0,
   );
 
   return (
     <BottomSheet visible={visible} onClose={onClose}>
-      <Text style={[styles.title, { color: theme.text }]}>Tipo de letra</Text>
-
-      <View style={styles.sizeSection}>
-        <PressableFeedback
-          onPress={decrease}
-          style={[styles.sizeButton, isDark && styles.sizeButtonDark]}
-        >
-          <PressableFeedback.Highlight />
-          <MaterialIcons name="remove" size={22} color={theme.text} />
-        </PressableFeedback>
-        <PressableFeedback onPress={reset} style={styles.sizeDisplay}>
-          <PressableFeedback.Highlight />
-          <Text style={[styles.sizeValue, { color: theme.text }]}>
-            {percentage}%
+      <View
+        style={[
+          styles.container,
+          {
+            paddingBottom:
+              Math.max(insets.bottom, 12) + (Platform.OS === 'web' ? 8 : 4),
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>
+            Tipo de letra
           </Text>
-          <Text style={styles.sizeLabel}>Tamaño</Text>
-        </PressableFeedback>
-        <PressableFeedback
-          onPress={increase}
-          style={[styles.sizeButton, isDark && styles.sizeButtonDark]}
-        >
-          <PressableFeedback.Highlight />
-          <MaterialIcons name="add" size={22} color={theme.text} />
-        </PressableFeedback>
-      </View>
+        </View>
 
-      <View style={styles.fontList}>
-        {availableFonts.map((font) => {
-          const isActive = font.cssValue === currentFontFamily;
-          return (
-            <PressableFeedback
-              key={font.cssValue}
-              style={[
-                styles.fontButton,
-                isDark && styles.fontButtonDark,
-                isActive &&
-                  (isDark
-                    ? styles.fontButtonActiveDark
-                    : styles.fontButtonActive),
-              ]}
-              onPress={() => onSetFontFamily(font.cssValue)}
-            >
-              <PressableFeedback.Highlight />
+        {/* ━━━━━━━━━━━━━━ TAMAÑO ━━━━━━━━━━━━━━ */}
+        <View style={[styles.card, isDark && styles.cardDark]}>
+          <View style={styles.cardHeader}>
+            <Text style={styles.cardLabel}>TAMAÑO</Text>
+            <View style={styles.cardValueWrap}>
               <Text
                 style={[
-                  styles.fontText,
+                  styles.cardValue,
                   {
-                    ...(getNativeFontFamily(font.cssValue) && {
-                      fontFamily: getNativeFontFamily(font.cssValue),
-                    }),
-                    color: isActive
+                    color: isSizeModified
                       ? isDark
-                        ? '#7AB3FF'
-                        : '#253883'
+                        ? '#FFB74D'
+                        : '#C77700'
                       : isDark
-                        ? '#EBEBF0'
-                        : '#1C1C1E',
-                    fontWeight: isActive ? '600' : '400',
+                        ? '#8E8E93'
+                        : '#8E8E93',
                   },
                 ]}
               >
-                {font.name}
+                {isSizeModified ? 'Modificado' : 'Original'}
               </Text>
-              {isActive && (
-                <MaterialIcons
-                  name="check"
-                  size={20}
-                  color={isDark ? '#7AB3FF' : '#253883'}
-                />
-              )}
+            </View>
+            <PressableFeedback
+              style={[
+                styles.resetIconBtn,
+                !isSizeModified && styles.resetIconBtnHidden,
+              ]}
+              onPress={resetSize}
+              disabled={!isSizeModified}
+              accessibilityLabel="Restablecer tamaño"
+            >
+              <PressableFeedback.Highlight />
+              <MaterialIcons
+                name="refresh"
+                size={18}
+                color={isDark ? '#AEAEB2' : '#636366'}
+              />
             </PressableFeedback>
-          );
-        })}
-      </View>
+          </View>
 
-      <PressableFeedback
-        style={[styles.resetButton, isDark && styles.resetButtonDark]}
-        onPress={reset}
-      >
-        <PressableFeedback.Highlight />
-        <MaterialIcons
-          name="refresh"
-          size={18}
-          color={isDark ? '#AEAEB2' : '#636366'}
-        />
-        <Text
-          style={[styles.resetText, { color: isDark ? '#AEAEB2' : '#636366' }]}
-        >
-          Restablecer
-        </Text>
-      </PressableFeedback>
+          <View style={styles.sizeRow}>
+            <PressableFeedback
+              style={[
+                styles.sizeStepBtn,
+                isDark ? styles.sizeStepBtnDark : null,
+                currentFontSize <= MIN_SIZE + 0.001 && styles.sizeStepDisabled,
+              ]}
+              onPress={decrease}
+              disabled={currentFontSize <= MIN_SIZE + 0.001}
+            >
+              <PressableFeedback.Highlight />
+              <MaterialIcons
+                name="remove"
+                size={24}
+                color={
+                  currentFontSize <= MIN_SIZE + 0.001
+                    ? isDark
+                      ? '#48484A'
+                      : '#C7C7CC'
+                    : isDark
+                      ? '#EBEBF0'
+                      : '#1C1C1E'
+                }
+              />
+            </PressableFeedback>
+
+            <View
+              style={[
+                styles.sizeDisplay,
+                isSizeModified
+                  ? isDark
+                    ? styles.sizeDisplayActiveDark
+                    : styles.sizeDisplayActive
+                  : isDark
+                    ? styles.sizeDisplayDark
+                    : null,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.sizePercent,
+                  {
+                    color: isSizeModified
+                      ? isDark
+                        ? '#F4C11E'
+                        : '#7A5A00'
+                      : isDark
+                        ? '#EBEBF0'
+                        : '#1C1C1E',
+                  },
+                ]}
+              >
+                {percentage}%
+              </Text>
+              <View
+                style={[
+                  styles.previewWrap,
+                  {
+                    transform: [
+                      {
+                        scale: Math.min(
+                          1.4,
+                          Math.max(0.6, currentFontSize / DEFAULT_FONT_SIZE_EM),
+                        ),
+                      },
+                    ],
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.previewText,
+                    {
+                      color: isDark ? '#AEAEB2' : '#636366',
+                      ...(getNativeFontFamily(currentFontFamily) && {
+                        fontFamily: getNativeFontFamily(currentFontFamily),
+                      }),
+                    },
+                  ]}
+                >
+                  Aa
+                </Text>
+              </View>
+            </View>
+
+            <PressableFeedback
+              style={[
+                styles.sizeStepBtn,
+                isDark ? styles.sizeStepBtnDark : null,
+                currentFontSize >= MAX_SIZE - 0.001 && styles.sizeStepDisabled,
+              ]}
+              onPress={increase}
+              disabled={currentFontSize >= MAX_SIZE - 0.001}
+            >
+              <PressableFeedback.Highlight />
+              <MaterialIcons
+                name="add"
+                size={24}
+                color={
+                  currentFontSize >= MAX_SIZE - 0.001
+                    ? isDark
+                      ? '#48484A'
+                      : '#C7C7CC'
+                    : isDark
+                      ? '#EBEBF0'
+                      : '#1C1C1E'
+                }
+              />
+            </PressableFeedback>
+          </View>
+        </View>
+
+        {/* ━━━━━━━━━━━━━━ TIPOGRAFÍA ━━━━━━━━━━━━━━ */}
+        <View style={[styles.card, isDark && styles.cardDark]}>
+          <View style={styles.cardHeader}>
+            <Text style={styles.cardLabel}>FUENTE</Text>
+            <View style={styles.cardValueWrap}>
+              <Text
+                style={[
+                  styles.cardValue,
+                  {
+                    color: isFontModified
+                      ? isDark
+                        ? '#FFB74D'
+                        : '#C77700'
+                      : isDark
+                        ? '#8E8E93'
+                        : '#8E8E93',
+                  },
+                ]}
+              >
+                {availableFonts.find((f) => f.cssValue === currentFontFamily)
+                  ?.name ?? 'Personalizada'}
+              </Text>
+            </View>
+            <PressableFeedback
+              style={[
+                styles.resetIconBtn,
+                !isFontModified && styles.resetIconBtnHidden,
+              ]}
+              onPress={resetFont}
+              disabled={!isFontModified}
+              accessibilityLabel="Restablecer fuente"
+            >
+              <PressableFeedback.Highlight />
+              <MaterialIcons
+                name="refresh"
+                size={18}
+                color={isDark ? '#AEAEB2' : '#636366'}
+              />
+            </PressableFeedback>
+          </View>
+
+          <View style={styles.fontGrid}>
+            {availableFonts.map((font) => {
+              const isActive = font.cssValue === currentFontFamily;
+              const nativeFamily = getNativeFontFamily(font.cssValue);
+              return (
+                <PressableFeedback
+                  key={font.cssValue}
+                  style={[
+                    styles.fontChip,
+                    isDark ? styles.fontChipDark : null,
+                    isActive &&
+                      (isDark
+                        ? styles.fontChipActiveDark
+                        : styles.fontChipActive),
+                  ]}
+                  onPress={() => onSetFontFamily(font.cssValue)}
+                >
+                  <PressableFeedback.Highlight />
+                  <Text
+                    style={[
+                      styles.fontChipPreview,
+                      {
+                        ...(nativeFamily && { fontFamily: nativeFamily }),
+                        color: isActive
+                          ? isDark
+                            ? '#F4C11E'
+                            : '#7A5A00'
+                          : isDark
+                            ? '#EBEBF0'
+                            : '#1C1C1E',
+                      },
+                    ]}
+                  >
+                    Aa
+                  </Text>
+                  <Text
+                    style={[
+                      styles.fontChipLabel,
+                      {
+                        color: isActive
+                          ? isDark
+                            ? '#F4C11E'
+                            : '#7A5A00'
+                          : isDark
+                            ? '#AEAEB2'
+                            : '#636366',
+                        fontWeight: isActive ? '700' : '500',
+                      },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {font.name}
+                  </Text>
+                </PressableFeedback>
+              );
+            })}
+          </View>
+        </View>
+
+        {(isSizeModified || isFontModified) && (
+          <PressableFeedback
+            style={[styles.resetAllBtn, isDark && styles.resetAllBtnDark]}
+            onPress={resetAll}
+          >
+            <PressableFeedback.Highlight />
+            <MaterialIcons
+              name="refresh"
+              size={16}
+              color={isDark ? '#AEAEB2' : '#636366'}
+            />
+            <Text
+              style={[
+                styles.resetAllText,
+                { color: isDark ? '#AEAEB2' : '#636366' },
+              ]}
+            >
+              Restablecer todo
+            </Text>
+          </PressableFeedback>
+        )}
+      </View>
     </BottomSheet>
   );
 }
 
 const styles = StyleSheet.create({
-  title: {
-    fontSize: 20,
-    fontWeight: '700',
-    marginBottom: 20,
-    textAlign: 'center',
-    letterSpacing: -0.4,
+  container: {
+    paddingTop: 4,
+    gap: 12,
   },
-  sizeSection: {
+  header: {
     flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 24,
-    gap: 16,
-  },
-  sizeButton: {
-    width: 44,
-    height: 44,
-    borderRadius: radii.md,
-    backgroundColor: '#F2F2F7',
     justifyContent: 'center',
-    alignItems: 'center',
+    paddingBottom: 4,
   },
-  sizeButtonDark: {
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+  },
+  card: {
+    backgroundColor: '#F7F7FB',
+    borderRadius: radii.lg,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    gap: 12,
+  },
+  cardDark: {
     backgroundColor: Colors.dark.card,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 28,
+  },
+  cardLabel: {
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 1.2,
+    color: '#8E8E93',
+  },
+  cardValueWrap: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: 8,
+  },
+  cardValue: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  resetIconBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  resetIconBtnHidden: {
+    opacity: 0,
+  },
+  sizeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  sizeStepBtn: {
+    width: 56,
+    height: 64,
+    borderRadius: radii.md,
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.06)',
+  },
+  sizeStepBtnDark: {
+    backgroundColor: '#1C1C1E',
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  sizeStepDisabled: {
+    opacity: 0.4,
   },
   sizeDisplay: {
-    alignItems: 'center',
-    minWidth: 80,
-  },
-  sizeValue: {
-    fontSize: 28,
-    fontWeight: '700',
-    fontVariant: ['tabular-nums'],
-  },
-  sizeLabel: {
-    fontSize: 12,
-    color: '#8E8E93',
-    marginTop: 2,
-  },
-  fontList: {
-    gap: 8,
-    marginBottom: 16,
-  },
-  fontButton: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 14,
-    paddingHorizontal: 18,
+    flex: 1,
+    height: 64,
     borderRadius: radii.md,
-    backgroundColor: '#F2F2F7',
+    backgroundColor: '#FFFFFF',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.06)',
   },
-  fontButtonDark: {
-    backgroundColor: Colors.dark.card,
+  sizeDisplayDark: {
+    backgroundColor: '#1C1C1E',
+    borderColor: 'rgba(255,255,255,0.08)',
   },
-  fontButtonActive: {
-    backgroundColor: '#E8F0FE',
-    borderWidth: 1.5,
-    borderColor: '#BDD4F7',
+  sizeDisplayActive: {
+    backgroundColor: '#FFF4DA',
+    borderColor: '#F4C11E',
   },
-  fontButtonActiveDark: {
-    backgroundColor: '#1A2744',
-    borderWidth: 1.5,
-    borderColor: '#2A3D66',
+  sizeDisplayActiveDark: {
+    backgroundColor: '#3A2D0A',
+    borderColor: '#7A5A00',
   },
-  fontText: {
-    fontSize: 16,
+  sizePercent: {
+    fontSize: 20,
+    fontWeight: '800',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.5,
   },
-  resetButton: {
+  previewWrap: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  previewText: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  fontGrid: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  fontChip: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderRadius: radii.md,
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.06)',
+    minHeight: 64,
+  },
+  fontChipDark: {
+    backgroundColor: '#1C1C1E',
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  fontChipActive: {
+    backgroundColor: '#FFF4DA',
+    borderColor: '#F4C11E',
+  },
+  fontChipActiveDark: {
+    backgroundColor: '#3A2D0A',
+    borderColor: '#7A5A00',
+  },
+  fontChipPreview: {
+    fontSize: 20,
+    fontWeight: '700',
+    lineHeight: 24,
+  },
+  fontChipLabel: {
+    fontSize: 11,
+    letterSpacing: 0.1,
+    textAlign: 'center',
+  },
+  resetAllBtn: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: 12,
+    paddingVertical: 10,
     borderRadius: radii.md,
     backgroundColor: '#F2F2F7',
-    gap: 8,
+    gap: 6,
+    marginTop: 2,
   },
-  resetButtonDark: {
+  resetAllBtnDark: {
     backgroundColor: Colors.dark.card,
   },
-  resetText: {
+  resetAllText: {
+    fontSize: 13,
     fontWeight: '600',
-    fontSize: 15,
   },
 });

--- a/mcm-app/components/TransposePanel.tsx
+++ b/mcm-app/components/TransposePanel.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Platform } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BottomSheet from './BottomSheet';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -19,6 +20,13 @@ interface Props {
   onSetCapoOverride?: (capo: number | null) => void;
 }
 
+const TONE_STEPS: { value: number; label: string }[] = [
+  { value: -2, label: '−2' },
+  { value: -1, label: '−1' },
+  { value: 1, label: '+1' },
+  { value: 2, label: '+2' },
+];
+
 export default function TransposePanel({
   visible,
   onClose,
@@ -31,233 +39,77 @@ export default function TransposePanel({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme];
+  const insets = useSafeAreaInsets();
 
-  const TransposeButton = ({
-    label,
-    value,
-    variant,
-  }: {
-    label: string;
-    value: number;
-    variant: 'up' | 'down';
-  }) => (
-    <PressableFeedback
-      style={[
-        styles.transposeButton,
-        isDark && styles.transposeButtonDark,
-        variant === 'up' &&
-          (isDark ? styles.transposeUpDark : styles.transposeUp),
-        variant === 'down' &&
-          (isDark ? styles.transposeDownDark : styles.transposeDown),
-      ]}
-      onPress={() => onSetTranspose(value)}
-    >
-      <PressableFeedback.Highlight />
-      <MaterialIcons
-        name={variant === 'up' ? 'arrow-upward' : 'arrow-downward'}
-        size={18}
-        color={
-          variant === 'up'
-            ? isDark
-              ? '#81C784'
-              : '#2E7D32'
-            : isDark
-              ? '#E57373'
-              : '#C62828'
-        }
-      />
-      <Text
-        style={[
-          styles.transposeButtonText,
-          {
-            color:
-              variant === 'up'
-                ? isDark
-                  ? '#81C784'
-                  : '#2E7D32'
-                : isDark
-                  ? '#E57373'
-                  : '#C62828',
-          },
-        ]}
-      >
-        {label}
-      </Text>
-    </PressableFeedback>
-  );
-
-  // Cejilla efectiva a mostrar: override si existe, original si no.
-  const effectiveCapo =
-    currentCapoOverride !== null && currentCapoOverride !== undefined
-      ? currentCapoOverride
-      : (originalCapo ?? 0);
+  const showCapoSection = onSetCapoOverride !== undefined;
   const isCapoOverridden =
     currentCapoOverride !== null && currentCapoOverride !== undefined;
-  const showCapoSection = onSetCapoOverride !== undefined;
+  const effectiveCapo = isCapoOverridden
+    ? (currentCapoOverride as number)
+    : (originalCapo ?? 0);
+  const isTransposed = currentTranspose !== 0;
+
+  const handleCapoMinus = () => {
+    if (!onSetCapoOverride) return;
+    const next = effectiveCapo - 1;
+    if (next < 0) return;
+    onSetCapoOverride(next === (originalCapo ?? 0) ? null : next);
+  };
+  const handleCapoPlus = () => {
+    if (!onSetCapoOverride) return;
+    const next = effectiveCapo + 1;
+    onSetCapoOverride(next === (originalCapo ?? 0) ? null : next);
+  };
 
   return (
     <BottomSheet visible={visible} onClose={onClose}>
-      <Text style={[styles.title, { color: theme.text }]}>Cambiar tono</Text>
-
-      <View style={styles.currentDisplay}>
-        <Text style={styles.currentLabel}>Transposición actual</Text>
-        <Text
-          style={[
-            styles.currentValue,
-            {
-              color:
-                currentTranspose === 0
-                  ? isDark
-                    ? '#8E8E93'
-                    : '#636366'
-                  : currentTranspose > 0
-                    ? isDark
-                      ? '#81C784'
-                      : '#2E7D32'
-                    : isDark
-                      ? '#E57373'
-                      : '#C62828',
-            },
-          ]}
-        >
-          {currentTranspose === 0
-            ? 'Original'
-            : `${currentTranspose > 0 ? '+' : ''}${currentTranspose} semitonos`}
-        </Text>
-      </View>
-
-      <View style={styles.buttonsGrid}>
-        <View style={styles.buttonsRow}>
-          <TransposeButton
-            label="+1"
-            value={currentTranspose + 1}
-            variant="up"
-          />
-          <TransposeButton
-            label="+2"
-            value={currentTranspose + 2}
-            variant="up"
-          />
-        </View>
-        <View style={styles.buttonsRow}>
-          <TransposeButton
-            label="-1"
-            value={currentTranspose - 1}
-            variant="down"
-          />
-          <TransposeButton
-            label="-2"
-            value={currentTranspose - 2}
-            variant="down"
-          />
-        </View>
-      </View>
-
-      <PressableFeedback
-        style={[styles.resetButton, isDark && styles.resetButtonDark]}
-        onPress={() => onSetTranspose(0)}
+      <View
+        style={[
+          styles.container,
+          {
+            paddingBottom:
+              Math.max(insets.bottom, 12) + (Platform.OS === 'web' ? 8 : 4),
+          },
+        ]}
       >
-        <PressableFeedback.Highlight />
-        <MaterialIcons
-          name="refresh"
-          size={18}
-          color={isDark ? '#AEAEB2' : '#636366'}
-        />
-        <Text
-          style={[styles.resetText, { color: isDark ? '#AEAEB2' : '#636366' }]}
-        >
-          Tono original
-        </Text>
-      </PressableFeedback>
-
-      {showCapoSection && (
-        <>
-          <View style={[styles.divider, isDark && styles.dividerDark]} />
-
-          <Text style={[styles.capoSectionTitle, { color: theme.text }]}>
-            Cejilla para esta sesión
+        <View style={styles.header}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>
+            Ajustes de canción
           </Text>
+        </View>
 
-          {originalCapo !== undefined && originalCapo > 0 && !isCapoOverridden && (
-            <Text style={styles.capoOriginalHint}>
-              Original: cejilla {originalCapo}
-            </Text>
-          )}
-          {isCapoOverridden && originalCapo !== undefined && originalCapo > 0 && (
-            <Text style={styles.capoOriginalHint}>
-              Original: cejilla {originalCapo} · sesión: cejilla{' '}
-              {currentCapoOverride}
-            </Text>
-          )}
-
-          <View style={styles.capoStepper}>
-            <PressableFeedback
-              style={[
-                styles.capoStepBtn,
-                isDark && styles.capoStepBtnDark,
-                effectiveCapo <= 0 && styles.capoStepBtnDisabled,
-              ]}
-              onPress={() => {
-                if (effectiveCapo > 0)
-                  onSetCapoOverride(effectiveCapo - 1 === 0 ? null : effectiveCapo - 1);
-              }}
-              disabled={effectiveCapo <= 0}
-            >
-              <PressableFeedback.Highlight />
-              <MaterialIcons
-                name="remove"
-                size={22}
-                color={
-                  effectiveCapo <= 0
-                    ? isDark
-                      ? '#48484A'
-                      : '#C7C7CC'
-                    : isDark
-                      ? '#E57373'
-                      : '#C62828'
-                }
-              />
-            </PressableFeedback>
-
-            <View style={styles.capoValueWrap}>
+        {/* ━━━━━━━━━━━━━━ TONO ━━━━━━━━━━━━━━ */}
+        <View style={[styles.card, isDark && styles.cardDark]}>
+          <View style={styles.cardHeader}>
+            <Text style={styles.cardLabel}>TONO</Text>
+            <View style={styles.cardValueWrap}>
               <Text
                 style={[
-                  styles.capoValue,
+                  styles.cardValue,
                   {
-                    color: isCapoOverridden
+                    color: isTransposed
                       ? isDark
-                        ? '#F4C11E'
-                        : '#7A5A00'
+                        ? '#FFB74D'
+                        : '#C77700'
                       : isDark
                         ? '#8E8E93'
-                        : '#636366',
+                        : '#8E8E93',
                   },
                 ]}
               >
-                {effectiveCapo === 0 ? 'Sin cejilla' : `Cejilla ${effectiveCapo}`}
+                {isTransposed
+                  ? `${currentTranspose > 0 ? '+' : ''}${currentTranspose} semitonos`
+                  : 'Original'}
               </Text>
-              {isCapoOverridden && (
-                <Text style={styles.capoOverrideBadge}>modificada</Text>
-              )}
             </View>
-
             <PressableFeedback
-              style={[styles.capoStepBtn, isDark && styles.capoStepBtnDark]}
-              onPress={() => onSetCapoOverride(effectiveCapo + 1)}
-            >
-              <PressableFeedback.Highlight />
-              <MaterialIcons
-                name="add"
-                size={22}
-                color={isDark ? '#81C784' : '#2E7D32'}
-              />
-            </PressableFeedback>
-          </View>
-
-          {isCapoOverridden && (
-            <PressableFeedback
-              style={[styles.resetButton, isDark && styles.resetButtonDark]}
-              onPress={() => onSetCapoOverride(null)}
+              style={[
+                styles.resetIconBtn,
+                !isTransposed && styles.resetIconBtnHidden,
+              ]}
+              onPress={() => onSetTranspose(0)}
+              disabled={!isTransposed}
+              accessibilityLabel="Restablecer tono"
             >
               <PressableFeedback.Highlight />
               <MaterialIcons
@@ -265,152 +117,321 @@ export default function TransposePanel({
                 size={18}
                 color={isDark ? '#AEAEB2' : '#636366'}
               />
-              <Text
+            </PressableFeedback>
+          </View>
+
+          <View style={styles.toneRow}>
+            {TONE_STEPS.map((step) => {
+              const isUp = step.value > 0;
+              return (
+                <PressableFeedback
+                  key={step.value}
+                  style={[
+                    styles.toneBtn,
+                    isUp
+                      ? isDark
+                        ? styles.toneBtnUpDark
+                        : styles.toneBtnUp
+                      : isDark
+                        ? styles.toneBtnDownDark
+                        : styles.toneBtnDown,
+                  ]}
+                  onPress={() => onSetTranspose(currentTranspose + step.value)}
+                >
+                  <PressableFeedback.Highlight />
+                  <Text
+                    style={[
+                      styles.toneBtnText,
+                      {
+                        color: isUp
+                          ? isDark
+                            ? '#81C784'
+                            : '#2E7D32'
+                          : isDark
+                            ? '#E57373'
+                            : '#C62828',
+                      },
+                    ]}
+                  >
+                    {step.label}
+                  </Text>
+                </PressableFeedback>
+              );
+            })}
+          </View>
+        </View>
+
+        {/* ━━━━━━━━━━━━━━ CEJILLA ━━━━━━━━━━━━━━ */}
+        {showCapoSection && (
+          <View style={[styles.card, isDark && styles.cardDark]}>
+            <View style={styles.cardHeader}>
+              <Text style={styles.cardLabel}>CEJILLA</Text>
+              <View style={styles.cardValueWrap}>
+                <Text
+                  style={[
+                    styles.cardValue,
+                    {
+                      color: isCapoOverridden
+                        ? isDark
+                          ? '#FFB74D'
+                          : '#C77700'
+                        : isDark
+                          ? '#8E8E93'
+                          : '#8E8E93',
+                    },
+                  ]}
+                >
+                  {isCapoOverridden
+                    ? originalCapo && originalCapo > 0
+                      ? `Original: ${originalCapo}`
+                      : 'Original: sin cejilla'
+                    : originalCapo && originalCapo > 0
+                      ? `Original: ${originalCapo}`
+                      : 'Sin cejilla'}
+                </Text>
+              </View>
+              <PressableFeedback
                 style={[
-                  styles.resetText,
-                  { color: isDark ? '#AEAEB2' : '#636366' },
+                  styles.resetIconBtn,
+                  !isCapoOverridden && styles.resetIconBtnHidden,
+                ]}
+                onPress={() => onSetCapoOverride!(null)}
+                disabled={!isCapoOverridden}
+                accessibilityLabel="Restablecer cejilla"
+              >
+                <PressableFeedback.Highlight />
+                <MaterialIcons
+                  name="refresh"
+                  size={18}
+                  color={isDark ? '#AEAEB2' : '#636366'}
+                />
+              </PressableFeedback>
+            </View>
+
+            <View style={styles.capoRow}>
+              <PressableFeedback
+                style={[
+                  styles.capoStepBtn,
+                  isDark ? styles.toneBtnDownDark : styles.toneBtnDown,
+                  effectiveCapo <= 0 && styles.capoStepBtnDisabled,
+                ]}
+                onPress={handleCapoMinus}
+                disabled={effectiveCapo <= 0}
+              >
+                <PressableFeedback.Highlight />
+                <MaterialIcons
+                  name="remove"
+                  size={26}
+                  color={
+                    effectiveCapo <= 0
+                      ? isDark
+                        ? '#48484A'
+                        : '#C7C7CC'
+                      : isDark
+                        ? '#E57373'
+                        : '#C62828'
+                  }
+                />
+              </PressableFeedback>
+
+              <View
+                style={[
+                  styles.capoDisplay,
+                  isCapoOverridden
+                    ? isDark
+                      ? styles.capoDisplayOverriddenDark
+                      : styles.capoDisplayOverridden
+                    : isDark
+                      ? styles.capoDisplayDark
+                      : null,
                 ]}
               >
-                Cejilla original
-              </Text>
-            </PressableFeedback>
-          )}
-        </>
-      )}
+                <Text
+                  style={[
+                    styles.capoDisplayValue,
+                    {
+                      color: isCapoOverridden
+                        ? isDark
+                          ? '#F4C11E'
+                          : '#7A5A00'
+                        : isDark
+                          ? '#EBEBF0'
+                          : '#1C1C1E',
+                    },
+                  ]}
+                >
+                  {effectiveCapo === 0
+                    ? 'Sin cejilla'
+                    : `Cejilla ${effectiveCapo}`}
+                </Text>
+                <Text
+                  style={[
+                    styles.capoDisplayBadge,
+                    !isCapoOverridden && styles.capoDisplayBadgeHidden,
+                  ]}
+                >
+                  modificada
+                </Text>
+              </View>
+
+              <PressableFeedback
+                style={[
+                  styles.capoStepBtn,
+                  isDark ? styles.toneBtnUpDark : styles.toneBtnUp,
+                ]}
+                onPress={handleCapoPlus}
+              >
+                <PressableFeedback.Highlight />
+                <MaterialIcons
+                  name="add"
+                  size={26}
+                  color={isDark ? '#81C784' : '#2E7D32'}
+                />
+              </PressableFeedback>
+            </View>
+          </View>
+        )}
+      </View>
     </BottomSheet>
   );
 }
 
 const styles = StyleSheet.create({
-  title: {
-    fontSize: 20,
-    fontWeight: '700',
-    marginBottom: 20,
-    textAlign: 'center',
-    letterSpacing: -0.4,
+  container: {
+    paddingTop: 4,
+    gap: 12,
   },
-  currentDisplay: {
-    alignItems: 'center',
-    marginBottom: 20,
-  },
-  currentLabel: {
-    fontSize: 13,
-    color: '#8E8E93',
-    marginBottom: 4,
-  },
-  currentValue: {
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  buttonsGrid: {
-    gap: 10,
-    marginBottom: 16,
-  },
-  buttonsRow: {
-    flexDirection: 'row',
-    gap: 10,
-  },
-  transposeButton: {
-    flex: 1,
+  header: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: 16,
-    borderRadius: radii.md,
-    gap: 8,
+    paddingBottom: 4,
   },
-  transposeButtonDark: {},
-  transposeUp: {
-    backgroundColor: '#E8F5E9',
-  },
-  transposeUpDark: {
-    backgroundColor: '#1B3A1B',
-  },
-  transposeDown: {
-    backgroundColor: '#FFEBEE',
-  },
-  transposeDownDark: {
-    backgroundColor: '#3A1B1B',
-  },
-  transposeButtonText: {
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  resetButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 12,
-    borderRadius: radii.md,
-    backgroundColor: '#F2F2F7',
-    gap: 8,
-  },
-  resetButtonDark: {
-    backgroundColor: Colors.dark.card,
-  },
-  resetText: {
-    fontWeight: '600',
-    fontSize: 15,
-  },
-  divider: {
-    height: 1,
-    backgroundColor: 'rgba(0,0,0,0.08)',
-    marginVertical: 16,
-  },
-  dividerDark: {
-    backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  capoSectionTitle: {
+  headerTitle: {
     fontSize: 17,
     fontWeight: '700',
-    textAlign: 'center',
-    marginBottom: 6,
     letterSpacing: -0.3,
   },
-  capoOriginalHint: {
-    fontSize: 13,
-    color: '#8E8E93',
-    textAlign: 'center',
-    marginBottom: 12,
+  card: {
+    backgroundColor: '#F7F7FB',
+    borderRadius: radii.lg,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    gap: 12,
   },
-  capoStepper: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 10,
-    marginBottom: 10,
-  },
-  capoStepBtn: {
-    width: 52,
-    height: 52,
-    borderRadius: radii.md,
-    backgroundColor: '#F2F2F7',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  capoStepBtnDark: {
+  cardDark: {
     backgroundColor: Colors.dark.card,
   },
-  capoStepBtnDisabled: {
-    opacity: 0.4,
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 28,
   },
-  capoValueWrap: {
+  cardLabel: {
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 1.2,
+    color: '#8E8E93',
+  },
+  cardValueWrap: {
     flex: 1,
     alignItems: 'center',
   },
-  capoValue: {
-    fontSize: 17,
-    fontWeight: '700',
-  },
-  capoOverrideBadge: {
-    fontSize: 11,
+  cardValue: {
+    fontSize: 13,
     fontWeight: '600',
-    color: '#9D5C00',
+  },
+  resetIconBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+  },
+  resetIconBtnHidden: {
+    opacity: 0,
+  },
+  toneRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  toneBtn: {
+    flex: 1,
+    height: 48,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  toneBtnUp: {
+    backgroundColor: '#E8F5E9',
+  },
+  toneBtnUpDark: {
+    backgroundColor: '#1B3A1B',
+  },
+  toneBtnDown: {
+    backgroundColor: '#FFEBEE',
+  },
+  toneBtnDownDark: {
+    backgroundColor: '#3A1B1B',
+  },
+  toneBtnText: {
+    fontSize: 17,
+    fontWeight: '800',
+    fontVariant: ['tabular-nums'],
+  },
+  capoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  capoStepBtn: {
+    width: 56,
+    height: 56,
+    borderRadius: radii.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  capoStepBtnDisabled: {
+    opacity: 0.35,
+  },
+  capoDisplay: {
+    flex: 1,
+    height: 56,
+    borderRadius: radii.md,
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 4,
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.06)',
+  },
+  capoDisplayDark: {
+    backgroundColor: '#1C1C1E',
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  capoDisplayOverridden: {
     backgroundColor: '#FFF4DA',
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 8,
-    marginTop: 4,
-    overflow: 'hidden',
+    borderColor: '#F4C11E',
+  },
+  capoDisplayOverriddenDark: {
+    backgroundColor: '#3A2D0A',
+    borderColor: '#7A5A00',
+  },
+  capoDisplayValue: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: -0.2,
+  },
+  capoDisplayBadge: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#9D5C00',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    marginTop: 2,
+  },
+  capoDisplayBadgeHidden: {
+    opacity: 0,
   },
 });

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -25,6 +25,10 @@ interface UseSongProcessorParams {
   capo?: number; // Added to pass capo
   isFullscreen?: boolean; // Added for fullscreen mode
   isDark?: boolean; // Dark mode support
+  /** Padding superior extra (px). Útil en fullscreen para evitar notch / close button. */
+  topInset?: number;
+  /** Padding inferior extra (px). Útil en fullscreen para no esconder texto bajo play/safe-area. */
+  bottomInset?: number;
 }
 
 export const useSongProcessor = ({
@@ -39,6 +43,8 @@ export const useSongProcessor = ({
   capo,
   isFullscreen = false,
   isDark = false,
+  topInset,
+  bottomInset,
 }: UseSongProcessorParams) => {
   const [songHtml, setSongHtml] = useState<string>('Cargando…');
   const [isLoadingSong, setIsLoadingSong] = useState<boolean>(true);
@@ -149,14 +155,23 @@ export const useSongProcessor = ({
         ? ''
         : '<style>.chord { display: none !important; }</style>';
 
-      // Platform-aware bottom padding
-      const bottomPadding = isFullscreen
-        ? 0
-        : Platform.OS === 'ios'
-          ? 120
-          : Platform.OS === 'web'
-            ? 40
-            : 80;
+      // Platform-aware bottom padding.
+      // En fullscreen reservamos espacio para el botón de play translúcido
+      // y el safe-area inferior (home indicator en iOS). En detalle, espacio
+      // suficiente para que el FAB no tape la última línea.
+      const bottomPadding =
+        bottomInset !== undefined
+          ? bottomInset
+          : isFullscreen
+            ? 110
+            : Platform.OS === 'ios'
+              ? 120
+              : Platform.OS === 'web'
+                ? 40
+                : 80;
+      // Padding superior: en fullscreen, espacio para el close button y notch.
+      const topPadding =
+        topInset !== undefined ? topInset : isFullscreen ? 72 : 16;
 
       // Dark mode aware colors
       const c = {
@@ -185,8 +200,7 @@ export const useSongProcessor = ({
             body {
               font-family: ${currentFontFamily};
               margin: 0;
-              padding: 16px 16px;
-              ${bottomPadding > 0 ? `padding-bottom: ${bottomPadding}px;` : ''}
+              padding: ${topPadding}px 16px ${bottomPadding}px 16px;
               background-color: ${c.bodyBg};
               color: ${c.bodyText};
               font-size: 100%;
@@ -341,6 +355,9 @@ export const useSongProcessor = ({
     key,
     capo,
     isDark,
+    isFullscreen,
+    topInset,
+    bottomInset,
   ]);
 
   return { songHtml, isLoadingSong };


### PR DESCRIPTION
## Summary

Refactors the TransposePanel and SongFontPanel components with a modern card-based UI design, improves the fullscreen song screen's auto-scroll controls with a custom vertical slider, and adds safe area inset support across all three screens.

## Key Changes

### TransposePanel (`components/TransposePanel.tsx`)
- **UI Redesign**: Replaced grid layout with card-based design featuring:
  - Unified header with title and reset button
  - Separate cards for "TONO" (transpose) and "CEJILLA" (capo) sections
  - Extracted `TONE_STEPS` constant for transpose buttons (±1, ±2 semitones)
- **Improved State Management**: Simplified capo override logic with dedicated `handleCapoMinus` and `handleCapoPlus` handlers
- **Safe Area Support**: Added `useSafeAreaInsets()` hook with platform-aware bottom padding
- **Visual Enhancements**: 
  - Color-coded status indicators (modified state shows orange/gold)
  - Disabled state styling for boundary conditions
  - Improved accessibility labels

### SongFontPanel (`components/SongFontPanel.tsx`)
- **UI Redesign**: Converted to card-based layout with:
  - Separate cards for "TAMAÑO" (size) and "FUENTE" (font) sections
  - Size controls now use custom step buttons with visual feedback
  - Font selection redesigned as chip grid instead of full-width buttons
- **Size Constraints**: Added `MIN_SIZE` (0.6) and `MAX_SIZE` (2.0) constants with proper boundary checks
- **State Tracking**: Added `isSizeModified` and `isFontModified` flags to show/hide reset buttons
- **Conditional Reset**: "Restablecer todo" button only appears when changes exist
- **Safe Area Support**: Added `useSafeAreaInsets()` hook with platform-aware padding
- **Preview Enhancement**: Size display now includes a scaled "Aa" preview with font family applied

### SongFullscreenScreen (`app/screens/SongFullscreenScreen.tsx`)
- **Custom Vertical Slider**: Implemented `VerticalSlider` component using `PanResponder` for cross-platform compatibility (replaces HeroUI Slider which doesn't work well vertically)
  - Smooth drag interaction with visual track fill
  - Proper hit area for easy thumb grabbing
  - Platform-specific shadow styling
- **Improved Auto-Scroll Controls**:
  - Renamed `scrollSpeed` → `speedFactor` (0–1 normalized value)
  - Speed range now 0.5–7 px/tick (more granular control)
  - Speed label shows "Lento" / "Normal" / "Rápido" / "Muy rápido" based on factor
  - Controls auto-hide after 2.4s of inactivity
- **Glass Morphism UI**: Unified `TranslucentBg` component for iOS BlurView + Android fallback
  - Applied to close button and speed pill
  - Consistent backdrop blur across platforms
- **Safe Area Integration**: Uses `useSafeAreaInsets()` to position controls around notches and safe areas
  - Close button positioned with top inset
  - Controls cluster positioned with bottom inset
  - HTML content padding adjusted for fullscreen (topInset + bottomInset)
- **Accessibility**: Added proper labels and long-press gesture to show controls on demand

### useSongProcessor Hook (`hooks/useSongProcessor.ts`)
- **New Parameters**: Added `topInset` and `bottomInset` for fullscreen padding control
- **HTML Padding**: Applies insets to song content wrapper to prevent overlap with UI controls

## Implementation Details

- All panels now use consistent card styling with `radii.lg` border radius and proper dark mode support
- Reset buttons use icon-only style with `resetIconBtnHidden` opacity state for cleaner UI
- Capo and tone buttons maintain color coding (green for up/+, red for down/−)
- Fullscreen slider uses normalized 0–1 value

https://claude.ai/code/session_01TV1tbuDJHvaGSjiJtvb6fQ