### PR TITLE
fix(cantoral, contigo): slider fullscreen estable + Contigo responsive iPad

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 ---
 
+## 2026-05-20 — Fix slider fullscreen del cantoral + Contigo responsive en iPad
+
+- **Slider de velocidad en `SongFullscreenScreen` migrado a react-native-gesture-handler + Reanimated**. La implementación anterior con `PanResponder` competía por los gestos con los componentes `PressableFeedback` de heroui-native (que ya usan RNGH internamente), lo que hacía que el slider se rompiera de forma recurrente. La nueva implementación con `Gesture.Pan()` + `useSharedValue` es estable cross-platform y soporta además tap-on-track para saltar a una posición concreta. También se pausa el auto-hide de los controles mientras se está arrastrando para que el slider no desaparezca a mitad del gesto.
+- **Contigo en iPad — wrappers con `maxWidth` y centrado**: aplicado un wrapper `View` con `maxWidth` (720/880 según ancho de ventana) y `alignSelf: 'center'` en `ContigoScreen`, `EvangelioScreen`, `RevisionScreen` y `BookmarksScreen`. Antes la página se estiraba a lo ancho del iPad dejando el HeroCard, los HabitTile y las stats cards en un layout muy disperso y desproporcionado. Ahora el contenido se mantiene legible y compacto en iPad/web sin afectar el diseño en móvil.
+- **Archivos**: `app/screens/SongFullscreenScreen.tsx`, `app/(tabs)/contigo/index.tsx`, `app/(tabs)/contigo/evangelio.tsx`, `app/(tabs)/contigo/revision.tsx`, `app/(tabs)/contigo/bookmarks.tsx`.
+
+---
+
 ## 2026-05-19 — Onboarding: opción "Otros" en perfil y delegación
 
 - **Nueva opción "Otros" en el paso de perfil** del onboarding (`app/onboarding.tsx`), con el texto «Si no te identificas con ninguno de los anteriores o simplemente quieres probar la app». Pensada para visitantes y casos no contemplados. Si el usuario la elige, se salta directamente la pantalla de delegación y se va al éxito.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-05-20 — Rediseño completo del cantoral para iPad (portrait + landscape)
+
+- **Nuevo hook `useResponsiveLayout`** (`hooks/useResponsiveLayout.ts`) que centraliza los breakpoints responsive (`xs`/`sm`/`md`/`lg`), expone `isWide`, `isExtraWide`, `isLandscape`/`isPortrait` y devuelve `gridColumns`, `readableMaxWidth` y `contentMaxWidth` recomendados según el ancho. Pensado para ser usado en cualquier pantalla que necesite adaptarse a iPad / web amplio.
+- **`CategoriesScreen` — grid de tarjetas en iPad**: en wide la primera tarjeta "Tu selección" se convierte en una hero card destacada con subtítulo informativo, y el resto de categorías se renderizan en un grid de 2 columnas con cards estilo dashboard (emoji grande, título, contador de canciones). En móvil se mantiene la lista tradicional. Contenido centrado con `maxWidth` cómodo.
+- **`SongListScreen` — lista centrada en iPad**: la lista de canciones y la barra de búsqueda se centran con `maxWidth: 640/760`. Los inputs y radios crecen en wide para sentirse nativos en tablet.
+- **`SongDetailScreen` — letra y acordes centrados en iPad**: el card del WebView se envuelve en un wrapper centrado con `maxWidth` amplio (760/980), manteniendo el banner del coro, la barra de pestañas y los botones flotantes en sus posiciones originales (top-left/right de la pantalla).
+- **`SelectedSongsScreen` — playlist centrada en iPad**: tanto la vista de canciones como el estado vacío usan `maxWidth + alignSelf: 'center'`.
+- **Archivos**: `hooks/useResponsiveLayout.ts` (nuevo), `app/screens/CategoriesScreen.tsx`, `app/screens/SongListScreen.tsx`, `app/screens/SongDetailScreen.tsx`, `app/screens/SelectedSongsScreen.tsx`.
+
+---
+
 ## 2026-05-20 — Fix slider fullscreen del cantoral + Contigo responsive en iPad
 
 - **Slider de velocidad en `SongFullscreenScreen` migrado a react-native-gesture-handler + Reanimated**. La implementación anterior con `PanResponder` competía por los gestos con los componentes `PressableFeedback` de heroui-native (que ya usan RNGH internamente), lo que hacía que el slider se rompiera de forma recurrente. La nueva implementación con `Gesture.Pan()` + `useSharedValue` es estable cross-platform y soporta además tap-on-track para saltar a una posición concreta. También se pausa el auto-hide de los controles mientras se está arrastrando para que el slider no desaparezca a mitad del gesto.

--- a/mcm-app/app/(tabs)/contigo/bookmarks.tsx
+++ b/mcm-app/app/(tabs)/contigo/bookmarks.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  useWindowDimensions,
 } from 'react-native';
 import { Stack, useRouter, useFocusEffect } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -29,6 +30,15 @@ export default function BookmarksScreen() {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const W = warm(isDark);
+  const { width: windowWidth } = useWindowDimensions();
+  const isWide = windowWidth >= 720;
+  const wideWrapperStyle = isWide
+    ? {
+        width: '100%' as const,
+        maxWidth: windowWidth >= 1100 ? 880 : 720,
+        alignSelf: 'center' as const,
+      }
+    : undefined;
 
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -136,110 +146,112 @@ export default function BookmarksScreen() {
           contentContainerStyle={styles.listWrap}
           showsVerticalScrollIndicator={false}
         >
-          {bookmarks.map((b) => {
-            const ev = b.readings?.evangelio;
-            const titulo =
-              b.readings?.info?.titulo || ev?.cita || 'Evangelio guardado';
-            const firstLine = ev?.texto
-              ? ev.texto
-                  .split('\n')
-                  .map((l: string) => l.trim())
-                  .filter(Boolean)[0]
-              : '';
-            return (
-              <View
-                key={b.date}
-                style={[
-                  styles.card,
-                  {
-                    backgroundColor: W.bgCard,
-                    borderColor: W.border,
-                    shadowColor: W.shadow,
-                  },
-                ]}
-              >
-                <LinearGradient
-                  colors={['#E8A838', '#C4922A']}
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={styles.cardBar}
-                />
-                <View style={styles.cardBody}>
-                  <View style={styles.cardHdrRow}>
-                    <View style={{ flex: 1 }}>
-                      {ev?.cita ? (
+          <View style={wideWrapperStyle}>
+            {bookmarks.map((b) => {
+              const ev = b.readings?.evangelio;
+              const titulo =
+                b.readings?.info?.titulo || ev?.cita || 'Evangelio guardado';
+              const firstLine = ev?.texto
+                ? ev.texto
+                    .split('\n')
+                    .map((l: string) => l.trim())
+                    .filter(Boolean)[0]
+                : '';
+              return (
+                <View
+                  key={b.date}
+                  style={[
+                    styles.card,
+                    {
+                      backgroundColor: W.bgCard,
+                      borderColor: W.border,
+                      shadowColor: W.shadow,
+                    },
+                  ]}
+                >
+                  <LinearGradient
+                    colors={['#E8A838', '#C4922A']}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={styles.cardBar}
+                  />
+                  <View style={styles.cardBody}>
+                    <View style={styles.cardHdrRow}>
+                      <View style={{ flex: 1 }}>
+                        {ev?.cita ? (
+                          <Text
+                            style={[styles.cita, { color: W.accent }]}
+                            numberOfLines={1}
+                          >
+                            {ev.cita}
+                          </Text>
+                        ) : null}
                         <Text
-                          style={[styles.cita, { color: W.accent }]}
+                          style={[styles.dateText, { color: W.textMuted }]}
                           numberOfLines={1}
                         >
-                          {ev.cita}
+                          {formatDateLong(b.date)}
                         </Text>
-                      ) : null}
-                      <Text
-                        style={[styles.dateText, { color: W.textMuted }]}
-                        numberOfLines={1}
+                      </View>
+                      <TouchableOpacity
+                        onPress={() => removeBookmark(b.date)}
+                        style={[
+                          styles.removeBtn,
+                          {
+                            backgroundColor: isDark
+                              ? 'rgba(255,255,255,0.08)'
+                              : 'rgba(0,0,0,0.05)',
+                          },
+                        ]}
+                        accessibilityLabel="Quitar de guardados"
                       >
-                        {formatDateLong(b.date)}
-                      </Text>
+                        <MaterialIcons
+                          name="close"
+                          size={14}
+                          color={W.textMuted}
+                        />
+                      </TouchableOpacity>
                     </View>
-                    <TouchableOpacity
-                      onPress={() => removeBookmark(b.date)}
-                      style={[
-                        styles.removeBtn,
-                        {
-                          backgroundColor: isDark
-                            ? 'rgba(255,255,255,0.08)'
-                            : 'rgba(0,0,0,0.05)',
-                        },
-                      ]}
-                      accessibilityLabel="Quitar de guardados"
-                    >
-                      <MaterialIcons
-                        name="close"
-                        size={14}
-                        color={W.textMuted}
-                      />
-                    </TouchableOpacity>
-                  </View>
-                  <Text
-                    style={[styles.cardTitle, { color: W.text }]}
-                    numberOfLines={2}
-                  >
-                    {titulo}
-                  </Text>
-                  {firstLine ? (
                     <Text
-                      style={[styles.preview, { color: W.textSec }]}
+                      style={[styles.cardTitle, { color: W.text }]}
                       numberOfLines={2}
                     >
-                      «{firstLine.replace(/^«|»$/g, '').trim()}»
+                      {titulo}
                     </Text>
-                  ) : null}
-                  <TouchableOpacity
-                    onPress={() =>
-                      router.push({
-                        pathname: '/(tabs)/contigo/evangelio',
-                        params: { date: b.date },
-                      } as never)
-                    }
-                    style={[
-                      styles.openBtn,
-                      {
-                        backgroundColor: isDark
-                          ? 'rgba(218,165,32,0.10)'
-                          : 'rgba(196,146,42,0.09)',
-                        borderColor: W.border,
-                      },
-                    ]}
-                  >
-                    <Text style={[styles.openText, { color: W.accent }]}>
-                      Leer evangelio →
-                    </Text>
-                  </TouchableOpacity>
+                    {firstLine ? (
+                      <Text
+                        style={[styles.preview, { color: W.textSec }]}
+                        numberOfLines={2}
+                      >
+                        «{firstLine.replace(/^«|»$/g, '').trim()}»
+                      </Text>
+                    ) : null}
+                    <TouchableOpacity
+                      onPress={() =>
+                        router.push({
+                          pathname: '/(tabs)/contigo/evangelio',
+                          params: { date: b.date },
+                        } as never)
+                      }
+                      style={[
+                        styles.openBtn,
+                        {
+                          backgroundColor: isDark
+                            ? 'rgba(218,165,32,0.10)'
+                            : 'rgba(196,146,42,0.09)',
+                          borderColor: W.border,
+                        },
+                      ]}
+                    >
+                      <Text style={[styles.openText, { color: W.accent }]}>
+                        Leer evangelio →
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
                 </View>
-              </View>
-            );
-          })}
+              );
+            })}
+          </View>
         </ScrollView>
       )}
     </View>

--- a/mcm-app/app/(tabs)/contigo/evangelio.tsx
+++ b/mcm-app/app/(tabs)/contigo/evangelio.tsx
@@ -10,6 +10,7 @@ import {
   Animated,
   Easing,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
 import {
   SafeAreaView,
@@ -35,6 +36,8 @@ import SettingsPanel from '@/components/SettingsPanel';
 import BottomSheet from '@/components/BottomSheet';
 import { radii, shadows } from '@/constants/uiStyles';
 import { hexAlpha } from '@/utils/colorUtils';
+
+import { CelebrationAnimation } from '@/components/contigo/CelebrationAnimation';
 
 // ── Contigo warm palette (aligned with redesign tokens) ──
 const WARM = {
@@ -95,8 +98,6 @@ function addDays(dateStr: string, offset: number): string {
   return `${ny}-${nm}-${nd}`;
 }
 
-import { CelebrationAnimation } from '@/components/contigo/CelebrationAnimation';
-
 export default function EvangelioScreen() {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
@@ -105,6 +106,17 @@ export default function EvangelioScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const fontScale = useFontScale();
+  const { width: windowWidth } = useWindowDimensions();
+  // iPad / large tablet / desktop web — cap content width.
+  const isWide = windowWidth >= 720;
+  const contentMaxWidth = windowWidth >= 1100 ? 880 : 720;
+  const wideWrapperStyle = isWide
+    ? {
+        width: '100%' as const,
+        maxWidth: contentMaxWidth,
+        alignSelf: 'center' as const,
+      }
+    : undefined;
 
   const { todayStr, getRecord, setReadingDone } = useContigoHabits();
   const params = useLocalSearchParams<{ date?: string }>();
@@ -297,559 +309,570 @@ export default function EvangelioScreen() {
         ]}
         showsVerticalScrollIndicator={false}
       >
-        {/* ── Date Navigator with liturgical color backdrop ── */}
-        <View
-          style={[
-            styles.dateNav,
-            {
-              backgroundColor: isDark
-                ? hexAlpha(liturgicalAccent, '10')
-                : hexAlpha(liturgicalAccent, '08'),
-              borderBottomColor: isDark
-                ? 'rgba(255,255,255,0.04)'
-                : 'rgba(0,0,0,0.04)',
-            },
-          ]}
-        >
-          <TouchableOpacity
-            onPress={() => changeDate(-1)}
+        <View style={wideWrapperStyle}>
+          {/* ── Date Navigator with liturgical color backdrop ── */}
+          <View
             style={[
-              styles.dateNavBtn,
+              styles.dateNav,
               {
                 backgroundColor: isDark
-                  ? 'rgba(255,255,255,0.08)'
-                  : 'rgba(0,0,0,0.05)',
+                  ? hexAlpha(liturgicalAccent, '10')
+                  : hexAlpha(liturgicalAccent, '08'),
+                borderBottomColor: isDark
+                  ? 'rgba(255,255,255,0.04)'
+                  : 'rgba(0,0,0,0.04)',
               },
             ]}
-            accessibilityLabel="Día anterior"
           >
-            <MaterialIcons name="chevron-left" size={26} color={theme.text} />
-          </TouchableOpacity>
-
-          <View style={styles.dateDisplay}>
-            <Text style={[styles.dateText, { color: theme.text }]}>
-              {formatDateDisplay(selectedDate)}
-            </Text>
-
-            {/* Liturgical badge */}
-            <View style={styles.badgeRow}>
-              <LiturgicalBadge dateStr={selectedDate} />
-            </View>
-
-            {/* Done / Pendiente chip */}
-            <View
-              style={[
-                styles.statusChip,
-                isDone
-                  ? {
-                      backgroundColor: isDark
-                        ? 'rgba(163,189,49,0.14)'
-                        : 'rgba(58,125,68,0.10)',
-                    }
-                  : {
-                      backgroundColor: isDark
-                        ? 'rgba(255,255,255,0.06)'
-                        : 'rgba(0,0,0,0.05)',
-                    },
-              ]}
-            >
-              {isDone ? (
-                <>
-                  <Text
-                    style={{
-                      fontSize: 10,
-                      color: isDark ? '#A3BD31' : '#3A7D44',
-                    }}
-                  >
-                    ✓
-                  </Text>
-                  <Text
-                    style={[
-                      styles.statusChipText,
-                      { color: isDark ? '#A3BD31' : '#3A7D44' },
-                    ]}
-                  >
-                    Leído
-                  </Text>
-                </>
-              ) : (
-                <Text style={[styles.statusChipText, { color: warm.warmGray }]}>
-                  Pendiente
-                </Text>
-              )}
-            </View>
-
-            {/* Liturgical day name / celebration */}
-            {readings?.info?.diaLiturgico ? (
-              <Text
-                style={[styles.diaLiturgico, { color: liturgicalAccent }]}
-                numberOfLines={2}
-              >
-                {readings.info.diaLiturgico}
-              </Text>
-            ) : null}
-
-            {/* Motivational title */}
-            {readings?.info?.titulo ? (
-              <Text
-                style={[
-                  styles.tituloLiturgico,
-                  { color: isDark ? warm.warmGray : '#8B7E6E' },
-                ]}
-                numberOfLines={2}
-              >
-                {readings.info.titulo}
-              </Text>
-            ) : null}
-          </View>
-
-          <TouchableOpacity
-            onPress={() => changeDate(1)}
-            style={[
-              styles.dateNavBtn,
-              {
-                backgroundColor: isDark
-                  ? 'rgba(255,255,255,0.08)'
-                  : 'rgba(0,0,0,0.05)',
-              },
-            ]}
-            accessibilityLabel="Día siguiente"
-          >
-            <MaterialIcons name="chevron-right" size={26} color={theme.text} />
-          </TouchableOpacity>
-        </View>
-
-        {/* ── Content ── */}
-        {isLoading ? (
-          <View style={styles.stateContainer}>
-            <ActivityIndicator size="large" color={warm.accent} />
-            <Text style={[styles.stateText, { color: warm.warmGray }]}>
-              Preparando la Palabra...
-            </Text>
-          </View>
-        ) : error || !readings?.evangelio ? (
-          <View style={styles.stateContainer}>
-            <MaterialIcons name="cloud-off" size={48} color={warm.warmGray} />
-            <Text style={[styles.stateText, { color: warm.warmGray }]}>
-              No se encontraron lecturas para este día.
-            </Text>
             <TouchableOpacity
-              onPress={() => setSelectedDate(todayStr)}
+              onPress={() => changeDate(-1)}
               style={[
-                styles.todayBtn,
-                { backgroundColor: hexAlpha(warm.accent, '15') },
-              ]}
-            >
-              <Text style={[styles.todayBtnText, { color: warm.accent }]}>
-                Volver a hoy
-              </Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          <View style={styles.mainContent}>
-            {/* ── Evangelio Card ── */}
-            <Card
-              style={[
-                styles.evangelioCard,
+                styles.dateNavBtn,
                 {
-                  backgroundColor: theme.card,
-                  borderColor: isDark
-                    ? 'rgba(255,255,255,0.06)'
-                    : 'rgba(0,0,0,0.04)',
+                  backgroundColor: isDark
+                    ? 'rgba(255,255,255,0.08)'
+                    : 'rgba(0,0,0,0.05)',
                 },
               ]}
+              accessibilityLabel="Día anterior"
             >
-              {/* HeroUI Tabs — Lectura / Comentario */}
-              {readings.evangelio.comentario ? (
-                <View>
-                  <View
-                    style={[
-                      styles.segmentedContainer,
-                      {
+              <MaterialIcons name="chevron-left" size={26} color={theme.text} />
+            </TouchableOpacity>
+
+            <View style={styles.dateDisplay}>
+              <Text style={[styles.dateText, { color: theme.text }]}>
+                {formatDateDisplay(selectedDate)}
+              </Text>
+
+              {/* Liturgical badge */}
+              <View style={styles.badgeRow}>
+                <LiturgicalBadge dateStr={selectedDate} />
+              </View>
+
+              {/* Done / Pendiente chip */}
+              <View
+                style={[
+                  styles.statusChip,
+                  isDone
+                    ? {
+                        backgroundColor: isDark
+                          ? 'rgba(163,189,49,0.14)'
+                          : 'rgba(58,125,68,0.10)',
+                      }
+                    : {
                         backgroundColor: isDark
                           ? 'rgba(255,255,255,0.06)'
-                          : 'rgba(0,0,0,0.04)',
+                          : 'rgba(0,0,0,0.05)',
                       },
-                    ]}
-                  >
-                    <TouchableOpacity
-                      activeOpacity={0.8}
-                      onPress={() => setViewMode('lectura')}
-                      style={[
-                        styles.segmentButton,
-                        viewMode === 'lectura' && [
-                          styles.segmentActive,
-                          {
-                            backgroundColor: isDark ? '#2A2A2A' : '#FFFFFF',
-                            borderColor: isDark
-                              ? 'rgba(255,255,255,0.1)'
-                              : 'rgba(0,0,0,0.04)',
-                          },
-                        ],
-                      ]}
-                    >
-                      <MaterialIcons
-                        name="menu-book"
-                        size={16}
-                        color={
-                          viewMode === 'lectura'
-                            ? isDark
-                              ? '#DAA520'
-                              : '#B8860B'
-                            : isDark
-                              ? '#A09A94'
-                              : '#888888'
-                        }
-                      />
-                      <Text
-                        style={[
-                          styles.segmentText,
-                          {
-                            color:
-                              viewMode === 'lectura'
-                                ? isDark
-                                  ? '#DAA520'
-                                  : '#B8860B'
-                                : isDark
-                                  ? '#A09A94'
-                                  : '#888888',
-                            fontWeight: viewMode === 'lectura' ? '700' : '500',
-                          },
-                        ]}
-                      >
-                        Lectura
-                      </Text>
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      activeOpacity={0.8}
-                      onPress={() => setViewMode('comentario')}
-                      style={[
-                        styles.segmentButton,
-                        viewMode === 'comentario' && [
-                          styles.segmentActive,
-                          {
-                            backgroundColor: isDark ? '#2A2A2A' : '#FFFFFF',
-                            borderColor: isDark
-                              ? 'rgba(255,255,255,0.1)'
-                              : 'rgba(0,0,0,0.04)',
-                          },
-                        ],
-                      ]}
-                    >
-                      <MaterialIcons
-                        name="lightbulb-outline"
-                        size={16}
-                        color={
-                          viewMode === 'comentario'
-                            ? isDark
-                              ? '#DAA520'
-                              : '#B8860B'
-                            : isDark
-                              ? '#A09A94'
-                              : '#888888'
-                        }
-                      />
-                      <Text
-                        style={[
-                          styles.segmentText,
-                          {
-                            color:
-                              viewMode === 'comentario'
-                                ? isDark
-                                  ? '#DAA520'
-                                  : '#B8860B'
-                                : isDark
-                                  ? '#A09A94'
-                                  : '#888888',
-                            fontWeight:
-                              viewMode === 'comentario' ? '700' : '500',
-                          },
-                        ]}
-                      >
-                        Comentario
-                      </Text>
-                    </TouchableOpacity>
-                  </View>
-
-                  <View style={styles.cardContent}>
-                    {viewMode === 'lectura' ? (
-                      <>
-                        <View
-                          style={[
-                            styles.citaBadge,
-                            { backgroundColor: hexAlpha(warm.accent, '12') },
-                          ]}
-                        >
-                          <Text
-                            style={{
-                              fontSize: 13,
-                              color: warm.accent,
-                              marginRight: 6,
-                              lineHeight: 16,
-                            }}
-                          >
-                            ✦
-                          </Text>
-                          <Text
-                            style={[styles.citaText, { color: warm.accent }]}
-                          >
-                            {readings.evangelio.cita}
-                          </Text>
-                        </View>
-                        <Text
-                          style={[
-                            styles.bodyText,
-                            {
-                              color: theme.text,
-                              fontSize: 18 * fontScale,
-                              lineHeight: 28 * fontScale,
-                              fontFamily:
-                                Platform.OS === 'ios' ? 'Palatino' : 'serif',
-                            },
-                          ]}
-                          selectable
-                        >
-                          {readings.evangelio.texto}
-                        </Text>
-                      </>
-                    ) : (
-                      <>
-                        <Text
-                          style={[
-                            styles.bodyText,
-                            {
-                              color: theme.text,
-                              fontSize: 18 * fontScale,
-                              lineHeight: 28 * fontScale,
-                            },
-                          ]}
-                          selectable
-                        >
-                          {readings.evangelio.comentario}
-                        </Text>
-
-                        {readings.evangelio.comentarista ? (
-                          <Text
-                            style={[
-                              styles.authorText,
-                              { color: warm.warmGray },
-                            ]}
-                          >
-                            — {readings.evangelio.comentarista}
-                          </Text>
-                        ) : null}
-
-                        {readings.evangelio.url ? (
-                          <TouchableOpacity
-                            onPress={openSource}
-                            style={[
-                              styles.sourceLink,
-                              {
-                                borderTopColor: isDark
-                                  ? 'rgba(255,255,255,0.06)'
-                                  : 'rgba(0,0,0,0.04)',
-                              },
-                            ]}
-                          >
-                            <Text
-                              style={[
-                                styles.sourceText,
-                                { color: warm.accent },
-                              ]}
-                            >
-                              Leer original completo
-                            </Text>
-                            <MaterialIcons
-                              name="open-in-new"
-                              size={14}
-                              color={warm.accent}
-                            />
-                          </TouchableOpacity>
-                        ) : null}
-                      </>
-                    )}
-                  </View>
-                </View>
-              ) : (
-                <View style={styles.cardContent}>
-                  <View
-                    style={[
-                      styles.citaBadge,
-                      { backgroundColor: hexAlpha(warm.accent, '12') },
-                    ]}
-                  >
-                    <Text
-                      style={{
-                        fontSize: 13,
-                        color: warm.accent,
-                        marginRight: 6,
-                        lineHeight: 16,
-                      }}
-                    >
-                      ✦
-                    </Text>
-                    <Text style={[styles.citaText, { color: warm.accent }]}>
-                      {readings.evangelio.cita}
-                    </Text>
-                  </View>
-                  <Text
-                    style={[
-                      styles.bodyText,
-                      {
-                        color: theme.text,
-                        fontSize: 18 * fontScale,
-                        lineHeight: 28 * fontScale,
-                        fontFamily:
-                          Platform.OS === 'ios' ? 'Palatino' : 'serif',
-                      },
-                    ]}
-                    selectable
-                  >
-                    {readings.evangelio.texto}
-                  </Text>
-                </View>
-              )}
-            </Card>
-
-            {/* ── Tracker button ── */}
-            <View style={styles.trackerContainer}>
-              <TouchableOpacity
-                activeOpacity={0.85}
-                onPress={handleToggleDone}
-                style={[
-                  styles.trackerBtnWrap,
-                  !isDone && {
-                    shadowColor: '#1D4ED8',
-                    shadowOffset: { width: 0, height: 6 },
-                    shadowOpacity: isDark ? 0.45 : 0.35,
-                    shadowRadius: 16,
-                    elevation: 6,
-                  },
                 ]}
               >
                 {isDone ? (
-                  <View
-                    style={[
-                      styles.trackerGradient,
-                      {
-                        backgroundColor: isDark
-                          ? 'rgba(163,189,49,0.12)'
-                          : 'rgba(58,125,68,0.08)',
-                        borderColor: isDark
-                          ? 'rgba(163,189,49,0.28)'
-                          : 'rgba(58,125,68,0.22)',
-                        borderWidth: 1.5,
-                      },
-                    ]}
+                  <>
+                    <Text
+                      style={{
+                        fontSize: 10,
+                        color: isDark ? '#A3BD31' : '#3A7D44',
+                      }}
+                    >
+                      ✓
+                    </Text>
+                    <Text
+                      style={[
+                        styles.statusChipText,
+                        { color: isDark ? '#A3BD31' : '#3A7D44' },
+                      ]}
+                    >
+                      Leído
+                    </Text>
+                  </>
+                ) : (
+                  <Text
+                    style={[styles.statusChipText, { color: warm.warmGray }]}
                   >
-                    <View style={styles.trackerContent}>
-                      <MaterialIcons
-                        name="check-circle"
-                        size={22}
-                        color={isDark ? '#A3BD31' : '#3A7D44'}
-                      />
-                      <Text
+                    Pendiente
+                  </Text>
+                )}
+              </View>
+
+              {/* Liturgical day name / celebration */}
+              {readings?.info?.diaLiturgico ? (
+                <Text
+                  style={[styles.diaLiturgico, { color: liturgicalAccent }]}
+                  numberOfLines={2}
+                >
+                  {readings.info.diaLiturgico}
+                </Text>
+              ) : null}
+
+              {/* Motivational title */}
+              {readings?.info?.titulo ? (
+                <Text
+                  style={[
+                    styles.tituloLiturgico,
+                    { color: isDark ? warm.warmGray : '#8B7E6E' },
+                  ]}
+                  numberOfLines={2}
+                >
+                  {readings.info.titulo}
+                </Text>
+              ) : null}
+            </View>
+
+            <TouchableOpacity
+              onPress={() => changeDate(1)}
+              style={[
+                styles.dateNavBtn,
+                {
+                  backgroundColor: isDark
+                    ? 'rgba(255,255,255,0.08)'
+                    : 'rgba(0,0,0,0.05)',
+                },
+              ]}
+              accessibilityLabel="Día siguiente"
+            >
+              <MaterialIcons
+                name="chevron-right"
+                size={26}
+                color={theme.text}
+              />
+            </TouchableOpacity>
+          </View>
+
+          {/* ── Content ── */}
+          {isLoading ? (
+            <View style={styles.stateContainer}>
+              <ActivityIndicator size="large" color={warm.accent} />
+              <Text style={[styles.stateText, { color: warm.warmGray }]}>
+                Preparando la Palabra...
+              </Text>
+            </View>
+          ) : error || !readings?.evangelio ? (
+            <View style={styles.stateContainer}>
+              <MaterialIcons name="cloud-off" size={48} color={warm.warmGray} />
+              <Text style={[styles.stateText, { color: warm.warmGray }]}>
+                No se encontraron lecturas para este día.
+              </Text>
+              <TouchableOpacity
+                onPress={() => setSelectedDate(todayStr)}
+                style={[
+                  styles.todayBtn,
+                  { backgroundColor: hexAlpha(warm.accent, '15') },
+                ]}
+              >
+                <Text style={[styles.todayBtnText, { color: warm.accent }]}>
+                  Volver a hoy
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <View style={styles.mainContent}>
+              {/* ── Evangelio Card ── */}
+              <Card
+                style={[
+                  styles.evangelioCard,
+                  {
+                    backgroundColor: theme.card,
+                    borderColor: isDark
+                      ? 'rgba(255,255,255,0.06)'
+                      : 'rgba(0,0,0,0.04)',
+                  },
+                ]}
+              >
+                {/* HeroUI Tabs — Lectura / Comentario */}
+                {readings.evangelio.comentario ? (
+                  <View>
+                    <View
+                      style={[
+                        styles.segmentedContainer,
+                        {
+                          backgroundColor: isDark
+                            ? 'rgba(255,255,255,0.06)'
+                            : 'rgba(0,0,0,0.04)',
+                        },
+                      ]}
+                    >
+                      <TouchableOpacity
+                        activeOpacity={0.8}
+                        onPress={() => setViewMode('lectura')}
                         style={[
-                          styles.trackerText,
-                          { color: isDark ? '#A3BD31' : '#3A7D44' },
+                          styles.segmentButton,
+                          viewMode === 'lectura' && [
+                            styles.segmentActive,
+                            {
+                              backgroundColor: isDark ? '#2A2A2A' : '#FFFFFF',
+                              borderColor: isDark
+                                ? 'rgba(255,255,255,0.1)'
+                                : 'rgba(0,0,0,0.04)',
+                            },
+                          ],
                         ]}
                       >
-                        ¡He rezado hoy con el Evangelio!
-                      </Text>
+                        <MaterialIcons
+                          name="menu-book"
+                          size={16}
+                          color={
+                            viewMode === 'lectura'
+                              ? isDark
+                                ? '#DAA520'
+                                : '#B8860B'
+                              : isDark
+                                ? '#A09A94'
+                                : '#888888'
+                          }
+                        />
+                        <Text
+                          style={[
+                            styles.segmentText,
+                            {
+                              color:
+                                viewMode === 'lectura'
+                                  ? isDark
+                                    ? '#DAA520'
+                                    : '#B8860B'
+                                  : isDark
+                                    ? '#A09A94'
+                                    : '#888888',
+                              fontWeight:
+                                viewMode === 'lectura' ? '700' : '500',
+                            },
+                          ]}
+                        >
+                          Lectura
+                        </Text>
+                      </TouchableOpacity>
+
+                      <TouchableOpacity
+                        activeOpacity={0.8}
+                        onPress={() => setViewMode('comentario')}
+                        style={[
+                          styles.segmentButton,
+                          viewMode === 'comentario' && [
+                            styles.segmentActive,
+                            {
+                              backgroundColor: isDark ? '#2A2A2A' : '#FFFFFF',
+                              borderColor: isDark
+                                ? 'rgba(255,255,255,0.1)'
+                                : 'rgba(0,0,0,0.04)',
+                            },
+                          ],
+                        ]}
+                      >
+                        <MaterialIcons
+                          name="lightbulb-outline"
+                          size={16}
+                          color={
+                            viewMode === 'comentario'
+                              ? isDark
+                                ? '#DAA520'
+                                : '#B8860B'
+                              : isDark
+                                ? '#A09A94'
+                                : '#888888'
+                          }
+                        />
+                        <Text
+                          style={[
+                            styles.segmentText,
+                            {
+                              color:
+                                viewMode === 'comentario'
+                                  ? isDark
+                                    ? '#DAA520'
+                                    : '#B8860B'
+                                  : isDark
+                                    ? '#A09A94'
+                                    : '#888888',
+                              fontWeight:
+                                viewMode === 'comentario' ? '700' : '500',
+                            },
+                          ]}
+                        >
+                          Comentario
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+
+                    <View style={styles.cardContent}>
+                      {viewMode === 'lectura' ? (
+                        <>
+                          <View
+                            style={[
+                              styles.citaBadge,
+                              { backgroundColor: hexAlpha(warm.accent, '12') },
+                            ]}
+                          >
+                            <Text
+                              style={{
+                                fontSize: 13,
+                                color: warm.accent,
+                                marginRight: 6,
+                                lineHeight: 16,
+                              }}
+                            >
+                              ✦
+                            </Text>
+                            <Text
+                              style={[styles.citaText, { color: warm.accent }]}
+                            >
+                              {readings.evangelio.cita}
+                            </Text>
+                          </View>
+                          <Text
+                            style={[
+                              styles.bodyText,
+                              {
+                                color: theme.text,
+                                fontSize: 18 * fontScale,
+                                lineHeight: 28 * fontScale,
+                                fontFamily:
+                                  Platform.OS === 'ios' ? 'Palatino' : 'serif',
+                              },
+                            ]}
+                            selectable
+                          >
+                            {readings.evangelio.texto}
+                          </Text>
+                        </>
+                      ) : (
+                        <>
+                          <Text
+                            style={[
+                              styles.bodyText,
+                              {
+                                color: theme.text,
+                                fontSize: 18 * fontScale,
+                                lineHeight: 28 * fontScale,
+                              },
+                            ]}
+                            selectable
+                          >
+                            {readings.evangelio.comentario}
+                          </Text>
+
+                          {readings.evangelio.comentarista ? (
+                            <Text
+                              style={[
+                                styles.authorText,
+                                { color: warm.warmGray },
+                              ]}
+                            >
+                              — {readings.evangelio.comentarista}
+                            </Text>
+                          ) : null}
+
+                          {readings.evangelio.url ? (
+                            <TouchableOpacity
+                              onPress={openSource}
+                              style={[
+                                styles.sourceLink,
+                                {
+                                  borderTopColor: isDark
+                                    ? 'rgba(255,255,255,0.06)'
+                                    : 'rgba(0,0,0,0.04)',
+                                },
+                              ]}
+                            >
+                              <Text
+                                style={[
+                                  styles.sourceText,
+                                  { color: warm.accent },
+                                ]}
+                              >
+                                Leer original completo
+                              </Text>
+                              <MaterialIcons
+                                name="open-in-new"
+                                size={14}
+                                color={warm.accent}
+                              />
+                            </TouchableOpacity>
+                          ) : null}
+                        </>
+                      )}
                     </View>
                   </View>
                 ) : (
-                  <LinearGradient
-                    colors={['#3B82F6', '#1D4ED8']}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 1, y: 1 }}
-                    style={styles.trackerGradient}
-                  >
-                    <View style={styles.trackerContent}>
-                      <MaterialIcons
-                        name="auto-stories"
-                        size={22}
-                        color="#FFFFFF"
-                      />
-                      <Text style={[styles.trackerText, { color: '#FFFFFF' }]}>
-                        Marcar como leído
+                  <View style={styles.cardContent}>
+                    <View
+                      style={[
+                        styles.citaBadge,
+                        { backgroundColor: hexAlpha(warm.accent, '12') },
+                      ]}
+                    >
+                      <Text
+                        style={{
+                          fontSize: 13,
+                          color: warm.accent,
+                          marginRight: 6,
+                          lineHeight: 16,
+                        }}
+                      >
+                        ✦
+                      </Text>
+                      <Text style={[styles.citaText, { color: warm.accent }]}>
+                        {readings.evangelio.cita}
                       </Text>
                     </View>
-                  </LinearGradient>
+                    <Text
+                      style={[
+                        styles.bodyText,
+                        {
+                          color: theme.text,
+                          fontSize: 18 * fontScale,
+                          lineHeight: 28 * fontScale,
+                          fontFamily:
+                            Platform.OS === 'ios' ? 'Palatino' : 'serif',
+                        },
+                      ]}
+                      selectable
+                    >
+                      {readings.evangelio.texto}
+                    </Text>
+                  </View>
                 )}
-              </TouchableOpacity>
-              <Text style={[styles.trackerNote, { color: warm.warmGray }]}>
-                Marcando este día sumas a tu constancia en «Contigo».
-              </Text>
-            </View>
+              </Card>
 
-            {/* ── Other Readings ── */}
-            {(readings.lectura1 || readings.salmo || readings.lectura2) && (
-              <View style={styles.otherReadings}>
-                <View
+              {/* ── Tracker button ── */}
+              <View style={styles.trackerContainer}>
+                <TouchableOpacity
+                  activeOpacity={0.85}
+                  onPress={handleToggleDone}
                   style={[
-                    styles.divider,
-                    {
-                      backgroundColor: isDark
-                        ? 'rgba(255,255,255,0.06)'
-                        : 'rgba(0,0,0,0.05)',
+                    styles.trackerBtnWrap,
+                    !isDone && {
+                      shadowColor: '#1D4ED8',
+                      shadowOffset: { width: 0, height: 6 },
+                      shadowOpacity: isDark ? 0.45 : 0.35,
+                      shadowRadius: 16,
+                      elevation: 6,
                     },
                   ]}
-                />
-                <Text
-                  style={[styles.otherReadingsTitle, { color: theme.text }]}
                 >
-                  Otras lecturas de la misa
+                  {isDone ? (
+                    <View
+                      style={[
+                        styles.trackerGradient,
+                        {
+                          backgroundColor: isDark
+                            ? 'rgba(163,189,49,0.12)'
+                            : 'rgba(58,125,68,0.08)',
+                          borderColor: isDark
+                            ? 'rgba(163,189,49,0.28)'
+                            : 'rgba(58,125,68,0.22)',
+                          borderWidth: 1.5,
+                        },
+                      ]}
+                    >
+                      <View style={styles.trackerContent}>
+                        <MaterialIcons
+                          name="check-circle"
+                          size={22}
+                          color={isDark ? '#A3BD31' : '#3A7D44'}
+                        />
+                        <Text
+                          style={[
+                            styles.trackerText,
+                            { color: isDark ? '#A3BD31' : '#3A7D44' },
+                          ]}
+                        >
+                          ¡He rezado hoy con el Evangelio!
+                        </Text>
+                      </View>
+                    </View>
+                  ) : (
+                    <LinearGradient
+                      colors={['#3B82F6', '#1D4ED8']}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 1 }}
+                      style={styles.trackerGradient}
+                    >
+                      <View style={styles.trackerContent}>
+                        <MaterialIcons
+                          name="auto-stories"
+                          size={22}
+                          color="#FFFFFF"
+                        />
+                        <Text
+                          style={[styles.trackerText, { color: '#FFFFFF' }]}
+                        >
+                          Marcar como leído
+                        </Text>
+                      </View>
+                    </LinearGradient>
+                  )}
+                </TouchableOpacity>
+                <Text style={[styles.trackerNote, { color: warm.warmGray }]}>
+                  Marcando este día sumas a tu constancia en «Contigo».
                 </Text>
-
-                {readings.lectura1 && (
-                  <ReadingCard
-                    title="Primera Lectura"
-                    cita={readings.lectura1.cita}
-                    texto={readings.lectura1.texto}
-                  />
-                )}
-
-                {readings.salmo && (
-                  <ReadingCard
-                    title="Salmo"
-                    cita={readings.salmo.cita}
-                    texto={readings.salmo.texto}
-                  />
-                )}
-
-                {readings.lectura2 && (
-                  <ReadingCard
-                    title="Segunda Lectura"
-                    cita={readings.lectura2.cita}
-                    texto={readings.lectura2.texto}
-                  />
-                )}
               </View>
-            )}
 
-            <TouchableOpacity
-              onPress={() => setCreditsVisible(true)}
-              style={{
-                alignItems: 'center',
-                paddingVertical: 24,
-                marginTop: 10,
-                paddingBottom: 40,
-              }}
-            >
-              <Text
+              {/* ── Other Readings ── */}
+              {(readings.lectura1 || readings.salmo || readings.lectura2) && (
+                <View style={styles.otherReadings}>
+                  <View
+                    style={[
+                      styles.divider,
+                      {
+                        backgroundColor: isDark
+                          ? 'rgba(255,255,255,0.06)'
+                          : 'rgba(0,0,0,0.05)',
+                      },
+                    ]}
+                  />
+                  <Text
+                    style={[styles.otherReadingsTitle, { color: theme.text }]}
+                  >
+                    Otras lecturas de la misa
+                  </Text>
+
+                  {readings.lectura1 && (
+                    <ReadingCard
+                      title="Primera Lectura"
+                      cita={readings.lectura1.cita}
+                      texto={readings.lectura1.texto}
+                    />
+                  )}
+
+                  {readings.salmo && (
+                    <ReadingCard
+                      title="Salmo"
+                      cita={readings.salmo.cita}
+                      texto={readings.salmo.texto}
+                    />
+                  )}
+
+                  {readings.lectura2 && (
+                    <ReadingCard
+                      title="Segunda Lectura"
+                      cita={readings.lectura2.cita}
+                      texto={readings.lectura2.texto}
+                    />
+                  )}
+                </View>
+              )}
+
+              <TouchableOpacity
+                onPress={() => setCreditsVisible(true)}
                 style={{
-                  fontSize: 13,
-                  color: warm.warmGray,
-                  textDecorationLine: 'underline',
+                  alignItems: 'center',
+                  paddingVertical: 24,
+                  marginTop: 10,
+                  paddingBottom: 40,
                 }}
               >
-                ¿De dónde sacamos los textos?
-              </Text>
-            </TouchableOpacity>
-          </View>
-        )}
+                <Text
+                  style={{
+                    fontSize: 13,
+                    color: warm.warmGray,
+                    textDecorationLine: 'underline',
+                  }}
+                >
+                  ¿De dónde sacamos los textos?
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
       </ScrollView>
 
       {/* Celebration burst animation */}

--- a/mcm-app/app/(tabs)/contigo/index.tsx
+++ b/mcm-app/app/(tabs)/contigo/index.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
+  useWindowDimensions,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -30,6 +31,11 @@ export default function ContigoScreen() {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const W = warm(isDark);
+  const { width: windowWidth } = useWindowDimensions();
+  // iPad / large tablet / desktop web — cap content width so the layout
+  // doesn't stretch into a sparse, unbalanced canvas.
+  const isWide = windowWidth >= 720;
+  const contentMaxWidth = windowWidth >= 1100 ? 880 : 720;
 
   const {
     todayStr,
@@ -113,165 +119,185 @@ export default function ContigoScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* ── Header ─────────────────────────────────── */}
-        <View style={styles.headerRow}>
-          <View style={{ flex: 1 }}>
-            <Text
-              style={[styles.title, { color: isDark ? '#F5EFE3' : '#2A1E0E' }]}
-            >
-              Contigo
-            </Text>
-            <Text style={[styles.subtitle, { color: W.textSec }]}>
-              {formatDateLong(todayStr)}
-            </Text>
-          </View>
-          <View style={styles.headerRight}>
-            <View style={styles.headerBadgeWrap}>
-              <LiturgicalBadge dateStr={todayStr} />
+        <View
+          style={
+            isWide
+              ? {
+                  width: '100%',
+                  maxWidth: contentMaxWidth,
+                  alignSelf: 'center',
+                }
+              : undefined
+          }
+        >
+          {/* ── Header ─────────────────────────────────── */}
+          <View style={styles.headerRow}>
+            <View style={{ flex: 1 }}>
+              <Text
+                style={[
+                  styles.title,
+                  { color: isDark ? '#F5EFE3' : '#2A1E0E' },
+                ]}
+              >
+                Contigo
+              </Text>
+              <Text style={[styles.subtitle, { color: W.textSec }]}>
+                {formatDateLong(todayStr)}
+              </Text>
             </View>
-            <TouchableOpacity
-              onPress={() => router.push('/(tabs)/contigo/bookmarks')}
-              style={[
-                styles.headerBtn,
-                {
-                  backgroundColor: isDark
-                    ? 'rgba(255,255,255,0.07)'
-                    : 'rgba(0,0,0,0.05)',
-                  borderColor: W.border,
-                },
-              ]}
-              accessibilityLabel="Ver evangelios guardados"
-            >
-              <MaterialIcons name="bookmarks" size={18} color={W.accent} />
-            </TouchableOpacity>
+            <View style={styles.headerRight}>
+              <View style={styles.headerBadgeWrap}>
+                <LiturgicalBadge dateStr={todayStr} />
+              </View>
+              <TouchableOpacity
+                onPress={() => router.push('/(tabs)/contigo/bookmarks')}
+                style={[
+                  styles.headerBtn,
+                  {
+                    backgroundColor: isDark
+                      ? 'rgba(255,255,255,0.07)'
+                      : 'rgba(0,0,0,0.05)',
+                    borderColor: W.border,
+                  },
+                ]}
+                accessibilityLabel="Ver evangelios guardados"
+              >
+                <MaterialIcons name="bookmarks" size={18} color={W.accent} />
+              </TouchableOpacity>
+            </View>
           </View>
-        </View>
 
-        {/* ── Hero card ──────────────────────────────── */}
-        <View style={styles.section}>
-          <HeroCard
-            doneCount={doneCount}
-            prayStreak={prayStreak}
-            totalMins={totalMins}
-            isDark={isDark}
-          />
-        </View>
-
-        {/* ── Three habit tiles ──────────────────────── */}
-        <View style={[styles.section, styles.tilesRow]}>
-          <HabitTile
-            habitKey="evangelio"
-            done={readingDone}
-            onPress={() => router.push('/(tabs)/contigo/evangelio')}
-            isDark={isDark}
-          />
-          <HabitTile
-            habitKey="oracion"
-            done={prayerDone}
-            onPress={() => router.push('/(tabs)/contigo/oracion')}
-            isDark={isDark}
-          />
-          <HabitTile
-            habitKey="revision"
-            done={revisionDone}
-            onPress={() => router.push('/(tabs)/contigo/revision' as never)}
-            isDark={isDark}
-          />
-        </View>
-
-        {/* ── Evangelio teaser ───────────────────────── */}
-        <View style={styles.section}>
-          <EvangelioTeaserCard
-            titulo={readings?.info?.titulo}
-            cita={readings?.evangelio?.cita}
-            texto={readings?.evangelio?.texto}
-            readingDone={readingDone}
-            onOpen={() => router.push('/(tabs)/contigo/evangelio')}
-            isDark={isDark}
-          />
-        </View>
-
-        {/* ── Esta semana ────────────────────────────── */}
-        <View style={[styles.section, { paddingTop: 18 }]}>
-          <Text style={[styles.smallLabel, { color: W.textMuted }]}>
-            ESTA SEMANA
-          </Text>
-          <View
-            style={[
-              styles.cardSurface,
-              {
-                backgroundColor: W.bgCard,
-                borderColor: W.border,
-                shadowColor: W.shadow,
-              },
-            ]}
-          >
-            <WeekStrip records={records} todayStr={todayStr} isDark={isDark} />
+          {/* ── Hero card ──────────────────────────────── */}
+          <View style={styles.section}>
+            <HeroCard
+              doneCount={doneCount}
+              prayStreak={prayStreak}
+              totalMins={totalMins}
+              isDark={isDark}
+            />
           </View>
-        </View>
 
-        {/* ── Stats ──────────────────────────────────── */}
-        <View style={[styles.section, styles.statsRow]}>
-          <StatCard
-            icon="🔥"
-            value={prayStreak}
-            label={'racha de\noración'}
-            color={W.fire}
-            isDark={isDark}
-          />
-          <StatCard
-            icon="⏱"
-            value={`${totalMins}'`}
-            label={'min\nesta sem.'}
-            color={W.accent}
-            isDark={isDark}
-          />
-          <StatCard
-            icon="📖"
-            value={totalReads}
-            label={'lecturas\neste mes'}
-            color={W.blue}
-            isDark={isDark}
-          />
-        </View>
+          {/* ── Three habit tiles ──────────────────────── */}
+          <View style={[styles.section, styles.tilesRow]}>
+            <HabitTile
+              habitKey="evangelio"
+              done={readingDone}
+              onPress={() => router.push('/(tabs)/contigo/evangelio')}
+              isDark={isDark}
+            />
+            <HabitTile
+              habitKey="oracion"
+              done={prayerDone}
+              onPress={() => router.push('/(tabs)/contigo/oracion')}
+              isDark={isDark}
+            />
+            <HabitTile
+              habitKey="revision"
+              done={revisionDone}
+              onPress={() => router.push('/(tabs)/contigo/revision' as never)}
+              isDark={isDark}
+            />
+          </View>
 
-        {/* ── Calendario completo ────────────────────── */}
-        <View style={[styles.section, { paddingTop: 18 }]}>
-          <View style={styles.monthHdr}>
+          {/* ── Evangelio teaser ───────────────────────── */}
+          <View style={styles.section}>
+            <EvangelioTeaserCard
+              titulo={readings?.info?.titulo}
+              cita={readings?.evangelio?.cita}
+              texto={readings?.evangelio?.texto}
+              readingDone={readingDone}
+              onOpen={() => router.push('/(tabs)/contigo/evangelio')}
+              isDark={isDark}
+            />
+          </View>
+
+          {/* ── Esta semana ────────────────────────────── */}
+          <View style={[styles.section, { paddingTop: 18 }]}>
             <Text style={[styles.smallLabel, { color: W.textMuted }]}>
-              {monthLabel.toUpperCase()}
+              ESTA SEMANA
             </Text>
             <View
               style={[
-                styles.monthBadge,
+                styles.cardSurface,
                 {
-                  backgroundColor: isDark
-                    ? 'rgba(218,165,32,0.12)'
-                    : 'rgba(196,146,42,0.10)',
+                  backgroundColor: W.bgCard,
+                  borderColor: W.border,
+                  shadowColor: W.shadow,
                 },
               ]}
             >
-              <Text style={[styles.monthBadgeText, { color: W.accent }]}>
-                {activeDays} {activeDays === 1 ? 'día activo' : 'días activos'}
-              </Text>
+              <WeekStrip
+                records={records}
+                todayStr={todayStr}
+                isDark={isDark}
+              />
             </View>
           </View>
-          <View
-            style={[
-              styles.cardSurface,
-              {
-                backgroundColor: W.bgCard,
-                borderColor: W.border,
-                shadowColor: W.shadow,
-              },
-            ]}
-          >
-            <MonthHeatmap
-              records={records}
-              todayStr={todayStr}
+
+          {/* ── Stats ──────────────────────────────────── */}
+          <View style={[styles.section, styles.statsRow]}>
+            <StatCard
+              icon="🔥"
+              value={prayStreak}
+              label={'racha de\noración'}
+              color={W.fire}
               isDark={isDark}
-              onDayPress={handleDayPress}
             />
+            <StatCard
+              icon="⏱"
+              value={`${totalMins}'`}
+              label={'min\nesta sem.'}
+              color={W.accent}
+              isDark={isDark}
+            />
+            <StatCard
+              icon="📖"
+              value={totalReads}
+              label={'lecturas\neste mes'}
+              color={W.blue}
+              isDark={isDark}
+            />
+          </View>
+
+          {/* ── Calendario completo ────────────────────── */}
+          <View style={[styles.section, { paddingTop: 18 }]}>
+            <View style={styles.monthHdr}>
+              <Text style={[styles.smallLabel, { color: W.textMuted }]}>
+                {monthLabel.toUpperCase()}
+              </Text>
+              <View
+                style={[
+                  styles.monthBadge,
+                  {
+                    backgroundColor: isDark
+                      ? 'rgba(218,165,32,0.12)'
+                      : 'rgba(196,146,42,0.10)',
+                  },
+                ]}
+              >
+                <Text style={[styles.monthBadgeText, { color: W.accent }]}>
+                  {activeDays}{' '}
+                  {activeDays === 1 ? 'día activo' : 'días activos'}
+                </Text>
+              </View>
+            </View>
+            <View
+              style={[
+                styles.cardSurface,
+                {
+                  backgroundColor: W.bgCard,
+                  borderColor: W.border,
+                  shadowColor: W.shadow,
+                },
+              ]}
+            >
+              <MonthHeatmap
+                records={records}
+                todayStr={todayStr}
+                isDark={isDark}
+                onDayPress={handleDayPress}
+              />
+            </View>
           </View>
         </View>
       </ScrollView>

--- a/mcm-app/app/(tabs)/contigo/revision.tsx
+++ b/mcm-app/app/(tabs)/contigo/revision.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   Platform,
   KeyboardAvoidingView,
+  useWindowDimensions,
 } from 'react-native';
 import { Stack, useRouter, useLocalSearchParams } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -38,6 +39,16 @@ export default function RevisionScreen() {
   const isDark = scheme === 'dark';
   const W = warm(isDark);
   const purple = isDark ? WARM_DARK.purple : WARM_LIGHT.purple;
+  const { width: windowWidth } = useWindowDimensions();
+  // iPad / large tablet / desktop web — cap content width.
+  const isWide = windowWidth >= 720;
+  const wideWrapperStyle = isWide
+    ? {
+        width: '100%' as const,
+        maxWidth: windowWidth >= 1100 ? 760 : 640,
+        alignSelf: 'center' as const,
+      }
+    : undefined;
 
   const params = useLocalSearchParams<{ date?: string }>();
   const { todayStr, setRevisionDone } = useContigoHabits();
@@ -298,19 +309,25 @@ export default function RevisionScreen() {
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
-          {step === 0 ? (
-            <GratefulStep
-              isDark={isDark}
-              mode={mode}
-              setMode={setMode}
-              items={items}
-              setItems={setItems}
-              singleGrat={singleGrat}
-              setSingleGrat={setSingleGrat}
-            />
-          ) : (
-            <RevisarStep isDark={isDark} text={revText} setText={setRevText} />
-          )}
+          <View style={wideWrapperStyle}>
+            {step === 0 ? (
+              <GratefulStep
+                isDark={isDark}
+                mode={mode}
+                setMode={setMode}
+                items={items}
+                setItems={setItems}
+                singleGrat={singleGrat}
+                setSingleGrat={setSingleGrat}
+              />
+            ) : (
+              <RevisarStep
+                isDark={isDark}
+                text={revText}
+                setText={setRevText}
+              />
+            )}
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
 
@@ -327,47 +344,55 @@ export default function RevisionScreen() {
           },
         ]}
       >
-        {saved ? (
-          <View style={styles.savedRow}>
-            <MaterialIcons name="check-circle" size={22} color={W.green} />
-            <Text style={[styles.savedText, { color: W.green }]}>
-              Revisión guardada
-            </Text>
-          </View>
-        ) : (
-          <View style={{ flexDirection: 'row', gap: 10 }}>
-            {step > 0 && (
+        <View style={wideWrapperStyle}>
+          {saved ? (
+            <View style={styles.savedRow}>
+              <MaterialIcons name="check-circle" size={22} color={W.green} />
+              <Text style={[styles.savedText, { color: W.green }]}>
+                Revisión guardada
+              </Text>
+            </View>
+          ) : (
+            <View style={{ flexDirection: 'row', gap: 10 }}>
+              {step > 0 && (
+                <TouchableOpacity
+                  onPress={() => setStep(step - 1)}
+                  style={[
+                    styles.backBtn,
+                    {
+                      borderColor: W.border,
+                    },
+                  ]}
+                  accessibilityLabel="Paso anterior"
+                >
+                  <MaterialIcons
+                    name="arrow-back"
+                    size={20}
+                    color={W.textSec}
+                  />
+                </TouchableOpacity>
+              )}
               <TouchableOpacity
-                onPress={() => setStep(step - 1)}
-                style={[
-                  styles.backBtn,
-                  {
-                    borderColor: W.border,
-                  },
-                ]}
-                accessibilityLabel="Paso anterior"
+                onPress={handleNext}
+                activeOpacity={0.85}
+                style={{ flex: 1 }}
               >
-                <MaterialIcons name="arrow-back" size={20} color={W.textSec} />
+                <LinearGradient
+                  colors={['#8B5CF6', '#6D28D9']}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 1 }}
+                  style={styles.nextBtn}
+                >
+                  <Text style={styles.nextBtnText}>
+                    {step < totalSteps - 1
+                      ? 'Continuar →'
+                      : '✓ Guardar revisión'}
+                  </Text>
+                </LinearGradient>
               </TouchableOpacity>
-            )}
-            <TouchableOpacity
-              onPress={handleNext}
-              activeOpacity={0.85}
-              style={{ flex: 1 }}
-            >
-              <LinearGradient
-                colors={['#8B5CF6', '#6D28D9']}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={styles.nextBtn}
-              >
-                <Text style={styles.nextBtnText}>
-                  {step < totalSteps - 1 ? 'Continuar →' : '✓ Guardar revisión'}
-                </Text>
-              </LinearGradient>
-            </TouchableOpacity>
-          </View>
-        )}
+            </View>
+          )}
+        </View>
       </View>
 
       {phase === 'breathing' && (

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -151,9 +151,10 @@ export default function CategoriesScreen({
   }, [navigation]);
 
   // En iPad/web amplio rendiriamos la "Tu selección" en una card destacada
-  // de ancho completo arriba, y las categorías reales en un grid de 2 cols.
+  // de ancho completo arriba, y las categorías reales en un grid de 2-3 cols
+  // según ancho (3 cols en iPad landscape / desktop, 2 cols en iPad portrait).
   const isWideLayout = layout.isWide;
-  const numColumns = isWideLayout ? 2 : 1;
+  const numColumns = layout.gridColumns;
   const gridData = useMemo(() => {
     if (!isWideLayout) return displayCategories;
     // En grid, la primera card ("Tu selección") la rendirizamos a parte

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -10,6 +10,7 @@ import {
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
@@ -59,7 +60,11 @@ export default function CategoriesScreen({
   }>;
 }) {
   const scheme = useColorScheme();
-  const styles = useMemo(() => createStyles(scheme), [scheme]);
+  const layout = useResponsiveLayout();
+  const styles = useMemo(
+    () => createStyles(scheme, layout.isWide, layout.contentMaxWidth),
+    [scheme, layout.isWide, layout.contentMaxWidth],
+  );
   const isDark = scheme === 'dark';
   const insets = useSafeAreaInsets();
   const { data: songsData, loading } = useFirebaseData<Record<
@@ -145,6 +150,17 @@ export default function CategoriesScreen({
     });
   }, [navigation]);
 
+  // En iPad/web amplio rendiriamos la "Tu selección" en una card destacada
+  // de ancho completo arriba, y las categorías reales en un grid de 2 cols.
+  const isWideLayout = layout.isWide;
+  const numColumns = isWideLayout ? 2 : 1;
+  const gridData = useMemo(() => {
+    if (!isWideLayout) return displayCategories;
+    // En grid, la primera card ("Tu selección") la rendirizamos a parte
+    // como hero/banner, así que la sacamos de los items del grid.
+    return displayCategories.slice(1);
+  }, [displayCategories, isWideLayout]);
+
   const renderItem = useCallback(
     ({
       item,
@@ -160,19 +176,39 @@ export default function CategoriesScreen({
       const displayName = isSpecial
         ? cleanText
         : cleanText.replace(/^\w\.?\s*/, '');
+      const onPress = () => {
+        if (item.id === SELECTED_SONGS_CATEGORY_ID) {
+          navigation.navigate('SelectedSongs');
+        } else {
+          navigation.navigate('SongsList', {
+            categoryId: item.id,
+            categoryName: item.name,
+          });
+        }
+      };
 
+      // ── Layout iPad: tarjeta cuadrada tipo dashboard ────────────────
+      if (isWideLayout && !isSpecial) {
+        return (
+          <PressableFeedback onPress={onPress} style={styles.gridCard}>
+            <PressableFeedback.Highlight />
+            <View style={styles.gridCardEmojiWrap}>
+              <Text style={styles.gridCardEmoji}>{emoji}</Text>
+            </View>
+            <Text style={styles.gridCardTitle} numberOfLines={2}>
+              {displayName}
+            </Text>
+            <Text style={styles.gridCardCount}>
+              {item.songCount} {item.songCount === 1 ? 'canción' : 'canciones'}
+            </Text>
+          </PressableFeedback>
+        );
+      }
+
+      // ── Layout móvil: fila tradicional ───────────────────────────────
       return (
         <PressableFeedback
-          onPress={() => {
-            if (item.id === SELECTED_SONGS_CATEGORY_ID) {
-              navigation.navigate('SelectedSongs');
-            } else {
-              navigation.navigate('SongsList', {
-                categoryId: item.id,
-                categoryName: item.name,
-              });
-            }
-          }}
+          onPress={onPress}
           style={[
             styles.card,
             isSpecial && styles.cardSpecial,
@@ -204,7 +240,59 @@ export default function CategoriesScreen({
         </PressableFeedback>
       );
     },
-    [isDark, navigation],
+    [isDark, navigation, isWideLayout, styles],
+  );
+
+  // ── Hero "Tu selección" para iPad ────────────────────────────────────
+  const renderSelectionHero = useCallback(() => {
+    if (!isWideLayout) return null;
+    const selectionItem = displayCategories[0];
+    if (!selectionItem) return null;
+    return (
+      <PressableFeedback
+        onPress={() => navigation.navigate('SelectedSongs')}
+        style={styles.heroCard}
+      >
+        <PressableFeedback.Highlight />
+        <View style={styles.heroEmojiWrap}>
+          <Text style={styles.heroEmoji}>🎵</Text>
+        </View>
+        <View style={styles.heroContent}>
+          <Text style={styles.heroTitle}>Tu selección</Text>
+          <Text style={styles.heroSubtitle}>
+            {selectionItem.songCount === 0
+              ? 'Añade canciones a tu playlist para tenerlas a mano'
+              : `${selectionItem.songCount} ${
+                  selectionItem.songCount === 1 ? 'canción' : 'canciones'
+                } en tu playlist`}
+          </Text>
+        </View>
+        <MaterialIcons
+          name="chevron-right"
+          size={24}
+          color={isDark ? '#7AB3FF' : '#253883'}
+        />
+      </PressableFeedback>
+    );
+  }, [isWideLayout, displayCategories, navigation, isDark, styles]);
+
+  const sectionLabel = useCallback(() => {
+    if (!isWideLayout) return null;
+    return (
+      <Text style={styles.sectionLabel}>
+        CATEGORÍAS · {displayCategories.length - 1}
+      </Text>
+    );
+  }, [isWideLayout, displayCategories.length, styles]);
+
+  const listHeader = useMemo(
+    () => (
+      <View>
+        {renderSelectionHero()}
+        {sectionLabel()}
+      </View>
+    ),
+    [renderSelectionHero, sectionLabel],
   );
 
   if (loading && sortedCategories.length === 0) {
@@ -220,7 +308,7 @@ export default function CategoriesScreen({
         />
       )}
       <FlatList
-        data={displayCategories}
+        data={gridData}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
@@ -229,6 +317,11 @@ export default function CategoriesScreen({
         windowSize={5}
         renderItem={renderItem}
         showsVerticalScrollIndicator={false}
+        ListHeaderComponent={listHeader}
+        numColumns={numColumns}
+        columnWrapperStyle={numColumns > 1 ? styles.gridRow : undefined}
+        // Cambiar numColumns en runtime requiere remontar la lista.
+        key={`cats-${numColumns}`}
       />
 
       <SuggestSongModal
@@ -242,8 +335,41 @@ export default function CategoriesScreen({
   );
 }
 
-const createStyles = (scheme: 'light' | 'dark' | null) => {
+const createStyles = (
+  scheme: 'light' | 'dark' | null,
+  isWide: boolean,
+  contentMaxWidth: number,
+) => {
   const isDark = scheme === 'dark';
+  const cardShadow =
+    Platform.OS === 'web'
+      ? ({
+          boxShadow: isDark
+            ? '0 1px 3px rgba(0,0,0,0.4)'
+            : '0 1px 3px rgba(0,0,0,0.06)',
+        } as any)
+      : {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: isDark ? 0.25 : 0.04,
+          shadowRadius: 3,
+          elevation: 1,
+        };
+  const gridCardShadow =
+    Platform.OS === 'web'
+      ? ({
+          boxShadow: isDark
+            ? '0 2px 10px rgba(0,0,0,0.4)'
+            : '0 2px 10px rgba(0,0,0,0.06)',
+        } as any)
+      : {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: isDark ? 0.3 : 0.06,
+          shadowRadius: 8,
+          elevation: 2,
+        };
+
   return StyleSheet.create({
     container: {
       flex: 1,
@@ -254,9 +380,17 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       borderRadius: 8,
     },
     listContent: {
-      paddingHorizontal: 16,
+      paddingHorizontal: isWide ? 24 : 16,
       paddingBottom: isIOS ? 100 : 80,
+      ...(isWide
+        ? {
+            maxWidth: contentMaxWidth,
+            width: '100%',
+            alignSelf: 'center',
+          }
+        : null),
     },
+    // ── Móvil: fila tradicional ─────────────────────────────────────────
     card: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -265,19 +399,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       paddingHorizontal: 14,
       paddingVertical: 11,
       marginBottom: 8,
-      ...(Platform.OS === 'web'
-        ? {
-            boxShadow: isDark
-              ? '0 1px 3px rgba(0,0,0,0.4)'
-              : '0 1px 3px rgba(0,0,0,0.06)',
-          }
-        : {
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: 1 },
-            shadowOpacity: isDark ? 0.25 : 0.04,
-            shadowRadius: 3,
-            elevation: 1,
-          }),
+      ...cardShadow,
     },
     cardSpecial: {
       backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
@@ -335,6 +457,94 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       height: 4,
       backgroundColor: '#f4c11e',
       zIndex: 1000,
+    },
+    // ── iPad: hero + grid ───────────────────────────────────────────────
+    sectionLabel: {
+      fontSize: 11,
+      fontWeight: '800',
+      letterSpacing: 1.2,
+      color: isDark ? '#8E8E93' : '#8E8E93',
+      marginTop: 22,
+      marginBottom: 12,
+      paddingLeft: 4,
+    },
+    heroCard: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+      borderRadius: radii.lg + 6,
+      paddingHorizontal: 22,
+      paddingVertical: 20,
+      marginTop: 18,
+      borderWidth: 1,
+      borderColor: isDark ? '#2A3D66' : '#D4E2FF',
+      gap: 18,
+    },
+    heroEmojiWrap: {
+      width: 56,
+      height: 56,
+      borderRadius: 16,
+      backgroundColor: isDark ? '#253883' : '#D4E2FF',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    heroEmoji: {
+      fontSize: 30,
+    },
+    heroContent: {
+      flex: 1,
+    },
+    heroTitle: {
+      fontSize: 22,
+      fontWeight: '800',
+      letterSpacing: -0.4,
+      color: isDark ? '#7AB3FF' : '#253883',
+      marginBottom: 4,
+    },
+    heroSubtitle: {
+      fontSize: 14,
+      color: isDark ? '#9CB7E0' : '#5A6B8A',
+      lineHeight: 19,
+    },
+    gridRow: {
+      gap: 14,
+      marginBottom: 14,
+    },
+    gridCard: {
+      flex: 1,
+      backgroundColor: isDark ? '#2C2C2E' : '#fff',
+      borderRadius: radii.lg + 4,
+      paddingVertical: 22,
+      paddingHorizontal: 18,
+      minHeight: 140,
+      justifyContent: 'flex-start',
+      ...gridCardShadow,
+    },
+    gridCardEmojiWrap: {
+      width: 52,
+      height: 52,
+      borderRadius: 14,
+      backgroundColor: isDark ? Colors.dark.card : '#F7F7FB',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: 14,
+    },
+    gridCardEmoji: {
+      fontSize: 28,
+    },
+    gridCardTitle: {
+      fontSize: 17,
+      fontWeight: '700',
+      letterSpacing: -0.3,
+      color: isDark ? '#FFFFFF' : '#1C1C1E',
+      lineHeight: 21,
+      marginBottom: 4,
+    },
+    gridCardCount: {
+      fontSize: 13,
+      fontWeight: '500',
+      color: isDark ? '#8E8E93' : '#8A8A8E',
+      fontVariant: ['tabular-nums'],
     },
   });
 };

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -36,6 +36,7 @@ import {
 import { useChoirSession } from '@/contexts/ChoirSessionContext';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
 import { RootStackParamList } from '../(tabs)/cancionero';
@@ -117,7 +118,11 @@ const SelectedSongsScreen: React.FC = () => {
   const route = useRoute();
   const scheme = useColorScheme() || 'light';
   const isDark = scheme === 'dark';
-  const styles = useMemo(() => createStyles(scheme), [scheme]);
+  const layout = useResponsiveLayout();
+  const styles = useMemo(
+    () => createStyles(scheme, layout.isWide, layout.readableMaxWidth),
+    [scheme, layout.isWide, layout.readableMaxWidth],
+  );
   const { data: allSongsData, loading } = useFirebaseData<
     Record<string, { categoryTitle: string; songs: Song[] }>
   >('songs', 'songs');
@@ -1477,7 +1482,11 @@ const SelectedSongsScreen: React.FC = () => {
   );
 };
 
-const createStyles = (scheme: 'light' | 'dark' | null) => {
+const createStyles = (
+  scheme: 'light' | 'dark' | null,
+  isWide: boolean = false,
+  maxWidth: number = 9999,
+) => {
   const isDark = scheme === 'dark';
   return StyleSheet.create({
     container: {
@@ -1554,6 +1563,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     },
     listContentContainer: {
       paddingBottom: Platform.OS === 'ios' ? 100 : 24,
+      ...(isWide ? { maxWidth, width: '100%', alignSelf: 'center' } : null),
     },
     categoryContainer: {
       marginTop: 12,
@@ -1591,6 +1601,7 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       padding: 20,
       backgroundColor: isDark ? '#1C1C1E' : '#F2F2F7',
       justifyContent: 'space-between',
+      ...(isWide ? { maxWidth, width: '100%', alignSelf: 'center' } : null),
     },
     emptyContent: {
       flex: 1,

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -13,6 +13,7 @@ import { useChoirSession } from '@/contexts/ChoirSessionContext';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
 import * as Clipboard from 'expo-clipboard';
 import { Colors } from '@/constants/colors';
@@ -78,6 +79,7 @@ export default function SongDetailScreen({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const insets = useSafeAreaInsets();
+  const layout = useResponsiveLayout();
 
   const { settings, setSettings, isLoadingSettings } = useSettings();
   const {
@@ -329,7 +331,10 @@ export default function SongDetailScreen({
   const floatingButtons = (
     <>
       <PressableFeedback
-        style={[styles.floatBtn, { top: btnTop, left: 16, backgroundColor: floatBtnBg }]}
+        style={[
+          styles.floatBtn,
+          { top: btnTop, left: 16, backgroundColor: floatBtnBg },
+        ]}
         onPress={() => navigation.goBack()}
         accessibilityLabel="Volver"
       >
@@ -337,12 +342,17 @@ export default function SongDetailScreen({
         <IconSymbol name="chevron.left" size={20} color={floatIconColor} />
       </PressableFeedback>
       <PressableFeedback
-        style={[styles.floatBtn, { top: btnTop, right: 16, backgroundColor: floatBtnBg }]}
+        style={[
+          styles.floatBtn,
+          { top: btnTop, right: 16, backgroundColor: floatBtnBg },
+        ]}
         onPress={() => {
           if (isSelected) removeSong(filename);
           else addSong(filename);
         }}
-        accessibilityLabel={isSelected ? 'Quitar de selección' : 'Añadir a selección'}
+        accessibilityLabel={
+          isSelected ? 'Quitar de selección' : 'Añadir a selección'
+        }
       >
         <PressableFeedback.Scale />
         <IconSymbol
@@ -354,6 +364,17 @@ export default function SongDetailScreen({
     </>
   );
 
+  // En iPad/web amplio centramos la card del WebView para mantener
+  // longitud de línea cómoda. En móvil, ancho completo.
+  const songCardWrapperStyle = layout.isWide
+    ? {
+        flex: 1,
+        width: '100%' as const,
+        maxWidth: layout.contentMaxWidth,
+        alignSelf: 'center' as const,
+      }
+    : { flex: 1 };
+
   const contentView = (
     <Animated.View
       style={[
@@ -364,10 +385,12 @@ export default function SongDetailScreen({
     >
       <View style={{ height: insets.top + 44 }} />
       <ChoirSessionBanner />
-      <SongDisplay
-        songHtml={songHtml}
-        isLoading={isFileLoading || isSongProcessing || isLoadingSettings}
-      />
+      <View style={songCardWrapperStyle}>
+        <SongDisplay
+          songHtml={songHtml}
+          isLoading={isFileLoading || isSongProcessing || isLoadingSettings}
+        />
+      </View>
       <SongControls
         chordsVisible={chordsVisible}
         currentTranspose={currentTranspose}
@@ -397,7 +420,9 @@ export default function SongDetailScreen({
   );
 
   const gestureContent =
-    navigationList && typeof currentIndex === 'number' && Platform.OS !== 'web' ? (
+    navigationList &&
+    typeof currentIndex === 'number' &&
+    Platform.OS !== 'web' ? (
       <PanGestureHandler
         activeOffsetX={[-20, 20]}
         failOffsetY={[-15, 15]}

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,14 +1,5 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Platform,
-  Animated,
-  PanResponder,
-  GestureResponderEvent,
-  PanResponderGestureState,
-} from 'react-native';
+import { View, Text, StyleSheet, Platform, Animated } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RouteProp,
@@ -19,6 +10,12 @@ import { WebView } from 'react-native-webview';
 import { BlurView } from 'expo-blur';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { PressableFeedback } from 'heroui-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Reanimated, {
+  useSharedValue,
+  useAnimatedStyle,
+  runOnJS,
+} from 'react-native-reanimated';
 import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSongProcessor } from '../../hooks/useSongProcessor';
@@ -46,66 +43,83 @@ const THUMB_D = 22; // thumb diameter
 const DRAG_RANGE = SLIDER_H - THUMB_D;
 const TRACK_W = 3;
 
-/** Cross-platform vertical slider via PanResponder. value: 0..1 */
+/**
+ * Cross-platform vertical slider built on react-native-gesture-handler +
+ * Reanimated. Using RNGH (instead of PanResponder) avoids gesture conflicts
+ * with the surrounding heroui-native PressableFeedback components, which is
+ * what kept breaking the previous implementation. value: 0..1
+ */
 function VerticalSlider({
   value,
   onChange,
+  onStart,
+  onEnd,
 }: {
   value: number;
   onChange: (v: number) => void;
+  onStart?: () => void;
+  onEnd?: () => void;
 }) {
-  const valueRef = useRef(value);
-  const startRef = useRef(value);
+  const sv = useSharedValue(value);
+  const start = useSharedValue(value);
 
   useEffect(() => {
-    valueRef.current = value;
+    sv.value = value;
+  }, [value, sv]);
+
+  const pan = Gesture.Pan()
+    .minDistance(0)
+    .onBegin(() => {
+      start.value = sv.value;
+      if (onStart) runOnJS(onStart)();
+    })
+    .onUpdate((e) => {
+      // dy > 0 = moved down = slower; top = fast (value 1)
+      const next = Math.max(
+        0,
+        Math.min(1, start.value - e.translationY / DRAG_RANGE),
+      );
+      sv.value = next;
+      runOnJS(onChange)(next);
+    })
+    .onFinalize(() => {
+      if (onEnd) runOnJS(onEnd)();
+    });
+
+  // Tap on the track to jump to that position.
+  const tap = Gesture.Tap().onEnd((e) => {
+    const raw = 1 - (e.y - THUMB_D / 2) / DRAG_RANGE;
+    const next = Math.max(0, Math.min(1, raw));
+    sv.value = next;
+    runOnJS(onChange)(next);
+    if (onEnd) runOnJS(onEnd)();
   });
 
-  const panResponder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: () => {
-        startRef.current = valueRef.current;
-      },
-      onPanResponderMove: (
-        _evt: GestureResponderEvent,
-        { dy }: PanResponderGestureState,
-      ) => {
-        // dy > 0 = moved down = slower; top = fast (value 1)
-        const next = Math.max(
-          0,
-          Math.min(1, startRef.current - dy / DRAG_RANGE),
-        );
-        onChange(next);
-      },
-    }),
-  ).current;
+  const gesture = Gesture.Exclusive(pan, tap);
 
-  const thumbTop = (1 - value) * DRAG_RANGE;
+  const thumbStyle = useAnimatedStyle(() => ({
+    top: (1 - sv.value) * DRAG_RANGE,
+  }));
+  const fillStyle = useAnimatedStyle(() => ({
+    top: (1 - sv.value) * DRAG_RANGE + THUMB_D / 2,
+    height: sv.value * DRAG_RANGE,
+  }));
 
   return (
-    <View
-      style={sliderStyles.container}
-      {...panResponder.panHandlers}
-      // Extra hit area so small thumbs are easy to grab
-      hitSlop={{ top: 8, bottom: 8, left: 14, right: 14 }}
-    >
-      {/* Track background */}
-      <View style={sliderStyles.trackBg} />
-      {/* Filled portion: from thumb down to bottom = the selected speed level */}
+    <GestureDetector gesture={gesture}>
       <View
-        style={[
-          sliderStyles.trackFill,
-          {
-            top: thumbTop + THUMB_D / 2,
-            height: value * DRAG_RANGE,
-          },
-        ]}
-      />
-      {/* Thumb */}
-      <View style={[sliderStyles.thumb, { top: thumbTop }]} />
-    </View>
+        style={sliderStyles.container}
+        // Extra hit area so small thumbs are easy to grab
+        hitSlop={{ top: 8, bottom: 8, left: 14, right: 14 }}
+      >
+        {/* Track background */}
+        <View style={sliderStyles.trackBg} />
+        {/* Filled portion: from thumb down to bottom = the selected speed level */}
+        <Reanimated.View style={[sliderStyles.trackFill, fillStyle]} />
+        {/* Thumb */}
+        <Reanimated.View style={[sliderStyles.thumb, thumbStyle]} />
+      </View>
+    </GestureDetector>
   );
 }
 
@@ -189,6 +203,7 @@ export default function SongFullscreenScreen({
   const [controlsVisible, setControlsVisible] = useState(false);
   const controlsOpacity = useRef(new Animated.Value(0)).current;
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isDraggingRef = useRef(false);
 
   // Refs for fluid web rAF scroll (avoid stale closures)
   const webRafRef = useRef<number | null>(null);
@@ -217,6 +232,9 @@ export default function SongFullscreenScreen({
     }).start();
 
     if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+    // Don't schedule auto-hide while the user is dragging the slider —
+    // hiding mid-drag would unmount the gesture target.
+    if (isDraggingRef.current) return;
     hideTimeoutRef.current = setTimeout(() => {
       Animated.timing(controlsOpacity, {
         toValue: 0,
@@ -225,6 +243,15 @@ export default function SongFullscreenScreen({
       }).start(() => setControlsVisible(false));
     }, 2400);
   }, [controlsOpacity]);
+
+  const handleSliderStart = useCallback(() => {
+    isDraggingRef.current = true;
+    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+  }, []);
+  const handleSliderEnd = useCallback(() => {
+    isDraggingRef.current = false;
+    showControls();
+  }, [showControls]);
 
   // Web: fluid rAF scroll loop driven from React side
   useEffect(() => {
@@ -388,10 +415,9 @@ export default function SongFullscreenScreen({
             </Text>
             <VerticalSlider
               value={speedFactor}
-              onChange={(v) => {
-                setSpeedFactor(v);
-                showControls();
-              }}
+              onChange={setSpeedFactor}
+              onStart={handleSliderStart}
+              onEnd={handleSliderEnd}
             />
           </Animated.View>
         )}

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -17,6 +17,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { filterSongsData } from '@/utils/filterSongsData';
@@ -83,9 +84,16 @@ export default function SongsListScreen({
   const { categoryId, categoryName } = route.params;
   const scheme = useColorScheme();
   const insets = useSafeAreaInsets();
+  const layout = useResponsiveLayout();
   const styles = useMemo(
-    () => createStyles(scheme || 'light', insets.bottom),
-    [scheme, insets.bottom],
+    () =>
+      createStyles(
+        scheme || 'light',
+        insets.bottom,
+        layout.isWide,
+        layout.readableMaxWidth,
+      ),
+    [scheme, insets.bottom, layout.isWide, layout.readableMaxWidth],
   );
   const isDark = scheme === 'dark';
   const [search, setSearch] = useState('');
@@ -304,7 +312,10 @@ export default function SongsListScreen({
                 clearButtonMode="while-editing"
               />
               {Platform.OS !== 'ios' && search.length > 0 && (
-                <TouchableOpacity onPress={() => setSearch('')} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                <TouchableOpacity
+                  onPress={() => setSearch('')}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
                   <MaterialIcons
                     name="cancel"
                     size={16}
@@ -396,6 +407,8 @@ export default function SongsListScreen({
 const createStyles = (
   scheme: 'light' | 'dark' | null,
   bottomInset: number = 0,
+  isWide: boolean = false,
+  maxWidth: number = 9999,
 ) => {
   const isDark = scheme === 'dark';
   return StyleSheet.create({
@@ -408,7 +421,7 @@ const createStyles = (
       marginRight: Platform.OS === 'web' ? 8 : 0,
     },
     searchContainer: {
-      paddingHorizontal: 16,
+      paddingHorizontal: isWide ? 0 : 16,
       paddingTop: 10,
       paddingBottom: 4,
     },
@@ -416,20 +429,20 @@ const createStyles = (
       flexDirection: 'row',
       alignItems: 'center',
       backgroundColor: isDark ? '#2C2C2E' : '#E5E5EA',
-      borderRadius: 10,
-      paddingHorizontal: 10,
-      paddingVertical: Platform.OS === 'ios' ? 9 : 7,
-      gap: 6,
+      borderRadius: isWide ? 14 : 10,
+      paddingHorizontal: isWide ? 14 : 10,
+      paddingVertical: isWide ? 12 : Platform.OS === 'ios' ? 9 : 7,
+      gap: 8,
     },
     searchInput: {
       flex: 1,
-      fontSize: 16,
+      fontSize: isWide ? 17 : 16,
       color: isDark ? '#F5F5F7' : '#1C1C1E',
       padding: 0,
       margin: 0,
     },
     countRow: {
-      paddingHorizontal: 20,
+      paddingHorizontal: isWide ? 4 : 20,
       paddingTop: 10,
       paddingBottom: 2,
     },
@@ -439,8 +452,15 @@ const createStyles = (
       letterSpacing: 0.2,
     },
     listContent: {
-      paddingHorizontal: 12,
+      paddingHorizontal: isWide ? 20 : 12,
       paddingBottom: bottomInset + 20,
+      ...(isWide
+        ? {
+            maxWidth,
+            width: '100%',
+            alignSelf: 'center',
+          }
+        : null),
     },
     errorText: {
       fontSize: 16,

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -16,6 +16,7 @@ import TransposePanel from './TransposePanel';
 import ReportBugsModal from './ReportBugsModal';
 import SecretPanelModal from './SecretPanelModal';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface FontOption {
@@ -84,7 +85,17 @@ const SongControls: React.FC<SongControlsProps> = ({
   const { toast } = useToast();
   const isDark = scheme === 'dark';
   const insets = useSafeAreaInsets();
+  const layout = useResponsiveLayout();
   const rotateAnim = useRef(new Animated.Value(0)).current;
+
+  // En iPad / web amplio el contenido del SongDetail está centrado con
+  // `contentMaxWidth`. Alineamos el FAB con el borde derecho de ese
+  // contenedor centrado en vez de pegarlo al borde de la pantalla para
+  // que visualmente "pertenezca" a la card de la canción.
+  const fabRightOffset =
+    layout.isWide && layout.width > layout.contentMaxWidth
+      ? (layout.width - layout.contentMaxWidth) / 2 + 16
+      : 16;
 
   const hasModifications =
     currentTranspose !== 0 ||
@@ -204,7 +215,10 @@ const SongControls: React.FC<SongControlsProps> = ({
       <View
         style={[
           styles.fabContainer,
-          { bottom: insets.bottom + (isIOS ? 52 : 24) },
+          {
+            bottom: insets.bottom + (isIOS ? 52 : 24),
+            right: fabRightOffset,
+          },
         ]}
       >
         {showActionButtons && (

--- a/mcm-app/components/SongDisplay.tsx
+++ b/mcm-app/components/SongDisplay.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { Spinner } from 'heroui-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
 
 interface SongDisplayProps {
   songHtml: string;
@@ -12,6 +13,18 @@ interface SongDisplayProps {
 const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
+  const layout = useResponsiveLayout();
+  // En iPad / web amplio la card del WebView está dentro de un wrapper
+  // centrado con margen alrededor. Para que no se vea cortada por abajo
+  // (en iOS sólo aplicamos esquinas top-only), añadimos las esquinas
+  // inferiores también.
+  const wideRadiusStyle = layout.isWide
+    ? {
+        borderBottomLeftRadius: 16,
+        borderBottomRightRadius: 16,
+        marginBottom: 8,
+      }
+    : null;
 
   if (isLoading) {
     return (
@@ -20,6 +33,7 @@ const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
           styles.cardContainer,
           isDark && styles.cardContainerDark,
           styles.loadingContainer,
+          wideRadiusStyle,
         ]}
       >
         <Spinner size="lg" color="#f4c11e" />
@@ -29,7 +43,13 @@ const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
 
   if (Platform.OS === 'web') {
     return (
-      <View style={[styles.cardContainer, isDark && styles.cardContainerDark]}>
+      <View
+        style={[
+          styles.cardContainer,
+          isDark && styles.cardContainerDark,
+          wideRadiusStyle,
+        ]}
+      >
         <iframe
           srcDoc={songHtml}
           style={{
@@ -46,7 +66,13 @@ const SongDisplay: React.FC<SongDisplayProps> = ({ songHtml, isLoading }) => {
   }
 
   return (
-    <View style={[styles.cardContainer, isDark && styles.cardContainerDark]}>
+    <View
+      style={[
+        styles.cardContainer,
+        isDark && styles.cardContainerDark,
+        wideRadiusStyle,
+      ]}
+    >
       <WebView
         originWhitelist={['*']}
         source={{ html: songHtml }}

--- a/mcm-app/hooks/useResponsiveLayout.ts
+++ b/mcm-app/hooks/useResponsiveLayout.ts
@@ -1,0 +1,69 @@
+import { useWindowDimensions } from 'react-native';
+
+/**
+ * Tamaño efectivo de pantalla, agnóstico de plataforma.
+ *
+ * Breakpoints alineados con tablets/iPad y web:
+ * - `xs`  → móvil portrait (< 480)
+ * - `sm`  → móvil grande o tablet pequeño portrait (< 720)
+ * - `md`  → iPad portrait (< 1024)
+ * - `lg`  → iPad landscape / desktop (>= 1024)
+ */
+export type ResponsiveSize = 'xs' | 'sm' | 'md' | 'lg';
+
+export interface ResponsiveLayout {
+  width: number;
+  height: number;
+  size: ResponsiveSize;
+  /** >= 720 px — empieza a tener sentido layout de tablet */
+  isWide: boolean;
+  /** >= 1024 px — iPad landscape / desktop */
+  isExtraWide: boolean;
+  /** True si la orientación actual es horizontal. */
+  isLandscape: boolean;
+  /** True si la orientación actual es vertical. */
+  isPortrait: boolean;
+  /** Número de columnas recomendado para grids de categorías. */
+  gridColumns: number;
+  /** Max-width pensado para listas legibles. */
+  readableMaxWidth: number;
+  /** Max-width pensado para contenido amplio (canción + acordes). */
+  contentMaxWidth: number;
+}
+
+/**
+ * Hook único para resolver breakpoints en toda la app.
+ *
+ * Pensado para que las pantallas no se estiren de forma desproporcionada
+ * en iPad portrait, iPad landscape y web amplio, conservando el diseño
+ * mobile-first en móvil.
+ */
+export function useResponsiveLayout(): ResponsiveLayout {
+  const { width, height } = useWindowDimensions();
+  const isLandscape = width > height;
+
+  let size: ResponsiveSize = 'xs';
+  if (width >= 1024) size = 'lg';
+  else if (width >= 720) size = 'md';
+  else if (width >= 480) size = 'sm';
+
+  const isWide = width >= 720;
+  const isExtraWide = width >= 1024;
+
+  const gridColumns = isExtraWide ? 3 : isWide ? 2 : 1;
+  const readableMaxWidth = isExtraWide ? 760 : isWide ? 640 : width;
+  const contentMaxWidth = isExtraWide ? 980 : isWide ? 760 : width;
+
+  return {
+    width,
+    height,
+    size,
+    isWide,
+    isExtraWide,
+    isLandscape,
+    isPortrait: !isLandscape,
+    gridColumns,
+    readableMaxWidth,
+    contentMaxWidth,
+  };
+}

--- a/mcm-app/hooks/useSongProcessor.ts
+++ b/mcm-app/hooks/useSongProcessor.ts
@@ -153,7 +153,9 @@ export const useSongProcessor = ({
         }
         if (currentTranspose !== 0) {
           const td =
-            currentTranspose > 0 ? `+${currentTranspose}` : `${currentTranspose}`;
+            currentTranspose > 0
+              ? `+${currentTranspose}`
+              : `${currentTranspose}`;
           fsMeta += `<span class="fs-badge-sm fs-badge-accent">${td} semitonos</span>`;
         }
         fsHeader = `<div class="fs-header">${title ? `<div class="fs-title">${title}</div>` : ''}${fsMeta ? `<div class="fs-meta">${fsMeta}</div>` : ''}</div>`;
@@ -234,6 +236,12 @@ export const useSongProcessor = ({
               -webkit-font-smoothing: antialiased;
               scrollbar-width: none;
               -ms-overflow-style: none;
+            }
+            /* En pantalla completa sobre iPad / web amplio limitamos la
+               longitud de línea para que los versos sigan siendo legibles
+               y no atraviesen toda la pantalla. */
+            @media (min-width: 720px) {
+              body { padding-left: max(16px, calc((100% - ${isFullscreen ? 920 : 760}px) / 2)); padding-right: max(16px, calc((100% - ${isFullscreen ? 920 : 760}px) / 2)); }
             }
             body::-webkit-scrollbar { width: 0; height: 0; }
             h1 {


### PR DESCRIPTION
- Migrar el slider de velocidad de SongFullscreenScreen de PanResponder a
  react-native-gesture-handler + Reanimated. PanResponder competía con los
  PressableFeedback de heroui-native (que ya usan RNGH internamente), lo
  que rompía el slider de forma recurrente. Ahora usa Gesture.Pan +
  useSharedValue, soporta tap-on-track, y pausa el auto-hide de controles
  mientras se arrastra para no desmontar el target del gesto.
- Añadir wrapper centrado con maxWidth en ContigoScreen, EvangelioScreen,
  RevisionScreen y BookmarksScreen para que el layout no se disperse en
  iPad / web amplio.

https://claude.ai/code/session_01XZksLYUR7TirzWVJd7wJfE