### PR TITLE
style: apply PageContainer + ScreenHero to all GruposScreen branches

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,16 @@
 
 ---
 
+## 2026-05-20 — Menú contextual del cantoral funcional en web (click derecho)
+
+- **Problema**: `onLongPress` de React Native no se dispara en web, así que el menú contextual de `SongListItem` (Añadir/Quitar lista + Compartir) quedaba inaccesible al abrir la app en navegador.
+- **Solución**: nuevo hook `useContextMenu(handler)` que devuelve `onLongPress` en nativo y `onContextMenu` (con `preventDefault`) en web. Cero cambios en API externa.
+- **Archivos**:
+  - `hooks/useContextMenu.ts` (nuevo): puente long-press ↔ click derecho, reutilizable en otras listas.
+  - `components/SongListItem.tsx`: consume el hook y esparce las props sobre `TouchableOpacity`. El menú custom (BottomSheet en `SongListScreen`) ya funcionaba en web; ahora también se abre.
+
+---
+
 ## 2026-05-20 — Eventos próximos: más eventos y agrupados por semana
 
 - **Más eventos visibles**: aumentado de 2 a 8 eventos máximos en el Home, para que el usuario vea un panorama más amplio de lo que se acerca.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,18 @@
 
 ---
 
+## 2026-05-20 — Atajos de teclado en web: Cmd+K, Esc y cantoral
+
+- **Cmd/Ctrl+K**: nuevo Command Palette global (web-only) montado en `app/_layout.tsx`. Lista las pantallas top-level del expo-router con sinónimos en castellano e inglés para búsqueda rápida.
+- **Esc**: cierra el overlay más reciente. Pila LIFO global (`OverlayStackProvider` en `contexts/OverlayStackContext.tsx`) compartida entre todos los `BottomSheet` y el Command Palette.
+- **Atajos del cantoral** (`SongDetailScreen`): ← / → canción anterior/siguiente, +/- transponer ±1 semitono, F fullscreen. `SongFullscreenScreen` sale con F o Esc.
+- **Infra**: `hooks/useKeyboardShortcut(key, handler, options)` wrap sobre `window.addEventListener('keydown')` con guard `Platform.OS === 'web'`. Ignora teclas si el foco está en un input, salvo combinaciones meta-prefixed.
+- **Archivos**:
+  - Nuevos: `hooks/useKeyboardShortcut.ts`, `hooks/useEscapeToClose.ts`, `contexts/OverlayStackContext.tsx`, `components/CommandPalette.tsx`.
+  - Modificados: `app/_layout.tsx` (provider + montaje del palette), `components/BottomSheet.tsx` (Esc), `app/screens/SongDetailScreen.tsx`, `app/screens/SongFullscreenScreen.tsx`.
+
+---
+
 ## 2026-05-20 — Menú contextual del cantoral funcional en web (click derecho)
 
 - **Problema**: `onLongPress` de React Native no se dispara en web, así que el menú contextual de `SongListItem` (Añadir/Quitar lista + Compartir) quedaba inaccesible al abrir la app en navegador.

--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -32,6 +32,8 @@
 - [x] ~~Skeletons en más pantallas~~ → Contactos, Visitas, Apps, Materiales, Horario, Profundiza, Grupos
 - [x] ~~`SongListItem` swipe colors~~ → centralizados en `SwipeColors` + `KeyPillColors` en `constants/colors.ts`
 - [x] ~~`BottomSheet` borderRadius~~ → usa `radii.xl` de `constants/uiStyles.ts`
+- [x] ~~`GruposScreen` — `PageContainer` y `ScreenHero`~~ → aplicados a las 5 ramas de render (skeleton, grupo, búsqueda, raíz, lista por categoría). Sigue el patrón de `MaterialesScreen` y `ContactosScreen`.
+- [x] ~~Menú contextual del cantoral en web~~ → nuevo hook `useContextMenu` traduce `onLongPress` (móvil) ↔ `onContextMenu` (web). Aplicado a `SongListItem`. Reutilizable para Reflexiones/Notificaciones/Contactos/Playlist (pendiente).
 
 ---
 
@@ -83,10 +85,13 @@ El compilador analiza automáticamente el árbol de componentes y memoiza en tie
 > rama `claude/modernize-app-design-V5LuI`. Cada una es independiente
 > y puede hacerse en su propio PR.
 
-- [ ] **`GruposScreen` — `PageContainer` y `ScreenHero`**.
-      Hoy `ScreenHero` solo se aplica en la vista raíz. Aplicar
-      `PageContainer` en las 5 ramas de render para que también centre en
-      web (búsqueda activa, categoría seleccionada, grupo seleccionado, etc.).
+- [ ] **Extender `useContextMenu` a otras listas**: el hook ya existe
+      (`hooks/useContextMenu.ts`) y se usa en `SongListItem`. Pendiente
+      aplicarlo a:
+  - Notificaciones (`app/notifications.tsx`) — marcar leída / eliminar
+  - Reflexiones (`app/screens/ReflexionesScreen.tsx`) — editar / copiar / compartir
+  - Contactos (`app/screens/ContactosScreen.tsx`) — llamar / WhatsApp / copiar teléfono
+  - Playlist (`app/screens/SelectedSongsScreen.tsx`) — subir / bajar / quitar
 
 ## Mantenimiento
 

--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -44,13 +44,18 @@
 - [ ] En iPad Contigo se ven desproporcionados los habit tracker
 
 
-- [ ] **Atajos de teclado en web**.
-  - `Cmd/Ctrl + K` para abrir un buscador global (cantoral, calendario,
-    reflexiones). Implementar con `useEffect` + `window.addEventListener('keydown')`
-    detrás de `Platform.OS === 'web'`. Posible UI: `Dialog` de
-    heroui-native en modo command palette.
-  - `Esc` para cerrar el sheet/diálogo abierto más reciente. Centralizar
-    en un hook `useEscapeToClose` o en cada componente sheet.
+- [x] ~~Atajos de teclado en web (Cmd+K, Esc, atajos del cantoral)~~ →
+      infraestructura en `hooks/useKeyboardShortcut.ts` +
+      `hooks/useEscapeToClose.ts` + `contexts/OverlayStackContext.tsx`.
+      Command Palette en `components/CommandPalette.tsx` (v1 navega a
+      pantallas top-level). Atajos ←/→/+/-/F en `SongDetailScreen`.
+- [ ] **Command Palette v2: deep-link a contenidos**: el palette actual sólo
+      navega a tabs/pantallas top-level. Para saltar a una canción concreta
+      o a un punto dentro de los stacks anidados (cancionero, más) hace
+      falta exponer su `navigation ref` (p. ej. via un
+      `CancioneroNavRefContext` o un `RootNavigationRef` global). Indexar
+      después canciones (`songs/data`), reflexiones (`compartiendo/data`) y
+      eventos del calendario.
 
 
 

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -38,6 +38,7 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import MaintenanceScreen from '@/components/MaintenanceScreen';
 import { NotificationsProvider } from '@/contexts/NotificationsContext';
 import { CalendarConfigProvider } from '@/contexts/CalendarConfigContext';
+import { OverlayStackProvider } from '@/contexts/OverlayStackContext';
 import UniwindThemeBridge from '@/components/UniwindThemeBridge';
 import { HeroUINativeProvider } from 'heroui-native';
 import { AppToastProvider, useToast } from '@/contexts/AppToastContext';
@@ -53,22 +54,24 @@ export default function RootLayout() {
         <SafeAreaProvider>
           <HeroUINativeProvider>
             <AppToastProvider>
-              <ProfileConfigProvider>
-                <AppSettingsProvider>
-                  <UniwindThemeBridge />
-                  <UserProfileProvider>
-                    <SelectedSongsProvider>
-                      <ChoirSessionProvider>
-                        <NotificationsProvider>
-                          <CalendarConfigProvider>
-                            <InnerLayout />
-                          </CalendarConfigProvider>
-                        </NotificationsProvider>
-                      </ChoirSessionProvider>
-                    </SelectedSongsProvider>
-                  </UserProfileProvider>
-                </AppSettingsProvider>
-              </ProfileConfigProvider>
+              <OverlayStackProvider>
+                <ProfileConfigProvider>
+                  <AppSettingsProvider>
+                    <UniwindThemeBridge />
+                    <UserProfileProvider>
+                      <SelectedSongsProvider>
+                        <ChoirSessionProvider>
+                          <NotificationsProvider>
+                            <CalendarConfigProvider>
+                              <InnerLayout />
+                            </CalendarConfigProvider>
+                          </NotificationsProvider>
+                        </ChoirSessionProvider>
+                      </SelectedSongsProvider>
+                    </UserProfileProvider>
+                  </AppSettingsProvider>
+                </ProfileConfigProvider>
+              </OverlayStackProvider>
             </AppToastProvider>
           </HeroUINativeProvider>
         </SafeAreaProvider>

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -34,6 +34,7 @@ import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import { isAppVersionSupported } from '@/utils/resolveProfileConfig';
 import { HelloWave } from '@/components/HelloWave';
 import AddToHomeBanner from '@/components/AddToHomeBanner';
+import CommandPalette from '@/components/CommandPalette';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import MaintenanceScreen from '@/components/MaintenanceScreen';
 import { NotificationsProvider } from '@/contexts/NotificationsContext';
@@ -199,6 +200,7 @@ function InnerLayout() {
       </Stack>
       <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
       <AddToHomeBanner />
+      <CommandPalette />
       <OTAUpdatePrompt
         visible={(ota.isReady || ota.isDownloading) && !otaDismissed}
         isDownloading={ota.isDownloading && !ota.isReady}

--- a/mcm-app/app/screens/GruposScreen.tsx
+++ b/mcm-app/app/screens/GruposScreen.tsx
@@ -22,6 +22,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import { radii } from '@/constants/uiStyles';
 import ScreenHero from '@/components/ui/ScreenHero';
+import PageContainer from '@/components/ui/PageContainer';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
 import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
@@ -126,80 +127,112 @@ export default function GruposScreen() {
 
   if (categoria && !data) {
     return (
-      <ScrollView style={{ flex: 1, backgroundColor: Colors[scheme ?? 'light'].background }}
-        contentContainerStyle={{ padding: 16, paddingBottom: 100, gap: spacing.md }}>
-        {[0, 1, 2, 3, 4].map((i) => (
-          <Skeleton key={i} style={{ height: 56, borderRadius: radii.lg }} />
-        ))}
-      </ScrollView>
+      <PageContainer>
+        <ScrollView
+          style={{
+            flex: 1,
+            backgroundColor: Colors[scheme ?? 'light'].background,
+          }}
+          contentContainerStyle={{
+            paddingBottom: 100,
+            gap: spacing.md,
+          }}
+        >
+          <ScreenHero
+            title={categoria}
+            left={
+              <Pressable
+                onPress={() => setCategoria(null)}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Volver"
+              >
+                <MaterialIcons name="arrow-back" size={24} color="#888" />
+              </Pressable>
+            }
+          />
+          <View style={{ paddingHorizontal: 16, gap: spacing.md }}>
+            {[0, 1, 2, 3, 4].map((i) => (
+              <Skeleton
+                key={i}
+                style={{ height: 56, borderRadius: radii.lg }}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      </PageContainer>
     );
   }
 
   // Si hay un grupo seleccionado, mostrar la vista del grupo (prioridad máxima)
   if (grupo) {
     return (
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={
-          Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
-        }
-      >
-        <View style={styles.backWrapper}>
-          <Pressable
-            onPress={() => {
-              setGrupo(null);
-              if (search.trim().length >= 3) {
-                setShowSearch(true);
-                setCategoria(null);
-              }
-            }}
-            style={styles.iconBtn}
-          >
-            <MaterialIcons name="arrow-back" size={24} color="#888" />
-          </Pressable>
-        </View>
-        <View style={styles.groupContainer}>
-          <View style={styles.groupHeader}>
-            <Text style={styles.groupTitle}>{grupo.nombre}</Text>
+      <PageContainer>
+        <ScrollView
+          style={styles.container}
+          contentContainerStyle={
+            Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
+          }
+        >
+          <ScreenHero
+            title={grupo.nombre}
+            kicker={categoria ?? undefined}
+            left={
+              <Pressable
+                onPress={() => {
+                  setGrupo(null);
+                  if (search.trim().length >= 3) {
+                    setShowSearch(true);
+                    setCategoria(null);
+                  }
+                }}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Volver"
+              >
+                <MaterialIcons name="arrow-back" size={24} color="#888" />
+              </Pressable>
+            }
+          />
+          <View style={styles.groupContainer}>
+            {grupo.subtitulo && (
+              <View style={styles.quoteContainer}>
+                <View style={styles.quoteBorder} />
+                <Text style={styles.quoteText}>{grupo.subtitulo}</Text>
+              </View>
+            )}
+
+            {grupo.mapa && (
+              <Button
+                variant="secondary"
+                onPress={() => openMap(grupo.mapa)}
+                className="my-3"
+              >
+                <Button.Label>📍 Ubicación</Button.Label>
+              </Button>
+            )}
+
+            {grupo.responsable && (
+              <>
+                <Text style={styles.sectionHeader}>Acompaña...</Text>
+                <View style={styles.listItem}>
+                  <Text style={styles.listItemTitle}>{grupo.responsable}</Text>
+                </View>
+              </>
+            )}
+            <Text style={styles.sectionHeader}>
+              Forman parte... ({grupo.miembros?.length || 0})
+            </Text>
+            {(grupo.miembros || [])
+              .filter((m) => m && typeof m === 'string')
+              .map((m, idx) => (
+                <View key={idx} style={styles.listItem}>
+                  <Text style={styles.listItemTitle}>{m}</Text>
+                </View>
+              ))}
           </View>
-
-          {grupo.subtitulo && (
-            <View style={styles.quoteContainer}>
-              <View style={styles.quoteBorder} />
-              <Text style={styles.quoteText}>{grupo.subtitulo}</Text>
-            </View>
-          )}
-
-          {grupo.mapa && (
-            <Button
-              variant="secondary"
-              onPress={() => openMap(grupo.mapa)}
-              className="my-3"
-            >
-              <Button.Label>📍 Ubicación</Button.Label>
-            </Button>
-          )}
-
-          {grupo.responsable && (
-            <>
-              <Text style={styles.sectionHeader}>Acompaña...</Text>
-              <View style={styles.listItem}>
-                <Text style={styles.listItemTitle}>{grupo.responsable}</Text>
-              </View>
-            </>
-          )}
-          <Text style={styles.sectionHeader}>
-            Forman parte... ({grupo.miembros?.length || 0})
-          </Text>
-          {(grupo.miembros || [])
-            .filter((m) => m && typeof m === 'string')
-            .map((m, idx) => (
-              <View key={idx} style={styles.listItem}>
-                <Text style={styles.listItemTitle}>{m}</Text>
-              </View>
-            ))}
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </PageContainer>
     );
   }
 
@@ -210,168 +243,161 @@ export default function GruposScreen() {
       grouped[r.categoria].push({ grupo: r.grupo, matches: r.matches });
     });
     return (
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={
-          Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
-        }
-      >
-        <View style={styles.searchContainer}>
-          <SearchField value={search} onChange={setSearch}>
-            <SearchField.Group>
-              <SearchField.SearchIcon />
-              <SearchField.Input
-                placeholder="Buscar grupo o persona"
-                autoFocus={showSearch}
-              />
-              <SearchField.ClearButton />
-            </SearchField.Group>
-          </SearchField>
-        </View>
-        {search.trim().length < 3 ? (
-          <View style={styles.emptyContainer}>
-            <Text style={styles.hintText}>Escribe al menos 3 caracteres</Text>
+      <PageContainer>
+        <ScrollView
+          style={styles.container}
+          contentContainerStyle={
+            Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
+          }
+        >
+          <ScreenHero
+            title="Buscar"
+            left={
+              <Pressable
+                onPress={() => {
+                  setShowSearch(false);
+                  setSearch('');
+                }}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Cerrar búsqueda"
+              >
+                <MaterialIcons name="arrow-back" size={24} color="#888" />
+              </Pressable>
+            }
+          />
+          <View style={styles.searchContainer}>
+            <SearchField value={search} onChange={setSearch}>
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input
+                  placeholder="Buscar grupo o persona"
+                  autoFocus={showSearch}
+                />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
           </View>
-        ) : searchResults.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>
-              No he encontrado nada, ya lo siento 😔
-            </Text>
-          </View>
-        ) : (
-          Object.entries(grouped).map(([cat, grupos]) => (
-            <View key={cat}>
-              <Text style={styles.sectionHeader}>{cat}</Text>
-              <ListGroup variant="transparent">
-                {grupos.map(({ grupo: g, matches }, idx) => (
-                  <React.Fragment key={idx}>
-                    <ListGroup.Item
-                      onPress={() => {
-                        setCategoria(cat);
-                        setGrupo(g);
-                        setShowSearch(false);
-                      }}
-                    >
-                      <ListGroup.ItemContent>
-                        <ListGroup.ItemTitle>{g.nombre}</ListGroup.ItemTitle>
-                        {g.subtitulo ? (
-                          <ListGroup.ItemDescription>
-                            {g.subtitulo}
-                          </ListGroup.ItemDescription>
-                        ) : null}
-                      </ListGroup.ItemContent>
-                    </ListGroup.Item>
-                    {matches
-                      .filter((m) => m !== '__match_name__')
-                      .map((m, j) => (
-                        <View
-                          key={j}
-                          style={[styles.listItem, styles.matchItem]}
-                        >
-                          <Text style={styles.listItemTitle}>{m}</Text>
-                        </View>
-                      ))}
-                    {idx < grupos.length - 1 && <Separator />}
-                  </React.Fragment>
-                ))}
-              </ListGroup>
+          {search.trim().length < 3 ? (
+            <View style={styles.emptyContainer}>
+              <Text style={styles.hintText}>Escribe al menos 3 caracteres</Text>
             </View>
-          ))
-        )}
-      </ScrollView>
+          ) : searchResults.length === 0 ? (
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyText}>
+                No he encontrado nada, ya lo siento 😔
+              </Text>
+            </View>
+          ) : (
+            Object.entries(grouped).map(([cat, grupos]) => (
+              <View key={cat}>
+                <Text style={styles.sectionHeader}>{cat}</Text>
+                <ListGroup variant="transparent">
+                  {grupos.map(({ grupo: g, matches }, idx) => (
+                    <React.Fragment key={idx}>
+                      <ListGroup.Item
+                        onPress={() => {
+                          setCategoria(cat);
+                          setGrupo(g);
+                          setShowSearch(false);
+                        }}
+                      >
+                        <ListGroup.ItemContent>
+                          <ListGroup.ItemTitle>{g.nombre}</ListGroup.ItemTitle>
+                          {g.subtitulo ? (
+                            <ListGroup.ItemDescription>
+                              {g.subtitulo}
+                            </ListGroup.ItemDescription>
+                          ) : null}
+                        </ListGroup.ItemContent>
+                      </ListGroup.Item>
+                      {matches
+                        .filter((m) => m !== '__match_name__')
+                        .map((m, j) => (
+                          <View
+                            key={j}
+                            style={[styles.listItem, styles.matchItem]}
+                          >
+                            <Text style={styles.listItemTitle}>{m}</Text>
+                          </View>
+                        ))}
+                      {idx < grupos.length - 1 && <Separator />}
+                    </React.Fragment>
+                  ))}
+                </ListGroup>
+              </View>
+            ))
+          )}
+        </ScrollView>
+      </PageContainer>
     );
   }
 
   if (!categoria && !showSearch && search.trim().length < 3) {
     return (
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={styles.catList}
-      >
-        <ScreenHero
-          title="Grupos"
-          right={
-            <Pressable
-              onPress={() => setShowSearch(true)}
-              style={styles.iconBtn}
-              accessibilityRole="button"
-              accessibilityLabel="Buscar grupo"
+      <PageContainer>
+        <ScrollView
+          style={styles.container}
+          contentContainerStyle={styles.catList}
+        >
+          <ScreenHero
+            title="Grupos"
+            right={
+              <Pressable
+                onPress={() => setShowSearch(true)}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Buscar grupo"
+              >
+                <MaterialIcons name="search" size={24} color="#888" />
+              </Pressable>
+            }
+          />
+          {categorias.map((c) => (
+            <PressableFeedback
+              key={c.name}
+              style={[styles.catCard, { backgroundColor: c.color }]}
+              onPress={() => setCategoria(c.name)}
             >
-              <MaterialIcons name="search" size={24} color="#888" />
-            </Pressable>
-          }
-        />
-        {categorias.map((c) => (
-          <PressableFeedback
-            key={c.name}
-            style={[styles.catCard, { backgroundColor: c.color }]}
-            onPress={() => setCategoria(c.name)}
-          >
-            <PressableFeedback.Highlight />
-            <MaterialIcons
-              name={c.icon}
-              size={40}
-              color={colors.white}
-              style={styles.catIcon}
-            />
-            <Text style={styles.catLabel}>{c.name}</Text>
-          </PressableFeedback>
-        ))}
-      </ScrollView>
+              <PressableFeedback.Highlight />
+              <MaterialIcons
+                name={c.icon}
+                size={40}
+                color={colors.white}
+                style={styles.catIcon}
+              />
+              <Text style={styles.catLabel}>{c.name}</Text>
+            </PressableFeedback>
+          ))}
+        </ScrollView>
+      </PageContainer>
     );
   }
 
   if (categoria && !grupo) {
     return (
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={
-          Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
-        }
-      >
-        <View style={styles.backWrapper}>
-          <Pressable onPress={() => setCategoria(null)} style={styles.iconBtn}>
-            <MaterialIcons name="arrow-back" size={24} color="#888" />
-          </Pressable>
-        </View>
-        <ListGroup variant="transparent">
-          {(data?.[categoria] || []).map((g, idx) => (
-            <React.Fragment key={idx}>
-              <ListGroup.Item onPress={() => setGrupo(g)}>
-                <ListGroup.ItemContent>
-                  <ListGroup.ItemTitle>{g.nombre}</ListGroup.ItemTitle>
-                  {g.subtitulo ? (
-                    <ListGroup.ItemDescription>
-                      {g.subtitulo}
-                    </ListGroup.ItemDescription>
-                  ) : null}
-                </ListGroup.ItemContent>
-              </ListGroup.Item>
-              {idx < (data?.[categoria]?.length ?? 0) - 1 && <Separator />}
-            </React.Fragment>
-          ))}
-        </ListGroup>
-      </ScrollView>
-    );
-  }
-
-  return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={
-        Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
-      }
-    >
-      <View style={styles.backWrapper}>
-        <Pressable onPress={() => setCategoria(null)} style={styles.iconBtn}>
-          <MaterialIcons name="arrow-back" size={24} color="#888" />
-        </Pressable>
-      </View>
-      <ListGroup variant="transparent">
-        {(categoria && data?.[categoria] ? data[categoria] : []).map(
-          (g: Grupo, idx: number) => {
-            const list = categoria && data?.[categoria] ? data[categoria] : [];
-            return (
+      <PageContainer>
+        <ScrollView
+          style={styles.container}
+          contentContainerStyle={
+            Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
+          }
+        >
+          <ScreenHero
+            title={categoria}
+            left={
+              <Pressable
+                onPress={() => setCategoria(null)}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Volver a categorías"
+              >
+                <MaterialIcons name="arrow-back" size={24} color="#888" />
+              </Pressable>
+            }
+          />
+          <ListGroup variant="transparent">
+            {(data?.[categoria] || []).map((g, idx) => (
               <React.Fragment key={idx}>
                 <ListGroup.Item onPress={() => setGrupo(g)}>
                   <ListGroup.ItemContent>
@@ -383,13 +409,61 @@ export default function GruposScreen() {
                     ) : null}
                   </ListGroup.ItemContent>
                 </ListGroup.Item>
-                {idx < list.length - 1 && <Separator />}
+                {idx < (data?.[categoria]?.length ?? 0) - 1 && <Separator />}
               </React.Fragment>
-            );
-          },
-        )}
-      </ListGroup>
-    </ScrollView>
+            ))}
+          </ListGroup>
+        </ScrollView>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={
+          Platform.OS === 'ios' ? { paddingBottom: 100 } : undefined
+        }
+      >
+        <ScreenHero
+          title={categoria ?? 'Grupos'}
+          left={
+            <Pressable
+              onPress={() => setCategoria(null)}
+              style={styles.iconBtn}
+              accessibilityRole="button"
+              accessibilityLabel="Volver"
+            >
+              <MaterialIcons name="arrow-back" size={24} color="#888" />
+            </Pressable>
+          }
+        />
+        <ListGroup variant="transparent">
+          {(categoria && data?.[categoria] ? data[categoria] : []).map(
+            (g: Grupo, idx: number) => {
+              const list =
+                categoria && data?.[categoria] ? data[categoria] : [];
+              return (
+                <React.Fragment key={idx}>
+                  <ListGroup.Item onPress={() => setGrupo(g)}>
+                    <ListGroup.ItemContent>
+                      <ListGroup.ItemTitle>{g.nombre}</ListGroup.ItemTitle>
+                      {g.subtitulo ? (
+                        <ListGroup.ItemDescription>
+                          {g.subtitulo}
+                        </ListGroup.ItemDescription>
+                      ) : null}
+                    </ListGroup.ItemContent>
+                  </ListGroup.Item>
+                  {idx < list.length - 1 && <Separator />}
+                </React.Fragment>
+              );
+            },
+          )}
+        </ListGroup>
+      </ScrollView>
+    </PageContainer>
   );
 }
 
@@ -408,7 +482,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     catIcon: { marginBottom: 4 },
     catLabel: { fontSize: 18, fontWeight: 'bold', color: colors.white },
     groupListTitle: { fontSize: 16, color: theme.text },
-    backWrapper: { padding: 8 },
     sectionHeader: {
       fontSize: 16,
       fontWeight: 'bold',
@@ -417,17 +490,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       paddingVertical: 8,
     },
     groupContainer: { paddingHorizontal: 16 },
-    groupHeader: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-    },
-    groupTitle: {
-      fontSize: 22,
-      fontWeight: 'bold',
-      marginVertical: 8,
-      color: theme.text,
-    },
     iconBtn: {
       padding: 8,
       borderRadius: 20,

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -17,6 +17,7 @@ import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
 import * as Clipboard from 'expo-clipboard';
 import { Colors } from '@/constants/colors';
 import { durations } from '@/constants/animations';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
 
 // Apple iOS system green — used as a "selected/done" tint inside the
 // add/remove song button. Not part of the MCM brand palette: it's an
@@ -317,6 +318,15 @@ export default function SongDetailScreen({
     }
   };
 
+  // Web keyboard shortcuts (no-op on native).
+  useKeyboardShortcut('arrowleft', handleSwipeLeft);
+  useKeyboardShortcut('arrowright', handleSwipeRight);
+  useKeyboardShortcut(['+', '='], () =>
+    handleSetTranspose(currentTranspose + 1),
+  );
+  useKeyboardShortcut('-', () => handleSetTranspose(currentTranspose - 1));
+  useKeyboardShortcut('f', handleNavigateToFullscreen);
+
   if (isLoadingSettings) {
     // Brief settings loading
   }
@@ -329,7 +339,10 @@ export default function SongDetailScreen({
   const floatingButtons = (
     <>
       <PressableFeedback
-        style={[styles.floatBtn, { top: btnTop, left: 16, backgroundColor: floatBtnBg }]}
+        style={[
+          styles.floatBtn,
+          { top: btnTop, left: 16, backgroundColor: floatBtnBg },
+        ]}
         onPress={() => navigation.goBack()}
         accessibilityLabel="Volver"
       >
@@ -337,12 +350,17 @@ export default function SongDetailScreen({
         <IconSymbol name="chevron.left" size={20} color={floatIconColor} />
       </PressableFeedback>
       <PressableFeedback
-        style={[styles.floatBtn, { top: btnTop, right: 16, backgroundColor: floatBtnBg }]}
+        style={[
+          styles.floatBtn,
+          { top: btnTop, right: 16, backgroundColor: floatBtnBg },
+        ]}
         onPress={() => {
           if (isSelected) removeSong(filename);
           else addSong(filename);
         }}
-        accessibilityLabel={isSelected ? 'Quitar de selección' : 'Añadir a selección'}
+        accessibilityLabel={
+          isSelected ? 'Quitar de selección' : 'Añadir a selección'
+        }
       >
         <PressableFeedback.Scale />
         <IconSymbol
@@ -397,7 +415,9 @@ export default function SongDetailScreen({
   );
 
   const gestureContent =
-    navigationList && typeof currentIndex === 'number' && Platform.OS !== 'web' ? (
+    navigationList &&
+    typeof currentIndex === 'number' &&
+    Platform.OS !== 'web' ? (
       <PanGestureHandler
         activeOffsetX={[-20, 20]}
         failOffsetY={[-15, 15]}

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -24,6 +24,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { useSongProcessor } from '../../hooks/useSongProcessor';
 import { useColorScheme } from '../../hooks/useColorScheme';
 import { Colors } from '../../constants/colors';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
 
 type SongFullscreenRouteProp = RouteProp<RootStackParamList, 'SongFullscreen'>;
 
@@ -162,6 +163,13 @@ export default function SongFullscreenScreen({
   const insets = useSafeAreaInsets();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme ?? 'light'];
+
+  // Web: F y Esc salen del modo presentación. Esc viaja por el modal nativo
+  // en algunos navegadores; añadimos handler explícito por seguridad.
+  useKeyboardShortcut('f', () => navigation.goBack());
+  useKeyboardShortcut('escape', () => navigation.goBack(), {
+    preventDefault: false,
+  });
   const { settings } = useSettings();
   const { chordsVisible, fontSize, fontFamily, notation } = settings;
 

--- a/mcm-app/components/BottomSheet.tsx
+++ b/mcm-app/components/BottomSheet.tsx
@@ -16,6 +16,7 @@ const nativeDriver = Platform.OS !== 'web';
 import { UIColors, Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useEscapeToClose } from '@/hooks/useEscapeToClose';
 
 const OFF_SCREEN = Dimensions.get('window').height;
 const DURATION = 300;
@@ -46,6 +47,8 @@ export default function BottomSheet({
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const bgColor = Colors[scheme ?? 'light'].background;
+
+  useEscapeToClose(visible, onClose);
 
   // Ref so the animation callback always calls the latest version of the prop
   // without needing it in the useEffect dependency array.

--- a/mcm-app/components/CommandPalette.tsx
+++ b/mcm-app/components/CommandPalette.tsx
@@ -1,0 +1,269 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Dialog, SearchField } from 'heroui-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { router } from 'expo-router';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+import { useEscapeToClose } from '@/hooks/useEscapeToClose';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { radii } from '@/constants/uiStyles';
+
+type MaterialIconName = React.ComponentProps<typeof MaterialIcons>['name'];
+
+interface Command {
+  id: string;
+  title: string;
+  subtitle?: string;
+  icon: MaterialIconName;
+  /** Path passed to `router.push`. Top-level routes only — sub-screens of
+   *  nested non-router stacks (cancionero / mas) aren't reachable directly. */
+  path: string;
+  /** Extra search terms (synonyms, abbreviations, related concepts). */
+  keywords?: string[];
+}
+
+const COMMANDS: Command[] = [
+  {
+    id: 'home',
+    title: 'Inicio',
+    subtitle: 'Pantalla principal',
+    icon: 'home',
+    path: '/',
+    keywords: ['home', 'principal', 'menú'],
+  },
+  {
+    id: 'cancionero',
+    title: 'Cantoral',
+    subtitle: 'Canciones con acordes',
+    icon: 'music-note',
+    path: '/cancionero',
+    keywords: ['canciones', 'songs', 'acordes', 'cantar', 'cancionero'],
+  },
+  {
+    id: 'calendario',
+    title: 'Calendario',
+    subtitle: 'Eventos y celebraciones',
+    icon: 'event',
+    path: '/calendario',
+    keywords: ['eventos', 'agenda', 'fechas', 'calendar'],
+  },
+  {
+    id: 'fotos',
+    title: 'Fotos',
+    subtitle: 'Galería de imágenes',
+    icon: 'photo-library',
+    path: '/fotos',
+    keywords: ['gallery', 'imágenes', 'galería', 'álbum'],
+  },
+  {
+    id: 'mas',
+    title: 'Más',
+    subtitle: 'Grupos, Materiales, Visitas...',
+    icon: 'apps',
+    path: '/mas',
+    keywords: ['más', 'mas', 'grupos', 'materiales', 'visitas', 'contactos'],
+  },
+  {
+    id: 'notifications',
+    title: 'Notificaciones',
+    icon: 'notifications',
+    path: '/notifications',
+    keywords: ['avisos', 'mensajes', 'noti'],
+  },
+  {
+    id: 'wordle',
+    title: 'Wordle',
+    subtitle: 'Juego diario',
+    icon: 'sports-esports',
+    path: '/wordle',
+    keywords: ['juego', 'game', 'palabras'],
+  },
+];
+
+function matchCommand(cmd: Command, query: string): boolean {
+  if (!query.trim()) return true;
+  const q = query.trim().toLowerCase();
+  if (cmd.title.toLowerCase().includes(q)) return true;
+  if (cmd.subtitle?.toLowerCase().includes(q)) return true;
+  return Boolean(cmd.keywords?.some((k) => k.toLowerCase().includes(q)));
+}
+
+/**
+ * Global command palette (Cmd/Ctrl + K). Web-only — returns `null` on
+ * native. Lives at root so the shortcut works from anywhere in the app.
+ *
+ * v1 only navigates between top-level expo-router screens. Deep-linking
+ * into nested stacks (e.g. specific song detail) needs the cancionero/mas
+ * stacks to expose their navigation ref — out of scope here.
+ */
+export default function CommandPalette() {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(scheme), [scheme]);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const handleOpen = useCallback(() => {
+    setQuery('');
+    setOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  useKeyboardShortcut('k', handleOpen, { meta: true });
+  useEscapeToClose(open, handleClose);
+
+  const filtered = useMemo(
+    () => COMMANDS.filter((c) => matchCommand(c, query)),
+    [query],
+  );
+
+  const handleSelect = useCallback((path: string) => {
+    setOpen(false);
+    setQuery('');
+    // expo-router accepts string paths; cast required because the typed
+    // Href union doesn't include arbitrary tab-internal routes.
+    router.push(path as never);
+  }, []);
+
+  if (Platform.OS !== 'web') return null;
+
+  return (
+    <Dialog
+      isOpen={open}
+      onOpenChange={(next) => {
+        if (!next) handleClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content>
+          <View style={styles.body}>
+            <SearchField value={query} onChange={setQuery}>
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input placeholder="Saltar a..." autoFocus />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+            <ScrollView
+              style={styles.list}
+              contentContainerStyle={styles.listContent}
+              keyboardShouldPersistTaps="handled"
+            >
+              {filtered.map((cmd) => (
+                <Pressable
+                  key={cmd.id}
+                  onPress={() => handleSelect(cmd.path)}
+                  style={({ pressed }) => [
+                    styles.item,
+                    pressed && styles.itemPressed,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={cmd.title}
+                >
+                  <View style={styles.itemIcon}>
+                    <MaterialIcons
+                      name={cmd.icon}
+                      size={20}
+                      color={isDark ? '#AEAEB2' : '#636366'}
+                    />
+                  </View>
+                  <View style={styles.itemText}>
+                    <Text style={styles.itemTitle}>{cmd.title}</Text>
+                    {cmd.subtitle ? (
+                      <Text style={styles.itemSubtitle}>{cmd.subtitle}</Text>
+                    ) : null}
+                  </View>
+                </Pressable>
+              ))}
+              {filtered.length === 0 ? (
+                <View style={styles.empty}>
+                  <Text style={styles.emptyText}>Sin resultados</Text>
+                </View>
+              ) : null}
+            </ScrollView>
+            <View style={styles.footer}>
+              <Text style={styles.footerHint}>
+                Esc para cerrar · ⌘K para abrir
+              </Text>
+            </View>
+          </View>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  );
+}
+
+const createStyles = (scheme: 'light' | 'dark' | null) => {
+  const isDark = scheme === 'dark';
+  const theme = Colors[scheme ?? 'light'];
+  return StyleSheet.create({
+    body: {
+      gap: 10,
+      paddingVertical: 4,
+    },
+    list: {
+      maxHeight: 360,
+    },
+    listContent: {
+      gap: 2,
+      paddingVertical: 4,
+    },
+    item: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      borderRadius: radii.md,
+      gap: 12,
+    },
+    itemPressed: {
+      backgroundColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
+    },
+    itemIcon: {
+      width: 28,
+      alignItems: 'center',
+    },
+    itemText: {
+      flex: 1,
+    },
+    itemTitle: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: theme.text,
+    },
+    itemSubtitle: {
+      fontSize: 12,
+      color: isDark ? '#AEAEB2' : '#8E8E93',
+      marginTop: 2,
+    },
+    empty: {
+      paddingVertical: 24,
+      alignItems: 'center',
+    },
+    emptyText: {
+      fontSize: 14,
+      color: isDark ? '#8E8E93' : '#8E8E93',
+      fontStyle: 'italic',
+    },
+    footer: {
+      paddingTop: 6,
+      alignItems: 'center',
+    },
+    footerHint: {
+      fontSize: 11,
+      color: isDark ? '#636366' : '#A0A0A8',
+      letterSpacing: 0.3,
+    },
+  });
+};

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useMemo } from 'react';
+import React, { useCallback, useRef, useEffect, useMemo } from 'react';
 import {
   TouchableOpacity,
   Text,
@@ -10,11 +10,17 @@ import { Swipeable } from 'react-native-gesture-handler';
 import { useSelectedSongs } from '../contexts/SelectedSongsContext';
 import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useContextMenu } from '@/hooks/useContextMenu';
 import { useSettings } from '../contexts/SettingsContext';
 import { convertChord } from '../utils/chordNotation';
 import { transposeKey, transposeLabel } from '../utils/transposeKey';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { Colors, StateColors, SwipeColors, KeyPillColors } from '@/constants/colors';
+import {
+  Colors,
+  StateColors,
+  SwipeColors,
+  KeyPillColors,
+} from '@/constants/colors';
 import { durations } from '@/constants/animations';
 
 // Type for song data
@@ -37,7 +43,12 @@ interface SongListItemProps {
 }
 
 const SongListItem: React.FC<SongListItemProps> = React.memo(
-  function SongListItem({ song, onPress, onLongPress, isSearchAllMode = false }) {
+  function SongListItem({
+    song,
+    onPress,
+    onLongPress,
+    isSearchAllMode = false,
+  }) {
     const { addSong, removeSong, isSongSelected, getSelectedSong } =
       useSelectedSongs();
     const { settings } = useSettings();
@@ -135,6 +146,14 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
 
     const cleanTitle = song.title.replace(/^\d+\.\s*/, '');
 
+    const contextHandler = useCallback(
+      () => onLongPress?.(song),
+      [onLongPress, song],
+    );
+    const contextMenuProps = useContextMenu(
+      onLongPress ? contextHandler : undefined,
+    );
+
     return (
       <Swipeable
         ref={swipeableRow}
@@ -153,10 +172,9 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
         <Animated.View style={[styles.songItemOuter, animatedStyle]}>
           <TouchableOpacity
             onPress={() => onPress(song)}
-            onLongPress={() => onLongPress?.(song)}
-            delayLongPress={400}
             style={styles.songItemInner}
             activeOpacity={0.6}
+            {...contextMenuProps}
           >
             <View style={styles.leftSection}>
               {isSelected && <View style={styles.selectedDot} />}

--- a/mcm-app/contexts/OverlayStackContext.tsx
+++ b/mcm-app/contexts/OverlayStackContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useCallback, useContext, useRef } from 'react';
+import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+
+export interface OverlayEntry {
+  /** Unique id (use `useId()` or any stable value). */
+  id: string;
+  /** Called when this overlay should close (e.g. user pressed Esc). */
+  onClose: () => void;
+}
+
+interface OverlayStackContextValue {
+  push: (entry: OverlayEntry) => void;
+  pop: (id: string) => void;
+  closeTop: () => boolean;
+}
+
+const OverlayStackContext = createContext<OverlayStackContextValue | null>(
+  null,
+);
+
+/**
+ * Maintains a LIFO stack of open overlays so a single global Esc handler
+ * can dismiss whichever sits on top. Each `useEscapeToClose` registers
+ * here when it opens and deregisters on close/unmount.
+ */
+export function OverlayStackProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const stackRef = useRef<OverlayEntry[]>([]);
+
+  const push = useCallback((entry: OverlayEntry) => {
+    stackRef.current = [
+      ...stackRef.current.filter((e) => e.id !== entry.id),
+      entry,
+    ];
+  }, []);
+
+  const pop = useCallback((id: string) => {
+    stackRef.current = stackRef.current.filter((e) => e.id !== id);
+  }, []);
+
+  const closeTop = useCallback(() => {
+    const top = stackRef.current[stackRef.current.length - 1];
+    if (!top) return false;
+    top.onClose();
+    return true;
+  }, []);
+
+  // Global Esc handler — closes the topmost registered overlay (web only).
+  useKeyboardShortcut('Escape', () => closeTop(), { preventDefault: false });
+
+  return (
+    <OverlayStackContext.Provider value={{ push, pop, closeTop }}>
+      {children}
+    </OverlayStackContext.Provider>
+  );
+}
+
+export function useOverlayStack(): OverlayStackContextValue {
+  const ctx = useContext(OverlayStackContext);
+  if (!ctx) {
+    // Outside a provider (rare in tests): no-op so the hook stays safe.
+    return {
+      push: () => {},
+      pop: () => {},
+      closeTop: () => false,
+    };
+  }
+  return ctx;
+}

--- a/mcm-app/hooks/useContextMenu.ts
+++ b/mcm-app/hooks/useContextMenu.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { Platform } from 'react-native';
+
+const LONG_PRESS_DELAY = 400;
+
+type WebContextMenuEvent = {
+  preventDefault?: () => void;
+};
+
+interface ContextMenuProps {
+  onLongPress?: () => void;
+  delayLongPress?: number;
+  onContextMenu?: (e: WebContextMenuEvent) => void;
+}
+
+/**
+ * Returns props to spread onto a pressable so it shows a contextual menu
+ * via long-press on native and via right-click on web. Pass `undefined`
+ * to disable.
+ *
+ * ```tsx
+ * const ctx = useContextMenu(() => openMenu(song));
+ * <TouchableOpacity onPress={...} {...ctx} />
+ * ```
+ */
+export function useContextMenu(
+  handler: (() => void) | undefined,
+): ContextMenuProps {
+  return useMemo(() => {
+    if (!handler) return {};
+    if (Platform.OS === 'web') {
+      return {
+        onContextMenu: (e: WebContextMenuEvent) => {
+          e?.preventDefault?.();
+          handler();
+        },
+      };
+    }
+    return { onLongPress: handler, delayLongPress: LONG_PRESS_DELAY };
+  }, [handler]);
+}

--- a/mcm-app/hooks/useEscapeToClose.ts
+++ b/mcm-app/hooks/useEscapeToClose.ts
@@ -1,0 +1,22 @@
+import { useEffect, useId, useRef } from 'react';
+import { useOverlayStack } from '@/contexts/OverlayStackContext';
+
+/**
+ * Registers the calling overlay in the global stack while `isOpen` is true.
+ * When Esc is pressed and this overlay sits on top, `onClose` fires.
+ *
+ * No-op on native — Esc is a desktop/web concept. The Modal's
+ * `onRequestClose` handles Android back-button separately.
+ */
+export function useEscapeToClose(isOpen: boolean, onClose: () => void): void {
+  const id = useId();
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const { push, pop } = useOverlayStack();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    push({ id, onClose: () => onCloseRef.current() });
+    return () => pop(id);
+  }, [isOpen, id, push, pop]);
+}

--- a/mcm-app/hooks/useKeyboardShortcut.ts
+++ b/mcm-app/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+export interface KeyboardShortcutOptions {
+  /** Require ⌘ (mac) / Ctrl (other). Default: false. */
+  meta?: boolean;
+  /** Require Shift. Default: false. */
+  shift?: boolean;
+  /** Require Alt/Option. Default: false. */
+  alt?: boolean;
+  /** Disable the listener without removing it from the call site. Default: false. */
+  disabled?: boolean;
+  /** Call `e.preventDefault()` before the handler. Default: true. */
+  preventDefault?: boolean;
+}
+
+type AnyKeyboardEvent = {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  preventDefault?: () => void;
+  target?: { tagName?: string; isContentEditable?: boolean } | null;
+};
+
+function isTypingTarget(target: AnyKeyboardEvent['target']): boolean {
+  if (!target) return false;
+  const tag = target.tagName?.toUpperCase();
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return Boolean(target.isContentEditable);
+}
+
+/**
+ * Registers a global keydown listener on web. No-op on native.
+ *
+ * `key` is matched case-insensitively against `event.key`. Pass an array to
+ * match any of several keys (useful for `['+', '=']`).
+ *
+ * The handler is skipped when focus is inside a text input — unless
+ * `meta: true`, since shortcuts like ⌘K should still work while typing.
+ */
+export function useKeyboardShortcut(
+  key: string | string[],
+  handler: (e: AnyKeyboardEvent) => void,
+  options: KeyboardShortcutOptions = {},
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const {
+    meta = false,
+    shift = false,
+    alt = false,
+    disabled = false,
+    preventDefault = true,
+  } = options;
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    if (disabled) return;
+    if (typeof window === 'undefined') return;
+
+    const keys = (Array.isArray(key) ? key : [key]).map((k) => k.toLowerCase());
+
+    const onKeyDown = (e: AnyKeyboardEvent) => {
+      const eventKey = (e.key || '').toLowerCase();
+      if (!keys.includes(eventKey)) return;
+
+      const metaPressed = Boolean(e.metaKey || e.ctrlKey);
+      if (meta !== metaPressed) return;
+      if (shift !== Boolean(e.shiftKey)) return;
+      if (alt !== Boolean(e.altKey)) return;
+
+      // Don't hijack normal typing — but ⌘-prefixed shortcuts still fire.
+      if (!meta && isTypingTarget(e.target)) return;
+
+      if (preventDefault) e.preventDefault?.();
+      handlerRef.current(e);
+    };
+
+    window.addEventListener('keydown', onKeyDown as never);
+    return () => window.removeEventListener('keydown', onKeyDown as never);
+  }, [key, meta, shift, alt, disabled, preventDefault]);
+}


### PR DESCRIPTION
Hasta ahora solo la rama raíz centraba contenido en web (vía ScreenHero),
y el resto de las 5 ramas de render quedaban sin centrar y sin un header
consistente. Sigue el patrón ya establecido en MaterialesScreen y
ContactosScreen.

Cambios por rama:
- Skeleton de categoría: añade hero con título = nombre de categoría
- Vista de grupo: hero con título = grupo.nombre, kicker = categoría,
  left = back button (sustituye al backWrapper)
- Búsqueda: hero con título "Buscar" y back button que limpia el estado
- Categoría/lista de grupos: hero con título = categoría, left = back
- Eliminados estilos muertos: backWrapper, groupHeader, groupTitle