### PR TITLE
Handle <br> tags as spaces in prose text

### DIFF
--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "mcm-app",
+    "name": "MCM App",
     "slug": "mcm-app",
     "version": "1.0.1",
     "runtimeVersion": "1.0.1",

--- a/scrapping-lecturas/scrapers/vida_nueva.py
+++ b/scrapping-lecturas/scrapers/vida_nueva.py
@@ -223,7 +223,7 @@ class VidaNuevaScraper(BaseScraper):
                     state = "COMMENTARY"
 
             elif child.name == "p":
-                plain = html_to_plain(child)
+                plain = html_to_plain(child, prose=True)
                 if not plain:
                     continue
                 if state == "GOSPEL":

--- a/scrapping-lecturas/tests/test_vida_nueva.py
+++ b/scrapping-lecturas/tests/test_vida_nueva.py
@@ -174,14 +174,14 @@ def test_no_html_artifacts_in_comentario(scraper, html_content):
 @responses_lib.activate
 def test_paragraph_separators_in_texto(scraper, html_content):
     """
-    Multi-paragraph texts use \\n\\n between paragraphs.
-    Single <br> within a paragraph becomes \\n.
-    The fixture gospel text contains <br> tags → should appear as \\n.
+    <br> within a <p> (prose mode) becomes a space, not a newline.
+    The fixture gospel text contains <br> tags — they should vanish as spaces,
+    not produce mid-sentence line breaks.
     """
     responses_lib.add(responses_lib.GET, URL, body=html_content, status=200)
     data = scraper.fetch()[0]
     assert data.evangelio_texto is not None
-    # The fixture gospel has <br> line breaks inside — they become \n
-    assert "\n" in data.evangelio_texto
+    # <br> inside a paragraph must NOT produce bare \n (prose mode converts to space)
+    assert "\n" not in data.evangelio_texto.replace("\n\n", "")
     # No raw HTML line break tags
     assert "<br" not in data.evangelio_texto

--- a/scrapping-lecturas/utils/text_utils.py
+++ b/scrapping-lecturas/utils/text_utils.py
@@ -6,32 +6,34 @@ import re
 from bs4 import Tag
 
 
-def html_to_plain(element: Tag) -> str:
+def html_to_plain(element: Tag, prose: bool = False) -> str:
     """
     Convert a BeautifulSoup element to clean plaintext.
 
-    - Replaces <br> tags with newlines
+    - prose=False (default): <br> → newline (for structured text like poetry/verses)
+    - prose=True: <br> → space (for flowing paragraph text where <br> is a CMS artifact)
     - Strips all remaining HTML tags
-    - Normalizes whitespace (collapses multiple blank lines)
+    - Normalizes whitespace
     - Unescapes HTML entities (&amp; → &, etc.)
     """
-    # Replace <br> with newline before stripping
+    br_replacement = " " if prose else "\n"
     for br in element.find_all("br"):
-        br.replace_with("\n")
+        br.replace_with(br_replacement)
 
     text = element.get_text(separator="")
 
-    # Collapse more than 2 consecutive newlines
-    text = re.sub(r"\n{3,}", "\n\n", text)
+    if prose:
+        # Collapse any internal whitespace runs (including stray \n) to a single space
+        text = re.sub(r"[ \t]*\n[ \t]*", " ", text)
+        text = re.sub(r" {2,}", " ", text)
+    else:
+        # Collapse more than 2 consecutive newlines
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        # Strip leading/trailing whitespace on each line
+        lines = [line.strip() for line in text.splitlines()]
+        text = "\n".join(lines)
 
-    # Strip leading/trailing whitespace on each line
-    lines = [line.strip() for line in text.splitlines()]
-    text = "\n".join(lines)
-
-    # Remove leading/trailing blank lines
-    text = text.strip()
-
-    return html.unescape(text)
+    return html.unescape(text.strip())
 
 
 def join_paragraphs(paragraphs: list[str]) -> str:

--- a/scrapping-lecturas/utils/text_utils.py
+++ b/scrapping-lecturas/utils/text_utils.py
@@ -19,7 +19,7 @@ def html_to_plain(element: Tag) -> str:
     for br in element.find_all("br"):
         br.replace_with("\n")
 
-    text = element.get_text(separator="\n")
+    text = element.get_text(separator="")
 
     # Collapse more than 2 consecutive newlines
     text = re.sub(r"\n{3,}", "\n\n", text)


### PR DESCRIPTION
## Summary
Updated the `html_to_plain()` utility to handle `<br>` tags differently depending on context: as newlines for structured text (poetry, verses) and as spaces for flowing prose. Applied this to gospel text parsing where `<br>` tags are CMS artifacts rather than intentional line breaks.

## Changes

- **`text_utils.py`**: Added `prose` parameter to `html_to_plain()`
  - `prose=False` (default): `<br>` → `\n` (preserves structure for poetry/verses)
  - `prose=True`: `<br>` → space (treats `<br>` as whitespace in flowing text)
  - Updated whitespace normalization logic to handle each mode appropriately
  - Changed `get_text(separator="\n")` to `separator=""` for better control over spacing

- **`vida_nueva.py`**: Pass `prose=True` when parsing gospel paragraphs
  - Gospel text (`<p>` elements) now treated as prose, converting internal `<br>` tags to spaces instead of line breaks

- **`test_vida_nueva.py`**: Updated test expectations
  - Changed assertion to verify that `<br>` tags don't produce bare newlines in gospel text
  - Test now confirms `<br>` artifacts are handled as spaces, not structural breaks

- **`app.json`**: Minor: Updated app display name from "mcm-app" to "MCM App"

## Implementation Details
The prose mode collapses newlines and multiple spaces into single spaces, while the default mode preserves intentional line structure and normalizes only excessive blank lines. This prevents CMS-generated `<br>` tags from breaking up sentences in flowing paragraph text.

https://claude.ai/code/session_01MPBkwyxnttoU2P2gMu9mYK