### PR TITLE
fix(ios): evitar "More" automático del tab bar limitando a 5 triggers

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,18 @@
 
 ---
 
+## 2026-05-20 — Fix iOS: tab bar con "More" feo del sistema cuando hay >5 tabs
+
+- **Problema**: `UITabBarController` en iPhone solo admite 5 items; con 6+ visibles iOS añade un "More" automático del sistema que ignoraba el estilo de la app (mostraba "Fotos" y nuestro "Más" dentro de un menú feo) y dejaba en segundo plano el `MasHomeScreen` cuidado del usuario.
+- **Solución**: limitamos la barra nativa de iOS a 5 triggers (4 prioritarios en el orden definido + `mas` siempre como 5º). Los tabs visibles que no caben (overflow) se exponen como tarjetas en `MasHomeScreen` con el mismo estilo bonito que el resto de items. Las rutas overflow siguen existiendo y son navegables vía `router.navigate('/<ruta>')` aunque no tengan `NativeTabs.Trigger` (expo-router las mantiene en el navigation state).
+- **Sin impacto en Android/Web**: allí seguimos usando los `Tabs` tradicionales sin límite duro y se muestran todos los tabs.
+- **Archivos**:
+  - `constants/tabsCatalog.ts` (nuevo): `TABS_CONFIG`, `splitTabsForIOS()` y constante `IOS_MAX_NATIVE_TABS = 5`. Movido desde `app/(tabs)/_layout.tsx` para ser consumido también por `MasHomeScreen`.
+  - `app/(tabs)/_layout.tsx`: el componente `IOSNativeTabsLayout` ahora sólo renderiza los `mainTabs` calculados por `splitTabsForIOS`.
+  - `app/screens/MasHomeScreen.tsx`: añade los tabs overflow como `NavigationItem` con `routePath` (en lugar de `target`); el `onPress` salta a `router.navigate(routePath)` para esos.
+
+---
+
 ## 2026-05-19 — Onboarding: opción "Otros" en perfil y delegación
 
 - **Nueva opción "Otros" en el paso de perfil** del onboarding (`app/onboarding.tsx`), con el texto «Si no te identificas con ninguno de los anteriores o simplemente quieres probar la app». Pensada para visitantes y casos no contemplados. Si el usuario la elige, se salta directamente la pantalla de delegación y se va al éxito.

--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -19,100 +19,31 @@ import {
   DefaultTheme,
 } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Colors, TabHeaderColors } from '@/constants/colors';
+import { Colors } from '@/constants/colors';
 import { hexAlpha } from '@/utils/colorUtils';
 import { HapticTab } from '@/components/HapticTab';
-
-// ============================================================================
-// CENTRALIZED TABS CONFIGURATION
-// ============================================================================
-interface TabConfig {
-  name: string;
-  label: string;
-  iosIcon: {
-    default: string;
-    selected: string;
-  };
-  androidIcon: string;
-  headerColor?: string;
-  headerShown?: boolean;
-}
-
-const TABS_CONFIG: TabConfig[] = [
-  {
-    name: 'index',
-    label: 'Inicio',
-    iosIcon: { default: 'house', selected: 'house.fill' },
-    androidIcon: 'home',
-    headerShown: true,
-  },
-  {
-    name: 'cancionero',
-    label: 'Cantoral',
-    iosIcon: { default: 'music.note', selected: 'music.note' },
-    androidIcon: 'music-note',
-    headerColor: TabHeaderColors.cancionero,
-    headerShown: false, // Cantoral uses its own StackNavigator header
-  },
-  {
-    name: 'contigo',
-    label: 'Contigo',
-    iosIcon: { default: 'heart', selected: 'heart.fill' },
-    androidIcon: 'favorite',
-    headerShown: false,
-  },
-  {
-    name: 'calendario',
-    label: 'Calendario',
-    iosIcon: { default: 'calendar', selected: 'calendar' },
-    androidIcon: 'calendar-today',
-    headerColor: TabHeaderColors.calendario,
-    headerShown: true,
-  },
-  {
-    name: 'fotos',
-    label: 'Fotos',
-    iosIcon: { default: 'photo', selected: 'photo.fill' },
-    androidIcon: 'photo-library',
-    headerColor: TabHeaderColors.fotos,
-    headerShown: true,
-  },
-  {
-    name: 'comunica',
-    label: 'Comunica',
-    iosIcon: { default: 'globe', selected: 'globe' },
-    androidIcon: 'public',
-    headerColor: TabHeaderColors.comunica,
-    headerShown: true,
-  },
-  {
-    name: 'mas',
-    label: 'Más',
-    iosIcon: { default: 'ellipsis', selected: 'ellipsis' },
-    androidIcon: 'more-horiz',
-    headerShown: false,
-  },
-];
+import { TABS_CONFIG, splitTabsForIOS } from '@/constants/tabsCatalog';
 
 // ============================================================================
 // iOS NativeTabs Component
 // ============================================================================
+// iOS sólo muestra 5 tabs antes de generar un "More" automático del sistema.
+// Limitamos a 5 triggers (4 prioritarios + "mas" como último) y los demás se
+// muestran como tarjetas dentro de MasHomeScreen. Las rutas sin trigger siguen
+// siendo navegables programáticamente (expo-router las mantiene en el state).
 function IOSNativeTabsLayout() {
   const resolved = useResolvedProfileConfig();
   const visibleTabs = new Set(resolved.tabs);
+  const { mainTabs } = splitTabsForIOS(visibleTabs);
 
   return (
     <NativeTabs>
-      {TABS_CONFIG.map((tab) => {
-        if (!visibleTabs.has(tab.name)) return null;
-
-        return (
-          <NativeTabs.Trigger key={tab.name} name={tab.name}>
-            <NativeTabs.Trigger.Label>{tab.label}</NativeTabs.Trigger.Label>
-            <NativeTabs.Trigger.Icon sf={tab.iosIcon as any} />
-          </NativeTabs.Trigger>
-        );
-      })}
+      {mainTabs.map((tab) => (
+        <NativeTabs.Trigger key={tab.name} name={tab.name}>
+          <NativeTabs.Trigger.Label>{tab.label}</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon sf={tab.iosIcon as any} />
+        </NativeTabs.Trigger>
+      ))}
     </NativeTabs>
   );
 }
@@ -177,7 +108,7 @@ function AndroidWebTabsLayout() {
                 title: tab.label,
                 tabBarIcon: ({ color, size }) => (
                   <MaterialIcons
-                    name={tab.androidIcon as any}
+                    name={tab.androidIcon}
                     color={color}
                     size={size}
                   />

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -4,6 +4,7 @@ import { PressableFeedback } from 'heroui-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { router } from 'expo-router';
 import { MaterialIcons } from '@expo/vector-icons';
 import type { ComponentProps } from 'react';
 
@@ -15,13 +16,17 @@ import { takePendingMasScreen } from '@/utils/masNavigation';
 import PageContainer from '@/components/ui/PageContainer';
 import ScreenHero from '@/components/ui/ScreenHero';
 import { useResponsive } from '@/hooks/useResponsive';
+import { splitTabsForIOS } from '@/constants/tabsCatalog';
 
 interface NavigationItem {
   label: string;
   subtitle: string;
   emoji: string;
   materialIcon: ComponentProps<typeof MaterialIcons>['name'];
-  target: keyof MasStackParamList;
+  /** Si está definido, navega a una ruta expo-router (overflow de tab). */
+  routePath?: string;
+  /** Si está definido, navega a una pantalla dentro del stack de Mas. */
+  target?: keyof MasStackParamList;
   tintColor: string;
   /** Id del evento a pasar como route param cuando target === 'JubileoHome'. */
   eventId?: string;
@@ -72,13 +77,36 @@ export default function MasHomeScreen() {
   const { isMd, isWeb } = useResponsive();
   const useTwoColumns = isWeb && isMd;
   const resolved = useResolvedProfileConfig();
-  const navigationItems = React.useMemo(
-    () =>
-      resolved.masItems
-        .map((id) => MAS_ITEM_CATALOG[id])
-        .filter((item): item is NavigationItem => Boolean(item)),
-    [resolved.masItems],
-  );
+  const navigationItems = React.useMemo(() => {
+    const items: NavigationItem[] = [];
+
+    // En iOS la barra nativa sólo admite 5 triggers; los tabs que no caben
+    // se exponen aquí como tarjetas para evitar el "More" automático del sistema.
+    if (Platform.OS === 'ios') {
+      const visibleSet = new Set(resolved.tabs);
+      const { overflowTabs } = splitTabsForIOS(visibleSet);
+      for (const tab of overflowTabs) {
+        // 'mas' nunca debería estar en overflow (splitTabsForIOS lo garantiza),
+        // pero filtramos defensivamente para no auto-referenciar esta pantalla.
+        if (tab.name === 'mas') continue;
+        items.push({
+          label: tab.label,
+          subtitle: tab.subtitle,
+          emoji: tab.emoji,
+          materialIcon: tab.androidIcon,
+          routePath: `/${tab.name}`,
+          tintColor: tab.tintColor,
+        });
+      }
+    }
+
+    for (const id of resolved.masItems) {
+      const entry = MAS_ITEM_CATALOG[id];
+      if (entry) items.push(entry);
+    }
+
+    return items;
+  }, [resolved.masItems, resolved.tabs]);
 
   // Deep-link desde la Home: si hay una pantalla pendiente, navegar a ella
   useFocusEffect(
@@ -136,14 +164,22 @@ export default function MasHomeScreen() {
                         boxShadow: `0 4px 12px ${item.tintColor}30`,
                       },
                 ]}
-                onPress={() =>
-                  navigation.navigate(
-                    item.target as any,
-                    item.eventId
-                      ? ({ eventId: item.eventId } as any)
-                      : undefined,
-                  )
-                }
+                onPress={() => {
+                  if (item.routePath) {
+                    // Overflow de tab: salta al tab sibling vía expo-router.
+                    // La ruta sigue existiendo aunque no tenga NativeTabs.Trigger.
+                    router.navigate(item.routePath as any);
+                    return;
+                  }
+                  if (item.target) {
+                    navigation.navigate(
+                      item.target as any,
+                      item.eventId
+                        ? ({ eventId: item.eventId } as any)
+                        : undefined,
+                    );
+                  }
+                }}
               >
                 <PressableFeedback.Highlight />
                 {/* Accent bar izquierda */}

--- a/mcm-app/constants/tabsCatalog.ts
+++ b/mcm-app/constants/tabsCatalog.ts
@@ -1,0 +1,163 @@
+// Catálogo compartido de tabs.
+//
+// Fuente única de verdad para la metadata visual de cada tab. Lo consumen:
+//   - `app/(tabs)/_layout.tsx` para registrar los NativeTabs/Tabs.
+//   - `app/screens/MasHomeScreen.tsx` para listar como tarjetas los tabs que
+//     no caben en la barra inferior de iOS (limitación nativa: UITabBarController
+//     sólo muestra 5 items; si hay más, añade un "More" automático poco bonito).
+//
+// Si añades un nuevo tab, añádelo aquí y a `constants/profileCatalog.KNOWN_TABS`.
+
+import type { ComponentProps } from 'react';
+import type { MaterialIcons } from '@expo/vector-icons';
+import { TabHeaderColors } from '@/constants/colors';
+
+export interface TabConfig {
+  /** Nombre del archivo en `app/(tabs)/` (sin extensión) y ruta expo-router. */
+  name: string;
+  label: string;
+  /** Subtítulo mostrado cuando el tab cae en MasHomeScreen como tarjeta. */
+  subtitle: string;
+  /** Emoji mostrado en la tarjeta de MasHomeScreen. */
+  emoji: string;
+  iosIcon: {
+    default: string;
+    selected: string;
+  };
+  androidIcon: ComponentProps<typeof MaterialIcons>['name'];
+  /** Color principal del tab (cabecera y acento de tarjeta en MasHome). */
+  tintColor: string;
+  /** Color de cabecera específico (algunos tabs usan otro distinto al tint). */
+  headerColor?: string;
+  headerShown?: boolean;
+}
+
+export const TABS_CONFIG: TabConfig[] = [
+  {
+    name: 'index',
+    label: 'Inicio',
+    subtitle: 'Pantalla principal',
+    emoji: '🏠',
+    iosIcon: { default: 'house', selected: 'house.fill' },
+    androidIcon: 'home',
+    tintColor: '#253883',
+    headerShown: true,
+  },
+  {
+    name: 'cancionero',
+    label: 'Cantoral',
+    subtitle: 'Canciones con acordes',
+    emoji: '🎵',
+    iosIcon: { default: 'music.note', selected: 'music.note' },
+    androidIcon: 'music-note',
+    tintColor: TabHeaderColors.cancionero,
+    headerColor: TabHeaderColors.cancionero,
+    headerShown: false, // Cantoral uses its own StackNavigator header
+  },
+  {
+    name: 'contigo',
+    label: 'Contigo',
+    subtitle: 'Acompañamiento y oración',
+    emoji: '❤️',
+    iosIcon: { default: 'heart', selected: 'heart.fill' },
+    androidIcon: 'favorite',
+    tintColor: TabHeaderColors.contigo,
+    headerShown: false,
+  },
+  {
+    name: 'calendario',
+    label: 'Calendario',
+    subtitle: 'Eventos y celebraciones',
+    emoji: '📅',
+    iosIcon: { default: 'calendar', selected: 'calendar' },
+    androidIcon: 'calendar-today',
+    tintColor: TabHeaderColors.calendario,
+    headerColor: TabHeaderColors.calendario,
+    headerShown: true,
+  },
+  {
+    name: 'fotos',
+    label: 'Fotos',
+    subtitle: 'Galería de fotos MCM',
+    emoji: '📷',
+    iosIcon: { default: 'photo', selected: 'photo.fill' },
+    androidIcon: 'photo-library',
+    tintColor: TabHeaderColors.fotos,
+    headerColor: TabHeaderColors.fotos,
+    headerShown: true,
+  },
+  {
+    name: 'comunica',
+    label: 'Comunica',
+    subtitle: 'Portal de comunicación',
+    emoji: '📣',
+    iosIcon: { default: 'globe', selected: 'globe' },
+    androidIcon: 'public',
+    tintColor: TabHeaderColors.comunica,
+    headerColor: TabHeaderColors.comunica,
+    headerShown: true,
+  },
+  {
+    name: 'mas',
+    label: 'Más',
+    subtitle: 'Atajos y secciones',
+    emoji: '✨',
+    iosIcon: { default: 'ellipsis', selected: 'ellipsis' },
+    androidIcon: 'more-horiz',
+    tintColor: '#78909C',
+    headerShown: false,
+  },
+];
+
+/**
+ * UITabBarController en iPhone sólo muestra 5 items; con 6+ añade un "More"
+ * automático del sistema que rompe el estilo de la app. Para evitarlo limitamos
+ * la barra nativa a 5 triggers como máximo: los 4 primeros del orden definido
+ * más el tab "mas" siempre como 5º (si está visible). El resto se navega desde
+ * MasHomeScreen como tarjetas.
+ *
+ * Las rutas que quedan sin Trigger siguen siendo navegables programáticamente
+ * (expo-router las mantiene en el navigation state aunque no tengan tab item).
+ */
+export const IOS_MAX_NATIVE_TABS = 5;
+
+export interface IOSTabSplit {
+  /** Tabs que se mostrarán como triggers nativos (≤ IOS_MAX_NATIVE_TABS). */
+  mainTabs: TabConfig[];
+  /** Tabs visibles según el perfil pero que no caben en la barra. */
+  overflowTabs: TabConfig[];
+}
+
+/**
+ * Divide la lista de tabs visibles en (mainTabs, overflowTabs) para iOS,
+ * garantizando que el tab `mas` (si está visible) sea siempre el último de la
+ * barra nativa para que actúe como puerta hacia los overflow.
+ */
+export function splitTabsForIOS(
+  visibleTabNames: ReadonlySet<string>,
+): IOSTabSplit {
+  const visible = TABS_CONFIG.filter((tab) => visibleTabNames.has(tab.name));
+
+  if (visible.length <= IOS_MAX_NATIVE_TABS) {
+    return { mainTabs: visible, overflowTabs: [] };
+  }
+
+  const masTab = visible.find((tab) => tab.name === 'mas');
+  const nonMas = visible.filter((tab) => tab.name !== 'mas');
+
+  if (!masTab) {
+    // Sin "mas" visible: simplemente recortamos a los primeros 5. El resto se
+    // pierde porque no hay un sitio razonable donde mostrarlos (no hay MasHome).
+    return {
+      mainTabs: nonMas.slice(0, IOS_MAX_NATIVE_TABS),
+      overflowTabs: nonMas.slice(IOS_MAX_NATIVE_TABS),
+    };
+  }
+
+  // Hueco para tabs principales = total - 1 (mas siempre al final).
+  const mainSlots = IOS_MAX_NATIVE_TABS - 1;
+  return {
+    mainTabs: [...nonMas.slice(0, mainSlots), masTab],
+    overflowTabs: nonMas.slice(mainSlots),
+  };
+}


### PR DESCRIPTION
UITabBarController en iPhone añade automáticamente un "More" feo cuando
hay >5 tabs, mostrando "Fotos" y nuestro "Más" cuidado dentro de un
menú genérico. Ahora limitamos la barra nativa a 5 triggers (4
prioritarios + "mas" como último) y exponemos los tabs overflow como
tarjetas dentro de MasHomeScreen, manteniendo el estilo bonito.

Las rutas overflow siguen siendo navegables programáticamente vía
router.navigate('/<ruta>'); expo-router las mantiene en el navigation
state aunque no tengan NativeTabs.Trigger.

- constants/tabsCatalog.ts (nuevo): TABS_CONFIG, splitTabsForIOS()
- app/(tabs)/_layout.tsx: solo renderiza mainTabs en iOS
- app/screens/MasHomeScreen.tsx: tarjetas para overflow tabs

https://claude.ai/code/session_01CXVKJBFL3zC942vYGTXzgR