### PR TITLE
⚡ Bolt: Optimize AppSettingsContext and SettingsContext providers

### DIFF
--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -3,6 +3,8 @@ import React, {
   useContext,
   useEffect,
   useState,
+  useCallback,
+  useMemo,
   ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -58,13 +60,18 @@ export const AppSettingsProvider = ({ children }: { children: ReactNode }) => {
     });
   }, [settings, loading]);
 
-  const update = (values: Partial<AppSettings>) => {
+  const update = useCallback((values: Partial<AppSettings>) => {
     setSettingsState((prev) => ({ ...prev, ...values }));
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ settings, setSettings: update, loading }),
+    [settings, update, loading]
+  );
 
   return (
     <AppSettingsContext.Provider
-      value={{ settings, setSettings: update, loading }}
+      value={value}
     >
       {children}
     </AppSettingsContext.Provider>

--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -3,6 +3,8 @@ import React, {
   useState,
   useContext,
   useEffect,
+  useCallback,
+  useMemo,
   ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -114,16 +116,21 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({
     };
   }, [settings, isLoadingSettings]);
 
-  const handleSetSettings = (newValues: Partial<SongSettings>) => {
+  const handleSetSettings = useCallback((newValues: Partial<SongSettings>) => {
     setAppSettings((prevSettings) => ({
       ...prevSettings,
       ...newValues,
     }));
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ settings, setSettings: handleSetSettings, isLoadingSettings }),
+    [settings, handleSetSettings, isLoadingSettings]
+  );
 
   return (
     <SettingsContext.Provider
-      value={{ settings, setSettings: handleSetSettings, isLoadingSettings }}
+      value={value}
     >
       {children}
     </SettingsContext.Provider>


### PR DESCRIPTION
💡 **What:** Wrapped the `value` prop objects of `AppSettingsContext` and `SettingsContext` providers in `useMemo`, and their state updater functions in `useCallback`.

🎯 **Why:** Previously, these context providers created a new `value` object literal on every single render. This forces *every* component that consumes these contexts to re-render whenever the provider re-renders, regardless of whether the actual settings data changed.

📊 **Impact:** Prevents cascading re-renders across the application for any component that uses `useSettings()` or `useAppSettings()`. This provides a small but systemic performance improvement by cutting down React reconciliation cycles.

🔬 **Measurement:** Use React Developer Tools Profiler. Record a trace when a high-level state change triggers a re-render of the providers, and observe that downstream consumer components no longer re-render unless the settings actually changed.

---
*PR created automatically by Jules for task [10425660390058001384](https://jules.google.com/task/10425660390058001384) started by @mcmespana*