### PR TITLE
Rebuild fullscreen auto-scroller from scratch

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,24 @@
 
 ---
 
+## 2026-05-21 — Auto-scroll del cantoral en pantalla completa, reescrito
+
+- **Problema**: el desplazador automático del modo pantalla completa era frágil. Slider vertical con gestos en conflicto con `PressableFeedback`, bucle frame-based (la velocidad cambiaba según refresh rate), sin persistencia entre sesiones, sin auto-pausa al final del documento ni cuando el usuario tocaba la pantalla, y dos bucles distintos en lados opuestos del puente nativo.
+- **Solución**: nuevo hook `hooks/useAutoScroller.ts` que aísla toda la lógica del desplazamiento y expone una API limpia (`isPlaying`, `speedIndex`, `setSpeedIndex`, `play/pause/toggle`, handlers de WebView). En la pantalla, el slider vertical se sustituye por un selector segmentado horizontal de 5 niveles ("Muy lento" … "Muy rápido").
+- **Mejoras técnicas**:
+  - **Time-based (px/s)** en lugar de frame-based: misma velocidad real en pantallas a 60Hz, 90Hz o 120Hz.
+  - **Acumulación sub-píxel** + **rampa de aceleración/frenado**: el inicio/parada es suave y los niveles bajos producen un movimiento continuo, no a saltos.
+  - **Bucle en la WebView**: en iOS/Android el rAF vive dentro de la propia WebView (cero overhead del puente). El lado React sólo envía la velocidad objetivo cuando cambia. Para web, rAF en lado React sobre el `div` scrollable.
+  - **Auto-pausa**: cuando el usuario interactúa manualmente (touch/wheel/mousedown/keydown) o al llegar al final del documento; en nativo el controlador postea un mensaje (`postMessage`) y React sincroniza estado.
+  - **Persistencia**: nivel de velocidad guardado en AsyncStorage (`@mcm_song_autoscroll_speed_index`); el usuario recupera su preferencia al volver a entrar.
+  - **Resiliencia**: `__mcmScrollInstalled` guard evita doble inyección; `onLoadEnd` reinyecta la velocidad si la WebView recarga con la reproducción activa.
+- **UX**: indicador discreto del nivel actual encima del play, panel de velocidades que aparece al pulsar y se oculta a los 3.2s, haptics (`Medium` en play/pause, `Light` al cambiar de nivel), atajos de teclado en web (`Espacio` play/pause, `↑/↓` subir/bajar velocidad), accesibilidad (`accessibilityState`, etiquetas).
+- **Archivos**:
+  - Nuevo: `hooks/useAutoScroller.ts`.
+  - Reescrito: `app/screens/SongFullscreenScreen.tsx` (eliminados `VerticalSlider`, `SCROLL_CONTROLLER_JS`, estado/refs/efectos del scroll inline).
+
+---
+
 ## 2026-05-20 — Atajos de teclado en web: Cmd+K, Esc y cantoral
 
 - **Cmd/Ctrl+K**: nuevo Command Palette global (web-only) montado en `app/_layout.tsx`. Lista las pantallas top-level del expo-router con sinónimos en castellano e inglés para búsqueda rápida.

--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, Platform, Animated } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Platform,
+  Animated,
+  Pressable,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RouteProp,
@@ -9,162 +16,222 @@ import {
 import { WebView } from 'react-native-webview';
 import { BlurView } from 'expo-blur';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import * as Haptics from 'expo-haptics';
 import { PressableFeedback } from 'heroui-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Reanimated, {
-  useSharedValue,
-  useAnimatedStyle,
-  runOnJS,
-} from 'react-native-reanimated';
 import { RootStackParamList } from '../(tabs)/cancionero';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSongProcessor } from '../../hooks/useSongProcessor';
 import { useColorScheme } from '../../hooks/useColorScheme';
 import { Colors } from '../../constants/colors';
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut';
+import {
+  AUTO_SCROLL_SPEEDS,
+  AUTO_SCROLL_CONTROLLER_JS,
+  useAutoScroller,
+} from '@/hooks/useAutoScroller';
 
 type SongFullscreenRouteProp = RouteProp<RootStackParamList, 'SongFullscreen'>;
 
-// Pixels per frame at ~60fps
-const MIN_SPEED_PPF = 0.1; // ~6 px/s — very slow
-const MAX_SPEED_PPF = 3.8; // ~228 px/s — fast
+const isIOS = Platform.OS === 'ios';
+const isWeb = Platform.OS === 'web';
 
-// Injected into WebView on page load — drives rAF scroll loop
-const SCROLL_CONTROLLER_JS =
-  '(function(){var _v=0,_a=0,_r=null;' +
-  'function _t(){_a+=_v;var p=Math.floor(_a);' +
-  'if(p>0){window.scrollBy(0,p);_a-=p;}' +
-  'if(_v>0){_r=requestAnimationFrame(_t);}else{_r=null;}}' +
-  'window.__mcmScroll=function(v){_v=v;if(v>0&&!_r){_r=requestAnimationFrame(_t);}};' +
-  '})();true;';
+const triggerHaptic = (style: Haptics.ImpactFeedbackStyle) => {
+  if (Platform.OS === 'web') return;
+  Haptics.impactAsync(style).catch(() => {});
+};
 
-// Vertical slider geometry
-const SLIDER_H = 130; // draggable range height (px)
-const THUMB_D = 22; // thumb diameter
-const DRAG_RANGE = SLIDER_H - THUMB_D;
-const TRACK_W = 3;
+// ─── Controles de auto-scroll (segmented + play) ─────────────────────────────
 
-/**
- * Cross-platform vertical slider built on react-native-gesture-handler +
- * Reanimated. Using RNGH (instead of PanResponder) avoids gesture conflicts
- * with the surrounding heroui-native PressableFeedback components, which is
- * what kept breaking the previous implementation. value: 0..1
- */
-function VerticalSlider({
-  value,
-  onChange,
-  onStart,
-  onEnd,
-}: {
-  value: number;
-  onChange: (v: number) => void;
-  onStart?: () => void;
-  onEnd?: () => void;
-}) {
-  const sv = useSharedValue(value);
-  const start = useSharedValue(value);
+interface AutoScrollControlsProps {
+  isPlaying: boolean;
+  speedIndex: number;
+  onToggle: () => void;
+  onSelectSpeed: (i: number) => void;
+  isDark: boolean;
+  bottom: number;
+}
+
+function AutoScrollControls({
+  isPlaying,
+  speedIndex,
+  onToggle,
+  onSelectSpeed,
+  isDark,
+  bottom,
+}: AutoScrollControlsProps) {
+  const [expanded, setExpanded] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelHideTimer = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleHide = useCallback(() => {
+    cancelHideTimer();
+    hideTimerRef.current = setTimeout(() => setExpanded(false), 3200);
+  }, [cancelHideTimer]);
+
+  const showPicker = useCallback(() => {
+    setExpanded(true);
+    scheduleHide();
+  }, [scheduleHide]);
 
   useEffect(() => {
-    sv.value = value;
-  }, [value, sv]);
+    Animated.timing(fadeAnim, {
+      toValue: expanded ? 1 : 0,
+      duration: expanded ? 180 : 240,
+      useNativeDriver: true,
+    }).start();
+    if (!expanded) cancelHideTimer();
+  }, [expanded, fadeAnim, cancelHideTimer]);
 
-  const pan = Gesture.Pan()
-    .minDistance(0)
-    .onBegin(() => {
-      start.value = sv.value;
-      if (onStart) runOnJS(onStart)();
-    })
-    .onUpdate((e) => {
-      // dy > 0 = moved down = slower; top = fast (value 1)
-      const next = Math.max(
-        0,
-        Math.min(1, start.value - e.translationY / DRAG_RANGE),
-      );
-      sv.value = next;
-      runOnJS(onChange)(next);
-    })
-    .onFinalize(() => {
-      if (onEnd) runOnJS(onEnd)();
-    });
+  useEffect(() => () => cancelHideTimer(), [cancelHideTimer]);
 
-  // Tap on the track to jump to that position.
-  const tap = Gesture.Tap().onEnd((e) => {
-    const raw = 1 - (e.y - THUMB_D / 2) / DRAG_RANGE;
-    const next = Math.max(0, Math.min(1, raw));
-    sv.value = next;
-    runOnJS(onChange)(next);
-    if (onEnd) runOnJS(onEnd)();
-  });
+  const handlePlay = useCallback(() => {
+    triggerHaptic(Haptics.ImpactFeedbackStyle.Medium);
+    onToggle();
+    // Al iniciar reproducción mostramos brevemente el selector como pista visual.
+    if (!isPlaying) showPicker();
+  }, [onToggle, isPlaying, showPicker]);
 
-  const gesture = Gesture.Exclusive(pan, tap);
+  const handleSelectSpeed = useCallback(
+    (i: number) => {
+      if (i !== speedIndex) triggerHaptic(Haptics.ImpactFeedbackStyle.Light);
+      onSelectSpeed(i);
+      showPicker();
+    },
+    [onSelectSpeed, speedIndex, showPicker],
+  );
 
-  const thumbStyle = useAnimatedStyle(() => ({
-    top: (1 - sv.value) * DRAG_RANGE,
-  }));
-  const fillStyle = useAnimatedStyle(() => ({
-    top: (1 - sv.value) * DRAG_RANGE + THUMB_D / 2,
-    height: sv.value * DRAG_RANGE,
-  }));
+  const currentLabel = AUTO_SCROLL_SPEEDS[speedIndex].label;
 
   return (
-    <GestureDetector gesture={gesture}>
-      <View
-        style={sliderStyles.container}
-        // Extra hit area so small thumbs are easy to grab
-        hitSlop={{ top: 8, bottom: 8, left: 14, right: 14 }}
+    <View style={[styles.controlsCluster, { bottom }]} pointerEvents="box-none">
+      {/* Selector de velocidad — pill horizontal, sólo visible al interactuar */}
+      <Animated.View
+        style={[styles.speedPanel, { opacity: fadeAnim }]}
+        pointerEvents={expanded ? 'auto' : 'none'}
       >
-        {/* Track background */}
-        <View style={sliderStyles.trackBg} />
-        {/* Filled portion: from thumb down to bottom = the selected speed level */}
-        <Reanimated.View style={[sliderStyles.trackFill, fillStyle]} />
-        {/* Thumb */}
-        <Reanimated.View style={[sliderStyles.thumb, thumbStyle]} />
-      </View>
-    </GestureDetector>
+        <TranslucentBg isDark={isDark} style={styles.speedPanelBg} />
+        <Text style={styles.speedHeading} numberOfLines={1}>
+          {currentLabel}
+        </Text>
+        <View
+          style={styles.segmentRow}
+          accessibilityRole="adjustable"
+          accessibilityLabel={`Velocidad de auto-scroll: ${currentLabel}`}
+        >
+          {AUTO_SCROLL_SPEEDS.map((s, i) => {
+            const selected = i === speedIndex;
+            return (
+              <Pressable
+                key={s.label}
+                style={({ pressed }) => [
+                  styles.segment,
+                  selected && styles.segmentSelected,
+                  pressed && styles.segmentPressed,
+                ]}
+                onPress={() => handleSelectSpeed(i)}
+                hitSlop={6}
+                accessibilityLabel={s.label}
+                accessibilityState={{ selected }}
+              >
+                <Text
+                  style={[
+                    styles.segmentText,
+                    selected && styles.segmentTextSelected,
+                  ]}
+                >
+                  {i + 1}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </Animated.View>
+
+      {/* Play / Pause + acceso al selector con long-press */}
+      <PressableFeedback
+        style={styles.playButton}
+        onPress={handlePlay}
+        onLongPress={() => {
+          triggerHaptic(Haptics.ImpactFeedbackStyle.Light);
+          showPicker();
+        }}
+        accessibilityLabel={
+          isPlaying ? 'Pausar desplazamiento' : 'Iniciar desplazamiento'
+        }
+        accessibilityRole="button"
+      >
+        <PressableFeedback.Scale />
+        <TranslucentBg isDark={isDark} style={styles.playButtonBg} />
+        <MaterialIcons
+          name={isPlaying ? 'pause' : 'play-arrow'}
+          color="#FFFFFF"
+          size={28}
+        />
+        {/* Indicador discreto del nivel actual sobre el botón */}
+        <View style={styles.levelBadge} pointerEvents="none">
+          <Text style={styles.levelBadgeText}>{speedIndex + 1}</Text>
+        </View>
+      </PressableFeedback>
+    </View>
   );
 }
 
-const sliderStyles = StyleSheet.create({
-  container: {
-    width: THUMB_D,
-    height: SLIDER_H,
-  },
-  trackBg: {
-    position: 'absolute',
-    top: THUMB_D / 2,
-    bottom: THUMB_D / 2,
-    left: (THUMB_D - TRACK_W) / 2,
-    width: TRACK_W,
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    borderRadius: TRACK_W / 2,
-  },
-  trackFill: {
-    position: 'absolute',
-    left: (THUMB_D - TRACK_W) / 2,
-    width: TRACK_W,
-    backgroundColor: 'rgba(255,255,255,0.8)',
-    borderRadius: TRACK_W / 2,
-  },
-  thumb: {
-    position: 'absolute',
-    left: 0,
-    width: THUMB_D,
-    height: THUMB_D,
-    borderRadius: THUMB_D / 2,
-    backgroundColor: '#FFFFFF',
-    ...Platform.select({
-      default: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 1 },
-        shadowOpacity: 0.35,
-        shadowRadius: 3,
-        elevation: 3,
-      },
-    }),
-  },
-});
+// ─── Fondo translúcido reutilizable ──────────────────────────────────────────
 
-// ─────────────────────────────────────────────────────────────────────────────
+function TranslucentBg({ isDark, style }: { isDark: boolean; style?: object }) {
+  if (isIOS) {
+    return (
+      <>
+        <BlurView
+          tint={isDark ? 'dark' : 'light'}
+          intensity={60}
+          style={[StyleSheet.absoluteFill, style]}
+        />
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              backgroundColor: isDark
+                ? 'rgba(20,20,22,0.35)'
+                : 'rgba(0,0,0,0.22)',
+            },
+            style,
+          ]}
+        />
+      </>
+    );
+  }
+  return (
+    <View
+      style={[
+        StyleSheet.absoluteFill,
+        isWeb
+          ? ({
+              backgroundColor: isDark
+                ? 'rgba(28,28,30,0.55)'
+                : 'rgba(0,0,0,0.42)',
+              backdropFilter: 'blur(18px)',
+              WebkitBackdropFilter: 'blur(18px)',
+            } as any)
+          : {
+              backgroundColor: isDark
+                ? 'rgba(40,40,42,0.82)'
+                : 'rgba(0,0,0,0.62)',
+            },
+        style,
+      ]}
+    />
+  );
+}
+
+// ─── Pantalla ────────────────────────────────────────────────────────────────
 
 export default function SongFullscreenScreen({
   route,
@@ -178,12 +245,12 @@ export default function SongFullscreenScreen({
   const isDark = scheme === 'dark';
   const theme = Colors[scheme ?? 'light'];
 
-  // Web: F y Esc salen del modo presentación. Esc viaja por el modal nativo
-  // en algunos navegadores; añadimos handler explícito por seguridad.
+  // Web: F y Esc salen del modo presentación.
   useKeyboardShortcut('f', () => navigation.goBack());
   useKeyboardShortcut('escape', () => navigation.goBack(), {
     preventDefault: false,
   });
+
   const { settings } = useSettings();
   const { chordsVisible, fontSize, fontFamily, notation } = settings;
 
@@ -204,24 +271,24 @@ export default function SongFullscreenScreen({
     bottomInset: Math.max(insets.bottom, 16) + 96,
   });
 
-  const webViewRef = useRef<WebView>(null);
-  const divRef = useRef<HTMLDivElement | null>(null);
-  const [autoScroll, setAutoScroll] = useState(false);
-  const [speedFactor, setSpeedFactor] = useState(0.35);
-  const [controlsVisible, setControlsVisible] = useState(false);
-  const controlsOpacity = useRef(new Animated.Value(0)).current;
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isDraggingRef = useRef(false);
+  const webViewRef = useRef<WebView | null>(null);
+  const webContainerRef = useRef<HTMLDivElement | null>(null);
 
-  // Refs for fluid web rAF scroll (avoid stale closures)
-  const webRafRef = useRef<number | null>(null);
-  const webAccRef = useRef(0);
-  const autoScrollRef = useRef(autoScroll);
-  const speedFactorRef = useRef(speedFactor);
-  autoScrollRef.current = autoScroll;
-  speedFactorRef.current = speedFactor;
+  const autoScroll = useAutoScroller({
+    webViewRef,
+    webContainerRef,
+  });
 
-  // Fade-in entry
+  // Atajos de teclado: espacio = play/pause, ↑/↓ = subir/bajar velocidad.
+  useKeyboardShortcut(' ', () => autoScroll.toggle());
+  useKeyboardShortcut('arrowup', () =>
+    autoScroll.setSpeedIndex(autoScroll.speedIndex + 1),
+  );
+  useKeyboardShortcut('arrowdown', () =>
+    autoScroll.setSpeedIndex(autoScroll.speedIndex - 1),
+  );
+
+  // Fade-in de entrada
   const fadeAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -231,139 +298,8 @@ export default function SongFullscreenScreen({
     }).start();
   }, [fadeAnim]);
 
-  const showControls = useCallback(() => {
-    setControlsVisible(true);
-    Animated.timing(controlsOpacity, {
-      toValue: 1,
-      duration: 180,
-      useNativeDriver: true,
-    }).start();
-
-    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-    // Don't schedule auto-hide while the user is dragging the slider —
-    // hiding mid-drag would unmount the gesture target.
-    if (isDraggingRef.current) return;
-    hideTimeoutRef.current = setTimeout(() => {
-      Animated.timing(controlsOpacity, {
-        toValue: 0,
-        duration: 280,
-        useNativeDriver: true,
-      }).start(() => setControlsVisible(false));
-    }, 2400);
-  }, [controlsOpacity]);
-
-  const handleSliderStart = useCallback(() => {
-    isDraggingRef.current = true;
-    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-  }, []);
-  const handleSliderEnd = useCallback(() => {
-    isDraggingRef.current = false;
-    showControls();
-  }, [showControls]);
-
-  // Web: fluid rAF scroll loop driven from React side
-  useEffect(() => {
-    if (Platform.OS !== 'web') return;
-    if (webRafRef.current !== null) {
-      cancelAnimationFrame(webRafRef.current);
-      webRafRef.current = null;
-    }
-    if (!autoScroll) return;
-    webAccRef.current = 0;
-    const ppf = MIN_SPEED_PPF + speedFactor * (MAX_SPEED_PPF - MIN_SPEED_PPF);
-    const step = () => {
-      webAccRef.current += ppf;
-      const px = Math.floor(webAccRef.current);
-      if (px >= 1) {
-        divRef.current?.scrollBy({ top: px });
-        webAccRef.current -= px;
-      }
-      webRafRef.current = requestAnimationFrame(step);
-    };
-    webRafRef.current = requestAnimationFrame(step);
-    return () => {
-      if (webRafRef.current !== null) cancelAnimationFrame(webRafRef.current);
-    };
-  }, [autoScroll, speedFactor]);
-
-  // Native WebView: send velocity to injected rAF controller
-  useEffect(() => {
-    if (Platform.OS === 'web') return;
-    const ppf = MIN_SPEED_PPF + speedFactor * (MAX_SPEED_PPF - MIN_SPEED_PPF);
-    webViewRef.current?.injectJavaScript(
-      `if(window.__mcmScroll)window.__mcmScroll(${autoScroll ? ppf : 0});true;`,
-    );
-  }, [autoScroll, speedFactor]);
-
-  useEffect(() => {
-    return () => {
-      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-    };
-  }, []);
-
-  // Re-apply velocity after WebView reloads (e.g. when songHtml changes)
-  const handleWebViewLoad = useCallback(() => {
-    if (!autoScrollRef.current) return;
-    const ppf =
-      MIN_SPEED_PPF + speedFactorRef.current * (MAX_SPEED_PPF - MIN_SPEED_PPF);
-    webViewRef.current?.injectJavaScript(
-      `if(window.__mcmScroll)window.__mcmScroll(${ppf});true;`,
-    );
-  }, []);
-
-  const isIOS = Platform.OS === 'ios';
-  const isWeb = Platform.OS === 'web';
   const closeTop = Math.max(insets.top, 12) + 8;
   const controlsBottom = Math.max(insets.bottom, 12) + 16;
-
-  const speedLabel = (() => {
-    if (speedFactor < 0.2) return 'Lento';
-    if (speedFactor < 0.55) return 'Normal';
-    if (speedFactor < 0.85) return 'Rápido';
-    return 'Muy rápido';
-  })();
-
-  const TranslucentBg = ({ style }: { style?: object }) =>
-    isIOS ? (
-      <>
-        <BlurView
-          tint={isDark ? 'dark' : 'light'}
-          intensity={60}
-          style={[StyleSheet.absoluteFill, style]}
-        />
-        <View
-          style={[
-            StyleSheet.absoluteFill,
-            {
-              backgroundColor: isDark
-                ? 'rgba(20,20,22,0.35)'
-                : 'rgba(0,0,0,0.22)',
-            },
-            style,
-          ]}
-        />
-      </>
-    ) : (
-      <View
-        style={[
-          StyleSheet.absoluteFill,
-          isWeb
-            ? ({
-                backgroundColor: isDark
-                  ? 'rgba(28,28,30,0.55)'
-                  : 'rgba(0,0,0,0.42)',
-                backdropFilter: 'blur(18px)',
-                WebkitBackdropFilter: 'blur(18px)',
-              } as any)
-            : {
-                backgroundColor: isDark
-                  ? 'rgba(40,40,42,0.82)'
-                  : 'rgba(0,0,0,0.62)',
-              },
-          style,
-        ]}
-      />
-    );
 
   return (
     <Animated.View
@@ -372,11 +308,11 @@ export default function SongFullscreenScreen({
         { backgroundColor: theme.background, opacity: fadeAnim },
       ]}
     >
-      {/* Song content — fills the screen; padding applied inside HTML */}
+      {/* Contenido de la canción */}
       <View style={styles.contentWrapper}>
         {isWeb ? (
           <div
-            ref={divRef}
+            ref={webContainerRef}
             style={webContainerStyle as any}
             dangerouslySetInnerHTML={{ __html: songHtml }}
           />
@@ -389,66 +325,33 @@ export default function SongFullscreenScreen({
             showsVerticalScrollIndicator={false}
             contentInsetAdjustmentBehavior="never"
             automaticallyAdjustContentInsets={false}
-            injectedJavaScript={SCROLL_CONTROLLER_JS}
-            onLoadEnd={handleWebViewLoad}
+            injectedJavaScript={AUTO_SCROLL_CONTROLLER_JS}
+            onLoadEnd={autoScroll.handleWebViewLoad}
+            onMessage={autoScroll.handleWebViewMessage}
           />
         )}
       </View>
 
-      {/* Close button — top right */}
+      {/* Cerrar — esquina superior derecha */}
       <PressableFeedback
         style={[styles.closeButton, { top: closeTop }]}
         onPress={() => navigation.goBack()}
         accessibilityLabel="Cerrar pantalla completa"
       >
         <PressableFeedback.Scale />
-        <TranslucentBg style={{ borderRadius: 20 }} />
+        <TranslucentBg isDark={isDark} style={{ borderRadius: 20 }} />
         <MaterialIcons name="close" color="#FFFFFF" size={22} />
       </PressableFeedback>
 
-      {/* Controls cluster — bottom right, vertical stack */}
-      <View
-        style={[styles.controlsCluster, { bottom: controlsBottom }]}
-        pointerEvents="box-none"
-      >
-        {/* Speed slider — appears above play button when controls are visible */}
-        {controlsVisible && (
-          <Animated.View
-            style={[styles.speedPill, { opacity: controlsOpacity }]}
-            pointerEvents="auto"
-          >
-            <TranslucentBg style={{ borderRadius: 24 }} />
-            <Text style={styles.speedLabel} numberOfLines={1}>
-              {speedLabel}
-            </Text>
-            <VerticalSlider
-              value={speedFactor}
-              onChange={setSpeedFactor}
-              onStart={handleSliderStart}
-              onEnd={handleSliderEnd}
-            />
-          </Animated.View>
-        )}
-
-        {/* Play / pause */}
-        <PressableFeedback
-          style={styles.playButton}
-          onPress={() => {
-            setAutoScroll((s: boolean) => !s);
-            showControls();
-          }}
-          onLongPress={() => showControls()}
-          accessibilityLabel={autoScroll ? 'Pausar scroll' : 'Iniciar scroll'}
-        >
-          <PressableFeedback.Scale />
-          <TranslucentBg style={{ borderRadius: 28 }} />
-          <MaterialIcons
-            name={autoScroll ? 'pause' : 'play-arrow'}
-            color="#FFFFFF"
-            size={28}
-          />
-        </PressableFeedback>
-      </View>
+      {/* Controles de auto-scroll — esquina inferior derecha */}
+      <AutoScrollControls
+        isPlaying={autoScroll.isPlaying}
+        speedIndex={autoScroll.speedIndex}
+        onToggle={autoScroll.toggle}
+        onSelectSpeed={autoScroll.setSpeedIndex}
+        isDark={isDark}
+        bottom={controlsBottom}
+      />
     </Animated.View>
   );
 }
@@ -467,7 +370,7 @@ const styles = StyleSheet.create({
   contentWrapper: {
     flex: 1,
   },
-  /* Close — top right */
+  /* Cerrar — superior derecha */
   closeButton: {
     position: 'absolute',
     right: 16,
@@ -491,26 +394,26 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  /* Column cluster at bottom right */
+  /* Cluster inferior derecha */
   controlsCluster: {
     position: 'absolute',
     right: 16,
     flexDirection: 'column',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     gap: 10,
     zIndex: 3,
   },
-  /* Vertical speed slider pill */
-  speedPill: {
-    width: 52,
-    paddingTop: 10,
-    paddingBottom: 10,
-    borderRadius: 26,
+  /* Panel horizontal con selector de velocidad */
+  speedPanel: {
+    flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 22,
     overflow: 'hidden',
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(255,255,255,0.22)',
+    gap: 10,
     ...Platform.select({
       web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' } as any,
       default: {
@@ -522,12 +425,44 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  speedLabel: {
-    color: 'rgba(255,255,255,0.85)',
-    fontSize: 9,
+  speedPanelBg: {
+    borderRadius: 22,
+  },
+  speedHeading: {
+    color: 'rgba(255,255,255,0.92)',
+    fontSize: 11,
     fontWeight: '700',
-    letterSpacing: 0.5,
+    letterSpacing: 0.4,
     textTransform: 'uppercase',
+    minWidth: 64,
+    textAlign: 'right',
+  },
+  segmentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  segment: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.10)',
+  },
+  segmentSelected: {
+    backgroundColor: 'rgba(255,255,255,0.92)',
+  },
+  segmentPressed: {
+    opacity: 0.7,
+  },
+  segmentText: {
+    color: 'rgba(255,255,255,0.78)',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  segmentTextSelected: {
+    color: '#1C1C1E',
   },
   /* Play / pause */
   playButton: {
@@ -549,5 +484,27 @@ const styles = StyleSheet.create({
         elevation: 7,
       },
     }),
+  },
+  playButtonBg: {
+    borderRadius: 28,
+  },
+  /* Pequeño badge con el nivel actual sobre el botón de play */
+  levelBadge: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    paddingHorizontal: 4,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  levelBadgeText: {
+    color: '#1C1C1E',
+    fontSize: 10,
+    fontWeight: '800',
+    lineHeight: 12,
   },
 });

--- a/mcm-app/hooks/useAutoScroller.ts
+++ b/mcm-app/hooks/useAutoScroller.ts
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+import type { WebView } from 'react-native-webview';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * Controlador de auto-scroll para el modo pantalla completa del cantoral.
+ *
+ * Diseño:
+ * - Tiempo real (px/segundo), no por frame: misma velocidad a 60Hz, 90Hz o 120Hz.
+ * - Niveles discretos persistidos: el usuario recupera "su" velocidad la próxima vez.
+ * - Acumulación sub-píxel: incluso a velocidades muy bajas el movimiento es continuo.
+ * - Para WebView nativa, el bucle vive DENTRO de la WebView (cero overhead del puente);
+ *   React Native solo envía la velocidad objetivo cuando cambia.
+ * - Para web, el bucle vive en el lado React con `requestAnimationFrame`.
+ * - Auto-pausa cuando el usuario interactúa manualmente con el contenido o al llegar
+ *   al final del documento.
+ */
+
+export interface AutoScrollSpeed {
+  /** Etiqueta legible para mostrar en UI. */
+  label: string;
+  /** Velocidad objetivo en píxeles por segundo. */
+  pxPerSec: number;
+}
+
+// Curva calibrada para acompañar el ritmo de una canción cantada en directo.
+// El paso de 3 → 4 es notable pero no brusco; el 1 es deliberadamente "ambiental".
+export const AUTO_SCROLL_SPEEDS: AutoScrollSpeed[] = [
+  { label: 'Muy lento', pxPerSec: 8 },
+  { label: 'Lento', pxPerSec: 22 },
+  { label: 'Normal', pxPerSec: 45 },
+  { label: 'Rápido', pxPerSec: 85 },
+  { label: 'Muy rápido', pxPerSec: 150 },
+];
+
+const DEFAULT_SPEED_INDEX = 2; // 'Normal'
+const STORAGE_KEY = '@mcm_song_autoscroll_speed_index';
+
+/**
+ * JS inyectado en la WebView nativa. Se ejecuta una sola vez por carga y expone
+ * `window.__mcmScroll(pxPerSec)`. El bucle es time-based (delta-T entre frames),
+ * acumula sub-píxeles y se auto-detiene al llegar al final del documento o ante
+ * interacción manual del usuario, posteando un mensaje al lado React.
+ */
+export const AUTO_SCROLL_CONTROLLER_JS = `(function(){
+  if (window.__mcmScrollInstalled) return; window.__mcmScrollInstalled = true;
+  var target = 0;       // px/s objetivo
+  var current = 0;      // px/s real (con rampa suave)
+  var acc = 0;          // acumulador sub-píxel
+  var lastT = 0;
+  var raf = null;
+  var RAMP = 600;       // px/s por segundo (rampa de aceleración/frenado)
+  function post(type){ try { window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: type })); } catch(e){} }
+  function atBottom(){
+    var sy = window.scrollY || window.pageYOffset || document.documentElement.scrollTop || 0;
+    var vh = window.innerHeight || document.documentElement.clientHeight || 0;
+    var sh = Math.max(document.documentElement.scrollHeight || 0, document.body ? document.body.scrollHeight : 0);
+    return sy + vh >= sh - 1;
+  }
+  function step(t){
+    if (!lastT) lastT = t;
+    var dt = Math.min((t - lastT) / 1000, 0.05); // cap 50ms (evita saltos tras un freeze)
+    lastT = t;
+    // Rampa suave hacia el objetivo
+    if (current < target) current = Math.min(target, current + RAMP * dt);
+    else if (current > target) current = Math.max(target, current - RAMP * dt);
+    if (current > 0) {
+      acc += current * dt;
+      var px = Math.floor(acc);
+      if (px > 0) { window.scrollBy(0, px); acc -= px; }
+      if (atBottom()) { target = 0; current = 0; raf = null; lastT = 0; post('scroll-end'); return; }
+      raf = requestAnimationFrame(step);
+    } else if (target <= 0) {
+      raf = null; lastT = 0;
+    } else {
+      raf = requestAnimationFrame(step);
+    }
+  }
+  window.__mcmScroll = function(v){
+    target = +v || 0;
+    if (target > 0 && !raf) { lastT = 0; raf = requestAnimationFrame(step); }
+  };
+  // Interacción manual del usuario → pausar inmediatamente
+  var onUserScroll = function(){
+    if (target > 0) { target = 0; current = 0; post('user-paused'); }
+  };
+  ['touchstart','wheel','mousedown','keydown'].forEach(function(evt){
+    window.addEventListener(evt, onUserScroll, { passive: true, capture: true });
+  });
+})(); true;`;
+
+interface UseAutoScrollerParams {
+  /** Ref a la WebView nativa (iOS/Android). */
+  webViewRef?: React.RefObject<WebView | null>;
+  /** Ref al contenedor scrollable en web. */
+  webContainerRef?: React.MutableRefObject<HTMLDivElement | null>;
+  /** Si la pantalla aún no está lista (e.g. esperando contenido), pausamos. */
+  enabled?: boolean;
+}
+
+export interface AutoScrollerApi {
+  isPlaying: boolean;
+  speedIndex: number;
+  speed: AutoScrollSpeed;
+  setSpeedIndex: (i: number) => void;
+  play: () => void;
+  pause: () => void;
+  toggle: () => void;
+  /** Conectar al `onLoadEnd` de la WebView. */
+  handleWebViewLoad: () => void;
+  /** Conectar al `onMessage` de la WebView. */
+  handleWebViewMessage: (event: { nativeEvent: { data: string } }) => void;
+}
+
+export function useAutoScroller({
+  webViewRef,
+  webContainerRef,
+  enabled = true,
+}: UseAutoScrollerParams): AutoScrollerApi {
+  const [speedIndex, setSpeedIndexState] =
+    useState<number>(DEFAULT_SPEED_INDEX);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hidratar velocidad preferida desde AsyncStorage
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((v) => {
+        if (cancelled) return;
+        const n = v != null ? Number.parseInt(v, 10) : NaN;
+        if (Number.isFinite(n) && n >= 0 && n < AUTO_SCROLL_SPEEDS.length) {
+          setSpeedIndexState(n);
+        }
+        setHydrated(true);
+      })
+      .catch(() => {
+        if (!cancelled) setHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setSpeedIndex = useCallback((i: number) => {
+    const clamped = Math.max(
+      0,
+      Math.min(AUTO_SCROLL_SPEEDS.length - 1, Math.round(i)),
+    );
+    setSpeedIndexState(clamped);
+    AsyncStorage.setItem(STORAGE_KEY, String(clamped)).catch(() => {});
+  }, []);
+
+  const speed = AUTO_SCROLL_SPEEDS[speedIndex];
+
+  // Refs siempre actualizados — evita closures obsoletos dentro del rAF
+  const isPlayingRef = useRef(isPlaying);
+  const pxPerSecRef = useRef(speed.pxPerSec);
+  isPlayingRef.current = isPlaying;
+  pxPerSecRef.current = speed.pxPerSec;
+
+  // ── Nativo: empujar la velocidad objetivo a la WebView ──────────────────
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    if (!hydrated) return;
+    const ref = webViewRef?.current;
+    if (!ref) return;
+    const target = enabled && isPlaying ? speed.pxPerSec : 0;
+    ref.injectJavaScript(
+      `if(window.__mcmScroll)window.__mcmScroll(${target});true;`,
+    );
+  }, [isPlaying, speed.pxPerSec, hydrated, enabled, webViewRef]);
+
+  // ── Web: bucle rAF time-based con acumulación sub-píxel ─────────────────
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    if (!enabled || !isPlaying) return;
+    const el = webContainerRef?.current;
+    if (!el) return;
+
+    let raf: number | null = null;
+    let lastT = 0;
+    let acc = 0;
+    let current = 0; // px/s con rampa suave
+    const RAMP = 600;
+
+    const step = (t: number) => {
+      if (!lastT) lastT = t;
+      const dt = Math.min((t - lastT) / 1000, 0.05);
+      lastT = t;
+
+      const target = pxPerSecRef.current;
+      if (current < target) current = Math.min(target, current + RAMP * dt);
+      else if (current > target)
+        current = Math.max(target, current - RAMP * dt);
+
+      if (current > 0) {
+        acc += current * dt;
+        const px = Math.floor(acc);
+        if (px > 0) {
+          el.scrollBy({ top: px });
+          acc -= px;
+        }
+        // Auto-pausa al llegar al final
+        const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+        if (atBottom) {
+          setIsPlaying(false);
+          raf = null;
+          return;
+        }
+      }
+      raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+
+    return () => {
+      if (raf != null) cancelAnimationFrame(raf);
+    };
+  }, [isPlaying, enabled, webContainerRef]);
+
+  // ── Web: pausar ante interacción manual del usuario ─────────────────────
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const el = webContainerRef?.current;
+    if (!el) return;
+
+    const onUserInteract = () => {
+      if (isPlayingRef.current) setIsPlaying(false);
+    };
+    el.addEventListener('wheel', onUserInteract, { passive: true });
+    el.addEventListener('touchstart', onUserInteract, { passive: true });
+    el.addEventListener('mousedown', onUserInteract, { passive: true });
+    return () => {
+      el.removeEventListener('wheel', onUserInteract);
+      el.removeEventListener('touchstart', onUserInteract);
+      el.removeEventListener('mousedown', onUserInteract);
+    };
+  }, [webContainerRef]);
+
+  // ── Controles ───────────────────────────────────────────────────────────
+  const play = useCallback(() => setIsPlaying(true), []);
+  const pause = useCallback(() => setIsPlaying(false), []);
+  const toggle = useCallback(() => setIsPlaying((p) => !p), []);
+
+  // ── WebView: reinyectar velocidad cuando recarga el HTML ────────────────
+  const handleWebViewLoad = useCallback(() => {
+    if (Platform.OS === 'web') return;
+    if (!isPlayingRef.current) return;
+    webViewRef?.current?.injectJavaScript(
+      `if(window.__mcmScroll)window.__mcmScroll(${pxPerSecRef.current});true;`,
+    );
+  }, [webViewRef]);
+
+  const handleWebViewMessage = useCallback(
+    (event: { nativeEvent: { data: string } }) => {
+      try {
+        const msg = JSON.parse(event.nativeEvent.data);
+        if (msg && (msg.type === 'scroll-end' || msg.type === 'user-paused')) {
+          setIsPlaying(false);
+        }
+      } catch {
+        // Ignorar mensajes que no sean JSON nuestros
+      }
+    },
+    [],
+  );
+
+  return {
+    isPlaying,
+    speedIndex,
+    speed,
+    setSpeedIndex,
+    play,
+    pause,
+    toggle,
+    handleWebViewLoad,
+    handleWebViewMessage,
+  };
+}


### PR DESCRIPTION
Replace the fragile vertical slider + frame-based scroll loop with a
clean, time-based, persistent auto-scroller backed by a dedicated hook.

- New hook hooks/useAutoScroller.ts owns the loop, speed presets,
  persistence and WebView/DOM glue.
- Time-based (px/s) with sub-pixel accumulation and smooth ramp:
  consistent speed across refresh rates, no jitter at low speeds.
- Native loop lives inside the WebView (no bridge overhead); React
  only sends target velocity on change. Web uses rAF on the scroll div.
- Auto-pauses on user interaction (touch/wheel/mousedown/keydown) and
  at the end of the document.
- 5 discrete speed levels persisted in AsyncStorage; horizontal
  segmented control replaces the old vertical slider.
- Haptics on play/pause and speed change. Keyboard shortcuts on web:
  Space toggles, Up/Down change speed.