### PR TITLE
fix(bottomsheet): eliminar padding inferior duplicado en drawers del cantoral

### DIFF
--- a/mcm-app/components/BottomSheet.tsx
+++ b/mcm-app/components/BottomSheet.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 
 const nativeDriver = Platform.OS !== 'web';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { UIColors, Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
@@ -34,6 +35,9 @@ export default function BottomSheet({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const bgColor = Colors[scheme ?? 'light'].background;
+  // useSafeAreaInsets inside Modal returns the real screen safe area (home
+  // indicator only, ~34px on iPhone X+), NOT the tab bar height.
+  const insets = useSafeAreaInsets();
 
   const [modalVisible, setModalVisible] = useState(false);
   const slideAnim = useRef(new Animated.Value(OFF_SCREEN)).current;
@@ -132,6 +136,7 @@ export default function BottomSheet({
           styles.sheet,
           {
             backgroundColor: bgColor,
+            paddingBottom: insets.bottom,
             transform: [{ translateY }],
           },
         ]}

--- a/mcm-app/components/SongFontPanel.tsx
+++ b/mcm-app/components/SongFontPanel.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BottomSheet from './BottomSheet';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -40,7 +39,6 @@ export default function SongFontPanel({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme ?? 'light'];
-  const insets = useSafeAreaInsets();
 
   const defaultFamily = availableFonts[0]?.cssValue ?? currentFontFamily;
   const isSizeModified =
@@ -69,7 +67,7 @@ export default function SongFontPanel({
           styles.container,
           {
             paddingBottom:
-              Math.max(insets.bottom, 12) + (Platform.OS === 'web' ? 8 : 4),
+              Platform.OS === 'web' ? 24 : 16,
           },
         ]}
       >

--- a/mcm-app/components/TransposePanel.tsx
+++ b/mcm-app/components/TransposePanel.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { MaterialIcons } from '@expo/vector-icons';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BottomSheet from './BottomSheet';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -39,7 +38,6 @@ export default function TransposePanel({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme ?? 'light'];
-  const insets = useSafeAreaInsets();
 
   const showCapoSection = onSetCapoOverride !== undefined;
   const isCapoOverridden =
@@ -67,8 +65,7 @@ export default function TransposePanel({
         style={[
           styles.container,
           {
-            paddingBottom:
-              Math.max(insets.bottom, 12) + (Platform.OS === 'web' ? 8 : 4),
+            paddingBottom: Platform.OS === 'web' ? 24 : 16,
           },
         ]}
       >


### PR DESCRIPTION
## Problema

Los drawers (tono, tipo de letra) mostraban un hueco innecesario al final igual de grande que el menú de tabs (~83px).

**Causa raíz:** `TransposePanel` y `SongFontPanel` llamaban `useSafeAreaInsets()` en el contexto del stack/tab, donde `insets.bottom` devuelve la altura del tab bar + home indicator (~83px en iPhone). Pero el BottomSheet se superpone al tab bar con un Modal, así que ese valor no era correcto.

## Fix

- **BottomSheet**: usa sus propios `useSafeAreaInsets()` (dentro del Modal = solo home indicator, ~34px correcto) para el `paddingBottom` del sheet
- **TransposePanel / SongFontPanel**: eliminado `useSafeAreaInsets()` — padding fijo de 16px (24px en web). El home indicator lo gestiona el BottomSheet

## Resultado

El sheet ahora se ciñe al contenido con solo 16px de espacio visual al final + 34px del home indicator gestionados correctamente.

## Test plan

- [ ] iOS: drawer de tono sin espacio extra al final
- [ ] iOS: drawer de tipo de letra sin espacio extra al final  
- [ ] iOS: home indicator visible y contenido no cortado
- [ ] Android/Web: drawers con padding normal

https://claude.ai/code/session_01ENeZri89Vj8koRKUyLLGdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENeZri89Vj8koRKUyLLGdA)_