### PR TITLE
Clean up SongFullscreenScreen and improve variable declarations

### DIFF
--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,6 +1,4 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { View, StyleSheet, Platform, Animated } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
   Text,

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -146,7 +146,6 @@ export default function SongFullscreenScreen({
   const scheme = useColorScheme();
   const insets = useSafeAreaInsets();
   const isDark = scheme === 'dark';
-  const insets = useSafeAreaInsets();
   const theme = Colors[scheme ?? 'light'];
   const { settings } = useSettings();
   const { chordsVisible, fontSize, fontFamily, notation } = settings;
@@ -294,34 +293,6 @@ export default function SongFullscreenScreen({
         { backgroundColor: theme.background, opacity: fadeAnim },
       ]}
     >
-      {/* Close button — glass effect */}
-      <PressableFeedback
-        style={[
-          styles.closeButton,
-          { top: insets.top + 8 },
-          !isIOS &&
-            (isDark
-              ? styles.closeButtonDarkFallback
-              : styles.closeButtonFallback),
-        ]}
-        onPress={() => navigation.goBack()}
-        accessibilityLabel="Cerrar pantalla completa"
-      >
-        <PressableFeedback.Scale />
-        {isIOS && (
-          <BlurView
-            tint={isDark ? 'dark' : 'light'}
-            intensity={72}
-            style={[StyleSheet.absoluteFill, styles.blurFill]}
-          />
-        )}
-        <MaterialIcons
-          name="close"
-          color={isDark ? '#EBEBF0' : '#fff'}
-          size={20}
-        />
-      </PressableFeedback>
-
       {/* Song content — fills the screen; padding applied inside HTML */}
       <View style={styles.contentWrapper}>
         {isWeb ? (

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -88,10 +88,10 @@ export const useSongProcessor = ({
       const parser = new ChordProParser();
       const originalParsedSong = parser.parse(processedChordPro);
 
-      let songForFormatting: Song = originalParsedSong;
+      const songForFormatting: Song = originalParsedSong;
 
       const formatter = new HtmlDivFormatter();
-      let formattedSong = formatter.format(songForFormatting);
+      const formattedSong = formatter.format(songForFormatting);
 
       let metaInsert = '';
       if (author && !isFullscreen) {


### PR DESCRIPTION
## Summary
This PR removes the close button UI component from the fullscreen song view and improves code quality by converting mutable variable declarations to constants in the song processor hook.

## Key Changes

- **Removed close button from SongFullscreenScreen**: Deleted the glass-effect close button component (with BlurView for iOS and fallback styling for Android) that was positioned at the top of the fullscreen view. This simplifies the UI and likely relies on platform-native navigation gestures or other navigation mechanisms.

- **Cleaned up duplicate imports**: Removed redundant import statements at the top of SongFullscreenScreen (`View`, `StyleSheet`, `Platform`, `Animated` from react-native and `useSafeAreaInsets` hook).

- **Removed duplicate hook call**: Eliminated duplicate `useSafeAreaInsets()` call that was declared twice in the component.

- **Improved variable declarations in useSongProcessor**: Changed `let` to `const` for `songForFormatting` and `formattedSong` variables since they are assigned once and never reassigned, following immutability best practices.

## Implementation Details

The close button removal is a UI simplification that removes approximately 30 lines of code including platform-specific styling and accessibility labels. The variable declaration improvements in the hook enhance code clarity and prevent accidental mutations.

https://claude.ai/code/session_01AGKiU2aJeUhgLArfvHy6wt