### PR TITLE
Add OTA update prompt and redesign toast notifications

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-05-19 — Toast rediseñado y prompt de actualización OTA
+
+- **Toast modernizado** (`contexts/AppToastContext.tsx`): nueva tarjeta con BlurView translúcida en iOS (tinte oscuro por variante), badge circular con icono según variante (`check-circle`, `error`, `warning`, `info`), border-radius 20, esquinas separadas (margin horizontal 18 + 18px más de aire vertical sobre tab bar/home indicator), sombra más prominente y entrada con spring + scale. Añadido haptic feedback contextual (success/error/warning/selection) en cada toast. Sin cambios en la API pública `useToast()` — todos los `toast.show(...)` existentes funcionan tal cual.
+- **Prompt de actualización OTA** (`components/OTAUpdatePrompt.tsx` + `hooks/useOTAUpdate.ts`, montado en `app/_layout.tsx`): sustituye el discreto texto "actualización disponible 🔄✅" que aparecía en el pie de la Home (`VersionDisplay.tsx`) por un modal con backdrop blur, icono animado (rotación + halo pulsante), título "Nueva versión disponible", descripción y dos CTAs:
+  - **"Reiniciar ahora"** → `Updates.reloadAsync()` (la app se reinicia sola y vuelve a abrirse con la nueva versión — Apple no permite cerrar la app a la fuerza, este es el patrón estándar de Expo Updates).
+  - **"Más tarde"** → se descarta hasta el próximo arranque.
+- El hook comprueba updates en background al arrancar (con 2.5s de delay para no bloquear el splash) y al volver del fondo, los descarga silenciosamente y muestra el modal cuando hay un bundle nuevo listo. Si el usuario abre el modal antes de que termine la descarga, se muestra estado "Preparando…" en el CTA.
+- `VersionDisplay` ahora solo muestra versión + hash corto del bundle OTA (o `dev` en dev mode). Sin cambios cosméticos en colores; los strings se han limpiado.
+
+---
+
 ## 2026-05-18 — App Store warning fix · Universal Links · Cloud Function de purga
 
 - **Fix ITMS-90737 (App Store warning)**: añadido `LSSupportsOpeningDocumentsInPlace: true` en `ios.infoPlist` (`app.json`). Apple lo exige para cualquier app que declare `CFBundleDocumentTypes` (en este caso, el tipo de archivo `.mcm`). Sin esto la subida pasa pero genera un warning en cada release.

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -40,6 +40,8 @@ import { NotificationsProvider } from '@/contexts/NotificationsContext';
 import UniwindThemeBridge from '@/components/UniwindThemeBridge';
 import { HeroUINativeProvider } from 'heroui-native';
 import { AppToastProvider, useToast } from '@/contexts/AppToastContext';
+import OTAUpdatePrompt from '@/components/OTAUpdatePrompt';
+import useOTAUpdate from '@/hooks/useOTAUpdate';
 // Importar iconos para asegurar que se incluyan en el build
 import '@/constants/iconAssets';
 
@@ -74,6 +76,7 @@ export default function RootLayout() {
 
 function InnerLayout() {
   const [showAnimation, setShowAnimation] = useState(true);
+  const [otaDismissed, setOtaDismissed] = useState(false);
   const scheme = useColorScheme();
   const pathname = usePathname();
   const segments = useSegments();
@@ -81,6 +84,7 @@ function InnerLayout() {
   const resolved = useResolvedProfileConfig();
   const { addSong } = useSelectedSongs();
   const { toast } = useToast();
+  const ota = useOTAUpdate();
 
   // Handle incoming .mcm files (opened from WhatsApp, Files, etc.)
   const handleIncomingPlaylist = useCallback(
@@ -189,6 +193,12 @@ function InnerLayout() {
       </Stack>
       <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
       <AddToHomeBanner />
+      <OTAUpdatePrompt
+        visible={(ota.isReady || ota.isDownloading) && !otaDismissed}
+        isDownloading={ota.isDownloading && !ota.isReady}
+        onApply={ota.applyUpdate}
+        onLater={() => setOtaDismissed(true)}
+      />
     </NavThemeProvider>
   );
 }

--- a/mcm-app/components/OTAUpdatePrompt.tsx
+++ b/mcm-app/components/OTAUpdatePrompt.tsx
@@ -1,0 +1,366 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Easing,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { BlurView } from 'expo-blur';
+import * as Haptics from 'expo-haptics';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import brand, { Colors } from '@/constants/colors';
+import { radii } from '@/constants/uiStyles';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+interface OTAUpdatePromptProps {
+  visible: boolean;
+  isDownloading: boolean;
+  onApply: () => void;
+  onLater: () => void;
+}
+
+/**
+ * Modal mostrado cuando una actualización OTA está descargada y lista para
+ * aplicarse. Sigue el patrón estándar de Expo Updates: el usuario decide
+ * cuándo reiniciar.
+ *
+ * En iOS las apps no pueden cerrarse a sí mismas a la fuerza (Apple lo
+ * prohíbe en App Store Review). `Updates.reloadAsync()` es la forma
+ * soportada: descarga el bundle nuevo y reinicia el contexto JS — para el
+ * usuario la app "se cierra y se vuelve a abrir" con la nueva versión.
+ */
+export default function OTAUpdatePrompt({
+  visible,
+  isDownloading,
+  onApply,
+  onLater,
+}: OTAUpdatePromptProps) {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const theme = Colors[scheme ?? 'light'];
+
+  const opacity = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(0.92)).current;
+  const rotate = useRef(new Animated.Value(0)).current;
+  const sparkle = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      try {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch {
+        // Sin haptics — ignorar.
+      }
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+        Animated.spring(scale, {
+          toValue: 1,
+          tension: 120,
+          friction: 11,
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      // Rotación continua suave del icono de update.
+      const rotationLoop = Animated.loop(
+        Animated.timing(rotate, {
+          toValue: 1,
+          duration: 2800,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      );
+      rotationLoop.start();
+
+      // Pulso suave del halo decorativo.
+      const sparkleLoop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(sparkle, {
+            toValue: 1,
+            duration: 1400,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(sparkle, {
+            toValue: 0,
+            duration: 1400,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+        ]),
+      );
+      sparkleLoop.start();
+
+      return () => {
+        rotationLoop.stop();
+        sparkleLoop.stop();
+      };
+    } else {
+      opacity.setValue(0);
+      scale.setValue(0.92);
+    }
+  }, [visible, opacity, scale, rotate, sparkle]);
+
+  const rotateInterpolate = rotate.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+  const sparkleScale = sparkle.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.85, 1.08],
+  });
+  const sparkleOpacity = sparkle.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.35, 0.7],
+  });
+
+  const cardBg = isDark ? '#1F1F22' : '#FFFFFF';
+  const subtleText = isDark ? '#B5B7BD' : '#5B6168';
+  const dividerColor = isDark ? '#2E2E32' : '#ECEEF1';
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="none"
+      transparent
+      statusBarTranslucent
+      onRequestClose={onLater}
+    >
+      <Animated.View style={[styles.backdrop, { opacity }]}>
+        {Platform.OS === 'ios' ? (
+          <BlurView
+            tint={isDark ? 'dark' : 'systemUltraThinMaterialDark'}
+            intensity={45}
+            style={StyleSheet.absoluteFill}
+          />
+        ) : (
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: 'rgba(0,0,0,0.55)' },
+            ]}
+          />
+        )}
+
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onLater}
+          accessibilityLabel="Cerrar diálogo de actualización"
+        />
+
+        <Animated.View
+          style={[
+            styles.cardWrap,
+            {
+              transform: [{ scale }],
+            },
+          ]}
+        >
+          <View style={[styles.card, { backgroundColor: cardBg }]}>
+            <View style={styles.hero}>
+              <Animated.View
+                style={[
+                  styles.heroHalo,
+                  {
+                    opacity: sparkleOpacity,
+                    transform: [{ scale: sparkleScale }],
+                  },
+                ]}
+              />
+              <View style={styles.heroBadge}>
+                <Animated.View
+                  style={{ transform: [{ rotate: rotateInterpolate }] }}
+                >
+                  <MaterialIcons name="autorenew" size={36} color="#FFFFFF" />
+                </Animated.View>
+              </View>
+            </View>
+
+            <Text style={[styles.title, { color: theme.text }]}>
+              Nueva versión disponible
+            </Text>
+            <Text style={[styles.subtitle, { color: subtleText }]}>
+              {isDownloading
+                ? 'Estamos descargando las novedades. Tardará solo unos segundos…'
+                : 'Hemos preparado mejoras y correcciones nuevas. Reinicia la app para empezar a usarlas — solo tarda un par de segundos.'}
+            </Text>
+
+            <View style={[styles.divider, { backgroundColor: dividerColor }]} />
+
+            <View style={styles.actions}>
+              <TouchableOpacity
+                onPress={onApply}
+                disabled={isDownloading}
+                style={[
+                  styles.primaryButton,
+                  isDownloading && styles.primaryButtonDisabled,
+                ]}
+                activeOpacity={0.85}
+                accessibilityRole="button"
+                accessibilityLabel="Reiniciar la app para aplicar la actualización"
+              >
+                <MaterialIcons
+                  name="rocket-launch"
+                  size={18}
+                  color="#FFFFFF"
+                  style={styles.primaryIcon}
+                />
+                <Text style={styles.primaryLabel}>
+                  {isDownloading ? 'Preparando…' : 'Reiniciar ahora'}
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={onLater}
+                style={styles.secondaryButton}
+                activeOpacity={0.6}
+                accessibilityRole="button"
+                accessibilityLabel="Aplicar más tarde"
+              >
+                <Text style={[styles.secondaryLabel, { color: subtleText }]}>
+                  Más tarde
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            <Text style={[styles.fineprint, { color: subtleText }]}>
+              La app se reiniciará sola para cargar la nueva versión.
+            </Text>
+          </View>
+        </Animated.View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 22,
+  },
+  cardWrap: {
+    width: '100%',
+    maxWidth: 420,
+  },
+  card: {
+    borderRadius: radii.xxl,
+    paddingHorizontal: 24,
+    paddingTop: 28,
+    paddingBottom: 18,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 18 },
+        shadowOpacity: 0.32,
+        shadowRadius: 32,
+      },
+      android: {
+        elevation: 20,
+      },
+      default: {
+        // @ts-ignore web only
+        boxShadow: '0px 18px 40px rgba(0, 0, 0, 0.28)',
+      },
+    }),
+  },
+  hero: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 18,
+    height: 96,
+  },
+  heroHalo: {
+    position: 'absolute',
+    width: 112,
+    height: 112,
+    borderRadius: 56,
+    backgroundColor: brand.secondary,
+  },
+  heroBadge: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: brand.primary,
+    ...Platform.select({
+      ios: {
+        shadowColor: brand.primary,
+        shadowOffset: { width: 0, height: 8 },
+        shadowOpacity: 0.4,
+        shadowRadius: 14,
+      },
+      android: {
+        elevation: 8,
+      },
+    }),
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '800',
+    textAlign: 'center',
+    letterSpacing: -0.3,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 15,
+    lineHeight: 21,
+    textAlign: 'center',
+    marginBottom: 22,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginBottom: 16,
+  },
+  actions: {
+    width: '100%',
+  },
+  primaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: brand.primary,
+    paddingVertical: 14,
+    borderRadius: radii.pill,
+    marginBottom: 6,
+  },
+  primaryButtonDisabled: {
+    opacity: 0.6,
+  },
+  primaryIcon: {
+    marginRight: 8,
+  },
+  primaryLabel: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+  },
+  secondaryLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  fineprint: {
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: 4,
+    opacity: 0.85,
+  },
+});

--- a/mcm-app/components/VersionDisplay.tsx
+++ b/mcm-app/components/VersionDisplay.tsx
@@ -11,41 +11,23 @@ export const VersionDisplay: React.FC<{ style?: any }> = ({ style }) => {
   const theme = Colors[scheme ?? 'light'];
 
   useEffect(() => {
-    const getUpdateInfo = async () => {
-      const appVersion = Constants.expoConfig?.version || '1.0.1';
+    // Solo mostramos versión + hash del bundle OTA cuando aplica. La
+    // notificación de "hay update disponible" la gestiona el modal
+    // <OTAUpdatePrompt> montado en el root layout — aquí no duplicamos
+    // ese mensaje para evitar ruido visual en el pie de la Home.
+    const appVersion = Constants.expoConfig?.version || '1.0.1';
 
-      if (!__DEV__ && Updates.isEnabled) {
-        try {
-          // Obtener info del update actual
-          const update = await Updates.checkForUpdateAsync();
+    if (__DEV__) {
+      setUpdateInfo(`v${appVersion} • dev`);
+      return;
+    }
 
-          if (update.isAvailable) {
-            // Hay un update disponible pero no aplicado aún
-            setUpdateInfo(
-              `v${appVersion} • actualización disponible reiniciando la app 🔄✅`,
-            );
-          } else {
-            // Verificar si estamos en un update OTA
-            const currentUpdate = Updates.updateId;
-            if (currentUpdate) {
-              // Estamos en un update OTA, mostrar los primeros 6 chars
-              const shortId = currentUpdate.slice(0, 6);
-              setUpdateInfo(`v${appVersion}+${shortId}`);
-            } else {
-              // Build original, sin updates
-              setUpdateInfo(`v${appVersion}`);
-            }
-          }
-        } catch {
-          setUpdateInfo(`v${appVersion}`);
-        }
-      } else {
-        // Desarrollo o Updates deshabilitados
-        setUpdateInfo(__DEV__ ? `v${appVersion} • dev` : `v${appVersion}`);
-      }
-    };
-
-    getUpdateInfo();
+    if (Updates.isEnabled && Updates.updateId) {
+      const shortId = Updates.updateId.slice(0, 6);
+      setUpdateInfo(`v${appVersion}+${shortId}`);
+    } else {
+      setUpdateInfo(`v${appVersion}`);
+    }
   }, []);
 
   if (!updateInfo) return null;

--- a/mcm-app/contexts/AppToastContext.tsx
+++ b/mcm-app/contexts/AppToastContext.tsx
@@ -8,12 +8,16 @@ import React, {
 } from 'react';
 import {
   Animated,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BlurView } from 'expo-blur';
+import { MaterialIcons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 
 type ToastVariant = 'default' | 'success' | 'danger' | 'warning';
 
@@ -43,15 +47,77 @@ export function useToast() {
   return useContext(ToastContext);
 }
 
-const VARIANT_STYLES: Record<
-  ToastVariant,
-  { bg: string; text: string; action: string }
-> = {
-  default: { bg: '#253883', text: '#FFFFFF', action: '#95d2f2' },
-  success: { bg: '#5A8E1A', text: '#FFFFFF', action: '#D4F0A0' },
-  danger: { bg: '#B91C1C', text: '#FFFFFF', action: '#FCA5A5' },
-  warning: { bg: '#B45309', text: '#FFFFFF', action: '#FDE68A' },
+type VariantStyle = {
+  /** Solid background fallback (Android/web) and tint behind the BlurView on iOS. */
+  tint: string;
+  /** Icon foreground color (rendered inside the leading badge). */
+  iconColor: string;
+  /** Background of the leading icon badge. */
+  iconBg: string;
+  /** Main label color. */
+  text: string;
+  /** Action button label color. */
+  action: string;
+  /** Icon glyph for the leading badge. */
+  icon: keyof typeof MaterialIcons.glyphMap;
 };
+
+const VARIANT_STYLES: Record<ToastVariant, VariantStyle> = {
+  default: {
+    tint: 'rgba(20, 24, 40, 0.78)',
+    iconColor: '#FFFFFF',
+    iconBg: 'rgba(149, 210, 242, 0.22)',
+    text: '#FFFFFF',
+    action: '#9FD3F5',
+    icon: 'info',
+  },
+  success: {
+    tint: 'rgba(20, 56, 18, 0.82)',
+    iconColor: '#FFFFFF',
+    iconBg: 'rgba(163, 189, 49, 0.32)',
+    text: '#FFFFFF',
+    action: '#D4F0A0',
+    icon: 'check-circle',
+  },
+  danger: {
+    tint: 'rgba(80, 12, 18, 0.84)',
+    iconColor: '#FFFFFF',
+    iconBg: 'rgba(255, 107, 122, 0.28)',
+    text: '#FFFFFF',
+    action: '#FFB0B7',
+    icon: 'error',
+  },
+  warning: {
+    tint: 'rgba(78, 44, 6, 0.82)',
+    iconColor: '#FFFFFF',
+    iconBg: 'rgba(252, 210, 0, 0.28)',
+    text: '#FFFFFF',
+    action: '#FDE68A',
+    icon: 'warning',
+  },
+};
+
+function triggerHaptic(variant: ToastVariant) {
+  if (Platform.OS === 'web') return;
+  try {
+    switch (variant) {
+      case 'success':
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        break;
+      case 'danger':
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        break;
+      case 'warning':
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+        break;
+      default:
+        Haptics.selectionAsync();
+        break;
+    }
+  } catch {
+    // Haptics unavailable on this device — silently ignore.
+  }
+}
 
 function ToastItem({
   toast: t,
@@ -62,7 +128,8 @@ function ToastItem({
 }) {
   const insets = useSafeAreaInsets();
   const opacity = useRef(new Animated.Value(0)).current;
-  const translateY = useRef(new Animated.Value(24)).current;
+  const translateY = useRef(new Animated.Value(28)).current;
+  const scale = useRef(new Animated.Value(0.96)).current;
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hide = useCallback(() => {
@@ -70,18 +137,24 @@ function ToastItem({
     Animated.parallel([
       Animated.timing(opacity, {
         toValue: 0,
-        duration: 180,
+        duration: 200,
         useNativeDriver: true,
       }),
       Animated.timing(translateY, {
-        toValue: 16,
-        duration: 180,
+        toValue: 20,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+      Animated.timing(scale, {
+        toValue: 0.97,
+        duration: 200,
         useNativeDriver: true,
       }),
     ]).start(onHide);
-  }, [opacity, translateY, onHide]);
+  }, [opacity, translateY, scale, onHide]);
 
   useEffect(() => {
+    triggerHaptic(t.variant ?? 'default');
     Animated.parallel([
       Animated.timing(opacity, {
         toValue: 1,
@@ -90,13 +163,19 @@ function ToastItem({
       }),
       Animated.spring(translateY, {
         toValue: 0,
-        tension: 90,
-        friction: 9,
+        tension: 110,
+        friction: 11,
+        useNativeDriver: true,
+      }),
+      Animated.spring(scale, {
+        toValue: 1,
+        tension: 130,
+        friction: 12,
         useNativeDriver: true,
       }),
     ]).start();
 
-    const duration = t.duration ?? (t.actionLabel ? 5000 : 3200);
+    const duration = t.duration ?? (t.actionLabel ? 5200 : 3400);
     timerRef.current = setTimeout(hide, duration);
 
     return () => {
@@ -105,39 +184,78 @@ function ToastItem({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const colors = VARIANT_STYLES[t.variant ?? 'default'];
-  const bottomOffset = Math.max(insets.bottom + 8, 20);
+  const v = VARIANT_STYLES[t.variant ?? 'default'];
+  // Extra breathing room above the tab bar / home indicator — much more
+  // than the previous build, which felt glued to the edge on iOS.
+  const bottomOffset =
+    Platform.OS === 'ios'
+      ? Math.max(insets.bottom + 18, 36)
+      : Math.max(insets.bottom + 12, 24);
+
+  const useBlur = Platform.OS === 'ios';
 
   return (
     <Animated.View
       style={[
-        styles.toast,
-        { backgroundColor: colors.bg, marginBottom: bottomOffset },
-        { opacity, transform: [{ translateY }] },
+        styles.toastShadow,
+        { marginBottom: bottomOffset },
+        { opacity, transform: [{ translateY }, { scale }] },
       ]}
     >
-      <Text style={[styles.label, { color: colors.text }]} numberOfLines={3}>
-        {t.label}
-      </Text>
-      {t.actionLabel && (
-        <TouchableOpacity
-          onPress={() => {
-            if (t.onActionPress) {
-              t.onActionPress({ hide });
-            } else {
-              hide();
-            }
-          }}
-          style={styles.actionButton}
-          activeOpacity={0.7}
-        >
-          <Text style={[styles.actionText, { color: colors.action }]}>
-            {t.actionLabel}
+      <View style={styles.toastClip}>
+        {useBlur ? (
+          <BlurView
+            tint="dark"
+            intensity={70}
+            style={[StyleSheet.absoluteFill, { backgroundColor: v.tint }]}
+          />
+        ) : (
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: solidTint(v.tint) },
+            ]}
+          />
+        )}
+        <View style={styles.toastContent}>
+          <View style={[styles.iconBadge, { backgroundColor: v.iconBg }]}>
+            <MaterialIcons name={v.icon} size={18} color={v.iconColor} />
+          </View>
+          <Text style={[styles.label, { color: v.text }]} numberOfLines={3}>
+            {t.label}
           </Text>
-        </TouchableOpacity>
-      )}
+          {t.actionLabel && (
+            <TouchableOpacity
+              onPress={() => {
+                if (t.onActionPress) {
+                  t.onActionPress({ hide });
+                } else {
+                  hide();
+                }
+              }}
+              style={styles.actionButton}
+              hitSlop={{ top: 10, bottom: 10, left: 8, right: 8 }}
+              activeOpacity={0.7}
+            >
+              <Text style={[styles.actionText, { color: v.action }]}>
+                {t.actionLabel}
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
     </Animated.View>
   );
+}
+
+/**
+ * Converts the iOS translucent tint (e.g. "rgba(20, 24, 40, 0.78)") into an
+ * opaque-enough solid for Android/web where we don't render a BlurView.
+ */
+function solidTint(rgba: string): string {
+  // Replace the trailing alpha with 0.96 to keep contrast on platforms
+  // without a real blur primitive.
+  return rgba.replace(/,\s*[\d.]+\)$/, ', 0.96)');
 }
 
 export function AppToastProvider({ children }: { children: React.ReactNode }) {
@@ -155,10 +273,7 @@ export function AppToastProvider({ children }: { children: React.ReactNode }) {
       <View style={styles.root}>
         {children}
         {current !== null && (
-          <View
-            style={styles.overlay}
-            pointerEvents="box-none"
-          >
+          <View style={styles.overlay} pointerEvents="box-none">
             <ToastItem key={current.id} toast={current} onHide={hide} />
           </View>
         )}
@@ -179,20 +294,47 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     zIndex: 9999,
   },
-  toast: {
+  toastShadow: {
+    marginHorizontal: 18,
+    maxWidth: 520,
+    width: '92%',
+    borderRadius: 20,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 10 },
+        shadowOpacity: 0.28,
+        shadowRadius: 22,
+      },
+      android: {
+        elevation: 14,
+      },
+      default: {
+        // @ts-ignore - web only
+        boxShadow: '0px 10px 30px rgba(0, 0, 0, 0.28)',
+      },
+    }),
+  },
+  toastClip: {
+    borderRadius: 20,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255, 255, 255, 0.14)',
+  },
+  toastContent: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginHorizontal: 16,
-    paddingVertical: 13,
-    paddingHorizontal: 18,
-    borderRadius: 14,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.25,
-    shadowRadius: 10,
-    elevation: 10,
-    maxWidth: 480,
-    width: '100%',
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    minHeight: 56,
+  },
+  iconBadge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
   },
   label: {
     flex: 1,
@@ -202,13 +344,15 @@ const styles = StyleSheet.create({
     letterSpacing: 0.1,
   },
   actionButton: {
-    marginLeft: 14,
-    paddingHorizontal: 2,
-    paddingVertical: 2,
+    marginLeft: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: 10,
   },
   actionText: {
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: '700',
-    letterSpacing: 0.2,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
   },
 });

--- a/mcm-app/hooks/useOTAUpdate.ts
+++ b/mcm-app/hooks/useOTAUpdate.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, AppStateStatus, Platform } from 'react-native';
+import * as Updates from 'expo-updates';
+
+/**
+ * Resultado del hook de actualización OTA.
+ *
+ * Sigue el patrón recomendado por Expo:
+ *   1. Comprueba si hay update en background al arrancar (y al volver del fondo).
+ *   2. Lo descarga silenciosamente si existe (`fetchUpdateAsync`).
+ *   3. Expone un estado limpio para que la UI pueda pedir al usuario que
+ *      reinicie la app en el momento que prefiera.
+ *
+ * Referencia: https://docs.expo.dev/eas-update/runtime-behavior/
+ */
+export interface OTAUpdateState {
+  /** El update ya está descargado y listo para aplicarse al reiniciar. */
+  isReady: boolean;
+  /** Hay un update detectado, descargando aún en background. */
+  isDownloading: boolean;
+  /** Hubo un fallo al comprobar/descargar (no bloqueante para el usuario). */
+  error: Error | null;
+  /** Aplica el update: descarga si hace falta y reinicia la app. */
+  applyUpdate: () => Promise<void>;
+}
+
+const CHECK_DELAY_MS = 2500; // dar tiempo a que arranque la app antes de pedir red
+
+export default function useOTAUpdate(): OTAUpdateState {
+  const [isReady, setIsReady] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const checkedRef = useRef(false);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  const checkAndFetch = useCallback(async () => {
+    // Updates.isEnabled es `false` en Expo Go y en dev clients sin canal OTA.
+    if (__DEV__ || !Updates.isEnabled) return;
+    if (Platform.OS === 'web') return;
+    if (checkedRef.current) return;
+    checkedRef.current = true;
+
+    try {
+      const result = await Updates.checkForUpdateAsync();
+      if (!result.isAvailable) return;
+
+      setIsDownloading(true);
+      const fetched = await Updates.fetchUpdateAsync();
+      setIsDownloading(false);
+      if (fetched.isNew) {
+        setIsReady(true);
+      }
+    } catch (err) {
+      setIsDownloading(false);
+      setError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      checkAndFetch();
+    }, CHECK_DELAY_MS);
+
+    // Volver a comprobar cuando la app vuelve del background — el usuario
+    // puede haber estado horas con la app en segundo plano.
+    const sub = AppState.addEventListener('change', (next) => {
+      const prev = appStateRef.current;
+      appStateRef.current = next;
+      if (prev.match(/inactive|background/) && next === 'active') {
+        // Resetear el flag para permitir una nueva comprobación.
+        checkedRef.current = false;
+        checkAndFetch();
+      }
+    });
+
+    return () => {
+      clearTimeout(timer);
+      sub.remove();
+    };
+  }, [checkAndFetch]);
+
+  const applyUpdate = useCallback(async () => {
+    try {
+      // Si por alguna razón aún no se descargó (p.ej. el usuario abrió el
+      // modal antes de que terminara el `fetchUpdateAsync`), lo forzamos.
+      if (!isReady) {
+        setIsDownloading(true);
+        await Updates.fetchUpdateAsync();
+        setIsDownloading(false);
+      }
+      await Updates.reloadAsync();
+    } catch (err) {
+      setIsDownloading(false);
+      setError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }, [isReady]);
+
+  return { isReady, isDownloading, error, applyUpdate };
+}


### PR DESCRIPTION
## Summary

Implements a polished OTA (Over-The-Air) update flow with a new modal prompt, and redesigns the toast notification system with modern glassmorphism styling, haptic feedback, and variant-specific icons.

## Key Changes

### New OTA Update System
- **`OTAUpdatePrompt.tsx`** (new): Modal dialog shown when an OTA update is ready to apply. Features:
  - Animated hero section with rotating icon and pulsing halo
  - Spring-based entrance animation with scale and opacity
  - "Restart now" and "Later" actions
  - Disabled state during download with loading text
  - Platform-specific shadows (iOS/Android/web)
  - Haptic feedback on appearance
  - Accessibility labels for screen readers

- **`useOTAUpdate.ts`** (new): Custom hook managing the OTA update lifecycle:
  - Checks for updates on app launch (with 2.5s delay to avoid blocking startup)
  - Re-checks when app returns from background
  - Silently downloads updates in background
  - Exposes `isReady`, `isDownloading`, `error`, and `applyUpdate()` states
  - Respects `__DEV__` and `Updates.isEnabled` flags
  - Follows Expo's recommended runtime behavior pattern

- **`_layout.tsx`** (modified): Integrated `OTAUpdatePrompt` and `useOTAUpdate` into root layout to display update modal when ready

### Toast Redesign
- **`AppToastContext.tsx`** (modified): Complete visual and interaction overhaul:
  - **Glassmorphism**: BlurView on iOS with translucent tints per variant; solid fallback on Android/web
  - **Icons**: Leading circular badge with variant-specific icons (`check-circle`, `error`, `warning`, `info`)
  - **Styling**: Border-radius 20, hairline border with subtle white tint, improved shadows
  - **Spacing**: Increased bottom margin (18px on iOS, 12px on Android) for better clearance above tab bar/home indicator
  - **Animation**: Spring-based entrance with scale transform; smoother exit
  - **Haptic feedback**: Context-aware haptics (success/error/warning/selection) via `triggerHaptic()`
  - **Action buttons**: Improved hit targets and uppercase labels
  - **Duration**: Slightly longer default timeouts (3.4s default, 5.2s with action)
  - **No API changes**: `useToast()` remains backward compatible

### Version Display Cleanup
- **`VersionDisplay.tsx`** (modified): Simplified to only show version + OTA hash when applicable. Removed duplicate "update available" messaging (now handled by `OTAUpdatePrompt` modal)

## Implementation Details

- **Haptic feedback** is wrapped in try-catch to gracefully handle devices without haptics support
- **OTA checks** are gated by `__DEV__`, `Updates.isEnabled`, and platform (web excluded)
- **Toast variants** now include icon glyphs and color-coded backgrounds with proper contrast
- **Animations** use native drivers for performance (opacity, transform, scale)
- **Platform-specific rendering**: BlurView on iOS, solid backgrounds on Android/web
- **Accessibility**: Added `accessibilityLabel` and `accessibilityRole` attributes to interactive elements

## Notes

- The OTA update modal follows Expo's recommended pattern: silent background check → user-initiated restart
- On iOS, `Updates.reloadAsync()` is the supported way to apply updates (app cannot force-close per App Store Review guidelines)
- Toast redesign maintains full backward compatibility with existing `useToast()` calls

https://claude.ai/code/session_01HNDSeHMSrdrddTsjAD69r1