### PR TITLE
fix(fotos): tratar Fotos en MasHome overflow como tab de plataforma

### DIFF
--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -27,7 +27,6 @@ import ComidaScreen from '../screens/ComidaScreen';
 import ComidaWebScreen from '../screens/ComidaWebScreen';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
 import { getEvent } from '@/constants/events';
-import { TabHeaderColors } from '@/constants/colors';
 
 /**
  * Route params comunes a todas las pantallas de un evento (Jubileo u otros
@@ -290,21 +289,12 @@ export default function MasTab() {
           name="Fotos"
           component={AlbumListScreen}
           options={{
-            title: 'Fotos',
-            headerStyle:
-              Platform.OS === 'ios'
-                ? { backgroundColor: 'transparent' }
-                : { backgroundColor: TabHeaderColors.fotos },
-            headerTintColor: Platform.OS === 'ios' ? '#1a1a1a' : '#fff',
-            headerTitleStyle: {
-              fontWeight: '700' as const,
-              fontSize: 18,
-              color: Platform.OS === 'ios' ? '#1a1a1a' : '#fff',
-            },
-            headerBackground: () =>
-              Platform.OS === 'ios' ? (
-                <GlassHeader tintColor={TabHeaderColors.fotos} />
-              ) : undefined,
+            // Fotos se comporta como un tab "de plataforma" (cantoral,
+            // calendario): pinta su franja de color desde TabScreenWrapper
+            // dentro de la propia pantalla en lugar de un header pesado.
+            // El gesto de swipe-back de iOS / botón nativo Android cubren
+            // la navegación de vuelta.
+            headerShown: false,
           }}
         />
         <Stack.Screen

--- a/mcm-app/app/screens/AlbumListScreen.tsx
+++ b/mcm-app/app/screens/AlbumListScreen.tsx
@@ -9,13 +9,13 @@ import {
   Platform,
 } from 'react-native';
 import { Button, Spinner } from 'heroui-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import TabScreenWrapper from '@/components/ui/TabScreenWrapper.ios';
 import AlbumCard from '@/components/AlbumCard';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import OfflineBanner from '@/components/OfflineBanner';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
-import { Colors as ThemeColors } from '@/constants/colors';
+import { Colors as ThemeColors, TabHeaderColors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 const ALBUMS_PER_PAGE = 4;
@@ -132,12 +132,13 @@ export default function AlbumListScreen() {
   }
 
   return (
-    <SafeAreaView
+    <TabScreenWrapper
       style={[
         styles.container,
         { backgroundColor: ThemeColors[scheme ?? 'light'].background },
       ]}
-      edges={['bottom']}
+      edges={['top']}
+      tintColor={TabHeaderColors.fotos}
     >
       {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
       <FlatList
@@ -160,13 +161,13 @@ export default function AlbumListScreen() {
         contentContainerStyle={[
           styles.listContent,
           { maxWidth: width > 1200 ? 1600 : 1200, alignSelf: 'center' },
-          Platform.OS === 'ios' && { paddingBottom: 20 },
+          Platform.OS === 'ios' && { paddingBottom: 100 },
         ]}
         onEndReached={loadMoreAlbums}
         onEndReachedThreshold={0.5}
         ListFooterComponent={renderFooter}
       />
-    </SafeAreaView>
+    </TabScreenWrapper>
   );
 }
 

--- a/mcm-app/components/ui/TabScreenWrapper.ios.tsx
+++ b/mcm-app/components/ui/TabScreenWrapper.ios.tsx
@@ -7,14 +7,20 @@ interface TabScreenWrapperProps {
   children: React.ReactNode;
   style?: any;
   edges?: ('top' | 'right' | 'bottom' | 'left')[];
+  /** Override the tint color derived from the current tab pathname. Useful
+   *  cuando la pantalla se alcanza desde un stack (p.ej. Fotos vía MasHome
+   *  overflow en iOS) y el pathname no coincide con un tab conocido. */
+  tintColor?: string;
 }
 
 export default function TabScreenWrapper({
   children,
   style,
   edges = ['top'],
+  tintColor,
 }: TabScreenWrapperProps) {
   const tabColor = useCurrentTabColor();
+  const resolvedColor = tintColor ?? tabColor;
 
   if (Platform.OS !== 'ios') {
     // On Android/Web, just use regular SafeAreaView
@@ -28,8 +34,8 @@ export default function TabScreenWrapper({
   // On iOS, add the color bar at the top
   return (
     <View style={styles.container}>
-      {tabColor && (
-        <View style={[styles.colorBar, { backgroundColor: tabColor }]} />
+      {resolvedColor && (
+        <View style={[styles.colorBar, { backgroundColor: resolvedColor }]} />
       )}
       <SafeAreaView style={[styles.content, style]} edges={edges}>
         {children}


### PR DESCRIPTION
Cuando un perfil tiene más de 5 tabs visibles en iOS, "fotos" cae en el
overflow y se accede vía MasStack > Fotos > AlbumListScreen. La pantalla
mostraba un header pesado rojo (GlassHeader con tint MIC) que rompía la
coherencia con el resto de tabs "de plataforma" (cantoral, calendario):
estos solo añaden una franja fina de color arriba a través de
TabScreenWrapper, sin header.

- TabScreenWrapper.ios admite ahora un prop opcional `tintColor` para
  forzar el color cuando el pathname no coincide con un tab conocido.
- AlbumListScreen envuelve su contenido en TabScreenWrapper con el
  color rojo de fotos (TabHeaderColors.fotos), igualando el aspecto
  del tab "fotos" cuando es accesible directamente.
- En el stack de Más, la screen Fotos pasa a `headerShown: false`
  (como Comunica). La navegación de vuelta se cubre con el swipe-back
  de iOS / el botón nativo de Android.