### PR TITLE
Hidden preview-channel opt-in (Laboratorio Alpha)

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,21 @@
 
 ---
 
+## 2026-05-22 — Canal "preview" en caliente: modo Laboratorio Alpha (7 taps)
+
+- **Qué hace**: permite a un dispositivo suscribirse al canal `preview` de EAS Update desde dentro de la app instalada en stores, sin necesidad de un binario aparte. Mientras esté activo, los OTAs vienen de la rama `preview` (que ya publica `/.github/workflows/ota-preview.yml`); al desactivarlo, en el siguiente arranque vuelve al canal `production`.
+- **Cómo se descubre**: 7 taps rápidos sobre el número de versión (`VersionDisplay`) o sobre el tagline "Movimiento Consolación para el Mundo" del pie de Home y de Más. Haptic creciente desde el 4º tap como pista. Reversible.
+- **UX del modal**: deliberadamente exagerada y festiva (rompiendo el minimalismo del resto de la app). Gradiente que muta entre tres paletas, 14 emojis flotando con rotación/escala, título "🧪 LABORATORIO ALPHA 🧪" con wobble, palanca gigante MUNDANO ↔ ALPHA, frases rotatorias, pergamino con la explicación técnica del pacto, burst de confeti al activar y "puff" al desactivar.
+- **Mecánica técnica**: `Updates.setUpdateURLAndRequestHeadersOverride({ updateUrl, requestHeaders: { 'expo-channel-name': 'preview' } })`. Persistido en `AsyncStorage`. Se aplica al hidratar el provider antes de que `useOTAUpdate` haga su primer `checkForUpdateAsync`. Inocuo si la `runtimeVersion` del binario no coincide con la del bundle preview.
+- **Archivos nuevos**:
+  - `hooks/useSecretTap.ts`: contador de taps con ventana de 1.5s y haptic ramp.
+  - `contexts/PreviewChannelContext.tsx`: flag persistido + override de canal + estado del modal.
+  - `components/SecretMenuTrigger.tsx`: wrapper Pressable transparente que añade el gesto sin afectar al layout.
+  - `components/PreviewChannelModal.tsx`: el modal "Laboratorio Alpha" con Reanimated + LinearGradient.
+- **Archivos modificados**: `app/_layout.tsx` (provider + montaje del modal), `components/VersionDisplay.tsx` (envuelto + indicador "· alpha" cuando está activo), `app/(tabs)/index.tsx` y `app/screens/MasHomeScreen.tsx` (tagline envuelto).
+
+---
+
 ## 2026-05-21 — Auto-scroll del cantoral en pantalla completa, reescrito
 
 - **Problema**: el desplazador automático del modo pantalla completa era frágil. Slider vertical con gestos en conflicto con `PressableFeedback`, bucle frame-based (la velocidad cambiaba según refresh rate), sin persistencia entre sesiones, sin auto-pausa al final del documento ni cuando el usuario tocaba la pantalla, y dos bucles distintos en lados opuestos del puente nativo.

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -41,6 +41,7 @@ import SettingsBottomSheet from '@/components/SettingsBottomSheet';
 import AppFeedbackModal from '@/components/AppFeedbackModal';
 import NotificationsBottomSheet from '@/components/NotificationsBottomSheet';
 import { VersionDisplay } from '@/components/VersionDisplay';
+import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import { useUserProfile } from '@/contexts/UserProfileContext';
 import { setPendingMasScreen } from '@/utils/masNavigation';
@@ -279,7 +280,9 @@ export default function Home() {
 
   const hasAnyVisibleCalendar =
     calendarConfigs.length > 0 && visibleCalendars.some(Boolean);
-  const hasUpcomingEvents = upcomingEventGroups.some(g => g.events.length > 0);
+  const hasUpcomingEvents = upcomingEventGroups.some(
+    (g) => g.events.length > 0,
+  );
 
   // Quick grid items — filtrados por la config del perfil resuelto
   const quickItems = useMemo<QuickItem[]>(() => {
@@ -368,7 +371,9 @@ export default function Home() {
       'contigo',
     ];
 
-    const isTab = tabPaths.some(p => naked === p || naked.startsWith(p + '/'));
+    const isTab = tabPaths.some(
+      (p) => naked === p || naked.startsWith(p + '/'),
+    );
     if (isTab) {
       return '/(tabs)/' + naked;
     }
@@ -394,7 +399,9 @@ export default function Home() {
     '/(tabs)/contigo/bookmarks': { label: 'Favoritos', icon: 'bookmark' },
   };
   const internalRouteInfo = latestNotification?.internalRoute
-    ? (ROUTE_LABELS[normalizeRoute(latestNotification.internalRoute)] ?? ROUTE_LABELS[latestNotification.internalRoute] ?? null)
+    ? (ROUTE_LABELS[normalizeRoute(latestNotification.internalRoute)] ??
+      ROUTE_LABELS[latestNotification.internalRoute] ??
+      null)
     : null;
   const internalRouteLabel = internalRouteInfo?.label ?? null;
 
@@ -458,7 +465,12 @@ export default function Home() {
                   style={[
                     styles.headerBtn,
                     {
-                      backgroundColor: Platform.OS === 'ios' ? 'transparent' : (scheme === 'dark' ? 'rgba(163,189,49,0.15)' : 'rgba(163,189,49,0.12)'),
+                      backgroundColor:
+                        Platform.OS === 'ios'
+                          ? 'transparent'
+                          : scheme === 'dark'
+                            ? 'rgba(163,189,49,0.15)'
+                            : 'rgba(163,189,49,0.12)',
                       borderColor: colors.success,
                     },
                   ]}
@@ -484,8 +496,16 @@ export default function Home() {
                   style={[
                     styles.headerBtn,
                     {
-                      backgroundColor: Platform.OS === 'ios' ? 'transparent' : (scheme === 'dark' ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)'),
-                      borderColor: scheme === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)',
+                      backgroundColor:
+                        Platform.OS === 'ios'
+                          ? 'transparent'
+                          : scheme === 'dark'
+                            ? 'rgba(255,255,255,0.07)'
+                            : 'rgba(0,0,0,0.05)',
+                      borderColor:
+                        scheme === 'dark'
+                          ? 'rgba(255,255,255,0.12)'
+                          : 'rgba(0,0,0,0.08)',
                     },
                   ]}
                   onPress={() => setNotifSheetOpen(true)}
@@ -496,9 +516,7 @@ export default function Home() {
                   }
                   accessibilityRole="button"
                 >
-                  {Platform.OS === 'ios' && (
-                    <GlassSurface variant="regular" />
-                  )}
+                  {Platform.OS === 'ios' && <GlassSurface variant="regular" />}
                   <View style={styles.bellWrap}>
                     <MaterialIcons
                       name="notifications"
@@ -522,16 +540,22 @@ export default function Home() {
                 style={[
                   styles.headerBtn,
                   {
-                    backgroundColor: Platform.OS === 'ios' ? 'transparent' : (scheme === 'dark' ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)'),
-                    borderColor: scheme === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)',
+                    backgroundColor:
+                      Platform.OS === 'ios'
+                        ? 'transparent'
+                        : scheme === 'dark'
+                          ? 'rgba(255,255,255,0.07)'
+                          : 'rgba(0,0,0,0.05)',
+                    borderColor:
+                      scheme === 'dark'
+                        ? 'rgba(255,255,255,0.12)'
+                        : 'rgba(0,0,0,0.08)',
                   },
                 ]}
                 accessibilityLabel="Perfil y ajustes"
                 accessibilityRole="button"
               >
-                {Platform.OS === 'ios' && (
-                  <GlassSurface variant="regular" />
-                )}
+                {Platform.OS === 'ios' && <GlassSurface variant="regular" />}
                 <MaterialIcons
                   name="account-circle"
                   size={22}
@@ -849,7 +873,9 @@ export default function Home() {
                       calendarConfigs[evt.calendarIndex]?.color ?? accentColor;
                     const calName = calendarConfigs[evt.calendarIndex]?.name;
                     return (
-                      <React.Fragment key={`${group.label}|${evt.title}|${evt.startDate}|${idx}`}>
+                      <React.Fragment
+                        key={`${group.label}|${evt.title}|${evt.startDate}|${idx}`}
+                      >
                         {isFirstInGroup && (
                           <Text
                             style={[
@@ -888,10 +914,14 @@ export default function Home() {
                               { backgroundColor: hexAlpha(calColor, '18') },
                             ]}
                           >
-                            <Text style={[styles.eventMonth, { color: calColor }]}>
+                            <Text
+                              style={[styles.eventMonth, { color: calColor }]}
+                            >
                               {MONTHS_SHORT[evtDate.getMonth()].toUpperCase()}
                             </Text>
-                            <Text style={[styles.eventDay, { color: calColor }]}>
+                            <Text
+                              style={[styles.eventDay, { color: calColor }]}
+                            >
                               {evtDate.getDate()}
                             </Text>
                           </View>
@@ -917,7 +947,10 @@ export default function Home() {
                                 ]}
                               >
                                 <Text
-                                  style={[styles.calBadgeText, { color: calColor }]}
+                                  style={[
+                                    styles.calBadgeText,
+                                    { color: calColor },
+                                  ]}
                                   numberOfLines={1}
                                 >
                                   {calName}
@@ -1001,9 +1034,11 @@ export default function Home() {
               ¿Algún fallo? Cuéntanoslo
             </Text>
           </TouchableOpacity>
-          <Text style={[styles.tagline, { color: theme.icon }]}>
-            Movimiento Consolación para el Mundo
-          </Text>
+          <SecretMenuTrigger>
+            <Text style={[styles.tagline, { color: theme.icon }]}>
+              Movimiento Consolación para el Mundo
+            </Text>
+          </SecretMenuTrigger>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -45,6 +45,8 @@ import { HeroUINativeProvider } from 'heroui-native';
 import { AppToastProvider, useToast } from '@/contexts/AppToastContext';
 import OTAUpdatePrompt from '@/components/OTAUpdatePrompt';
 import { OTAProvider, useOTAContext } from '@/contexts/OTAContext';
+import { PreviewChannelProvider } from '@/contexts/PreviewChannelContext';
+import { PreviewChannelModal } from '@/components/PreviewChannelModal';
 // Importar iconos para asegurar que se incluyan en el build
 import '@/constants/iconAssets';
 
@@ -64,9 +66,11 @@ export default function RootLayout() {
                         <ChoirSessionProvider>
                           <NotificationsProvider>
                             <CalendarConfigProvider>
-                              <OTAProvider>
-                                <InnerLayout />
-                              </OTAProvider>
+                              <PreviewChannelProvider>
+                                <OTAProvider>
+                                  <InnerLayout />
+                                </OTAProvider>
+                              </PreviewChannelProvider>
                             </CalendarConfigProvider>
                           </NotificationsProvider>
                         </ChoirSessionProvider>
@@ -209,6 +213,7 @@ function InnerLayout() {
         onApply={applyUpdate}
         onLater={() => setDismissed(true)}
       />
+      <PreviewChannelModal />
     </NavThemeProvider>
   );
 }

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useState } from 'react';
-import { View, StyleSheet, Text, ScrollView, Platform, TouchableOpacity } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Text,
+  ScrollView,
+  Platform,
+  TouchableOpacity,
+} from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -11,6 +18,7 @@ import type { ComponentProps } from 'react';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { hexAlpha } from '@/utils/colorUtils';
 import { VersionDisplay } from '@/components/VersionDisplay';
+import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import AppFeedbackModal from '@/components/AppFeedbackModal';
 import { MasStackParamList } from '../(tabs)/mas';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
@@ -91,7 +99,9 @@ export default function MasHomeScreen() {
       const visibleSet = new Set(resolved.tabs);
       const { overflowTabs } = splitTabsForIOS(visibleSet);
       // Tabs cuyo screen está registrado en el stack de Más (no accesibles vía router.navigate en iOS)
-      const OVERFLOW_STACK_TARGETS: Partial<Record<string, keyof MasStackParamList>> = {
+      const OVERFLOW_STACK_TARGETS: Partial<
+        Record<string, keyof MasStackParamList>
+      > = {
         fotos: 'Fotos',
       };
       for (const tab of overflowTabs) {
@@ -105,7 +115,9 @@ export default function MasHomeScreen() {
           emoji: tab.emoji,
           materialIcon: tab.androidIcon,
           tintColor: tab.tintColor,
-          ...(stackTarget ? { target: stackTarget } : { routePath: `/${tab.name}` }),
+          ...(stackTarget
+            ? { target: stackTarget }
+            : { routePath: `/${tab.name}` }),
         });
       }
     }
@@ -146,7 +158,9 @@ export default function MasHomeScreen() {
         <ScrollView
           style={styles.container}
           contentContainerStyle={
-            Platform.OS === 'ios' ? { paddingBottom: 140 } : { paddingBottom: spacing.xl }
+            Platform.OS === 'ios'
+              ? { paddingBottom: 140 }
+              : { paddingBottom: spacing.xl }
           }
           showsVerticalScrollIndicator={false}
         >
@@ -262,13 +276,25 @@ export default function MasHomeScreen() {
               onPress={() => setFeedbackVisible(true)}
               style={styles.feedbackLink}
             >
-              <Text style={[styles.feedbackText, { color: isDark ? '#8E8E93' : '#6B7280' }]}>
+              <Text
+                style={[
+                  styles.feedbackText,
+                  { color: isDark ? '#8E8E93' : '#6B7280' },
+                ]}
+              >
                 ¿Algún fallo? Cuéntanoslo
               </Text>
             </TouchableOpacity>
-            <Text style={[styles.tagline, { color: isDark ? '#8E8E93' : '#6B7280' }]}>
-              Movimiento Consolación para el Mundo
-            </Text>
+            <SecretMenuTrigger>
+              <Text
+                style={[
+                  styles.tagline,
+                  { color: isDark ? '#8E8E93' : '#6B7280' },
+                ]}
+              >
+                Movimiento Consolación para el Mundo
+              </Text>
+            </SecretMenuTrigger>
           </View>
         </ScrollView>
       </PageContainer>

--- a/mcm-app/components/PreviewChannelModal.tsx
+++ b/mcm-app/components/PreviewChannelModal.tsx
@@ -1,0 +1,847 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import Animated, {
+  Easing,
+  cancelAnimation,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { usePreviewChannel } from '@/contexts/PreviewChannelContext';
+
+/**
+ * Modal "Laboratorio Alpha" — UI deliberadamente exagerada, festiva y opuesta
+ * al estilo minimalista del resto de la app. Activa/desactiva el canal preview
+ * de EAS Update. Sólo se llega aquí tras dar 7 taps escondidos en elementos
+ * decorativos del pie (versión + tagline "Movimiento Consolación").
+ */
+
+// ─── Datos visuales ─────────────────────────────────────────────────────────
+
+const FLOATING_EMOJIS = [
+  '🚀',
+  '✨',
+  '🌈',
+  '🪄',
+  '🎉',
+  '🧪',
+  '🔮',
+  '⭐',
+  '💫',
+  '🌟',
+  '🎈',
+  '🛸',
+];
+
+const FUN_PHRASES = [
+  'Bienvenido al multiverso de las features por venir 🐛',
+  'Eres oficialmente parte del equipo cool 😎',
+  'Pueden caer novedades sin previo aviso 🪂',
+  'Aquí se prueba antes de que el resto del mundo lo vea 🔭',
+  'Versión: mañana. Estabilidad: quizás. 🤞',
+  'Pacto firmado con tinta invisible. Indeleble. 🖋️',
+  'Si algo se rompe, has cumplido tu misión 🎯',
+  'Bienvenido al laboratorio. Cuidado con las pócimas. ⚗️',
+];
+
+// ─── Capa de gradientes morphing ────────────────────────────────────────────
+
+const GRADIENT_DURATION = 4000;
+const GRADIENT_HOLD = 0;
+
+function AnimatedGradients() {
+  const a = useSharedValue(1);
+  const b = useSharedValue(0);
+  const c = useSharedValue(0);
+
+  useEffect(() => {
+    const totalCycle = GRADIENT_DURATION * 3 + GRADIENT_HOLD * 3;
+    const breathe = (start: number, sv: typeof a) => {
+      sv.value = withDelay(
+        start,
+        withRepeat(
+          withSequence(
+            withTiming(1, { duration: GRADIENT_DURATION }),
+            withTiming(0, { duration: GRADIENT_DURATION }),
+            withTiming(0, { duration: totalCycle - GRADIENT_DURATION * 2 }),
+          ),
+          -1,
+          false,
+        ),
+      );
+    };
+    // A empieza ya visible; B y C entran escalonadas.
+    a.value = 1;
+    b.value = 0;
+    c.value = 0;
+    breathe(0, a);
+    breathe(GRADIENT_DURATION, b);
+    breathe(GRADIENT_DURATION * 2, c);
+    return () => {
+      cancelAnimation(a);
+      cancelAnimation(b);
+      cancelAnimation(c);
+    };
+  }, [a, b, c]);
+
+  const styleA = useAnimatedStyle(() => ({ opacity: a.value }));
+  const styleB = useAnimatedStyle(() => ({ opacity: b.value }));
+  const styleC = useAnimatedStyle(() => ({ opacity: c.value }));
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      <Animated.View style={[StyleSheet.absoluteFill, styleA]}>
+        <LinearGradient
+          colors={['#FF8E53', '#FE6B8B', '#F4C11E']}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+      </Animated.View>
+      <Animated.View style={[StyleSheet.absoluteFill, styleB]}>
+        <LinearGradient
+          colors={['#6A11CB', '#2575FC', '#00C9A7']}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+      </Animated.View>
+      <Animated.View style={[StyleSheet.absoluteFill, styleC]}>
+        <LinearGradient
+          colors={['#43E97B', '#38F9D7', '#5B86E5']}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFill}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+// ─── Partículas flotando ────────────────────────────────────────────────────
+
+function FloatingParticle({
+  index,
+  width,
+  height,
+  phase,
+}: {
+  index: number;
+  width: number;
+  height: number;
+  phase: SharedValue<number>;
+}) {
+  const emoji = FLOATING_EMOJIS[index % FLOATING_EMOJIS.length];
+  // "Aleatorio" determinista por índice (LCG-ish — basta para distribuir).
+  const baseX = ((index * 173) % 100) / 100;
+  const baseY = ((index * 271) % 100) / 100;
+  const ampX = 40 + ((index * 11) % 60);
+  const ampY = 30 + ((index * 13) % 70);
+  const speedX = 0.6 + ((index * 7) % 9) / 18;
+  const speedY = 0.7 + ((index * 5) % 11) / 22;
+  const rotSpeed = 30 + ((index * 17) % 60);
+  const size = 22 + ((index * 3) % 18);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const t = phase.value;
+    const x = baseX * width + Math.sin(t * speedX + index) * ampX;
+    const y = baseY * height + Math.cos(t * speedY + index) * ampY;
+    const rot = (t * rotSpeed + index * 50) % 360;
+    const scale = 0.85 + Math.sin(t * 1.4 + index) * 0.18;
+    return {
+      transform: [
+        { translateX: x },
+        { translateY: y },
+        { rotate: `${rot}deg` },
+        { scale },
+      ],
+    };
+  });
+
+  return (
+    <Animated.Text
+      style={[styles.particle, { fontSize: size }, animatedStyle]}
+      allowFontScaling={false}
+    >
+      {emoji}
+    </Animated.Text>
+  );
+}
+
+// ─── Burst de confeti (explosión) ───────────────────────────────────────────
+
+const BURST_PARTICLES = 26;
+
+function ConfettiBurst({
+  centerX,
+  centerY,
+  variant,
+}: {
+  centerX: number;
+  centerY: number;
+  variant: 'explode' | 'puff';
+}) {
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      {Array.from({ length: BURST_PARTICLES }).map((_, i) => (
+        <ConfettiPiece
+          key={i}
+          index={i}
+          centerX={centerX}
+          centerY={centerY}
+          variant={variant}
+        />
+      ))}
+    </View>
+  );
+}
+
+function ConfettiPiece({
+  index,
+  centerX,
+  centerY,
+  variant,
+}: {
+  index: number;
+  centerX: number;
+  centerY: number;
+  variant: 'explode' | 'puff';
+}) {
+  const angle = (index / BURST_PARTICLES) * Math.PI * 2 + (index % 2) * 0.3;
+  const distance = variant === 'explode' ? 180 + (index % 5) * 40 : -60;
+  const targetX = Math.cos(angle) * distance;
+  const targetY = Math.sin(angle) * distance;
+  const duration = variant === 'explode' ? 900 + (index % 4) * 120 : 600;
+
+  const t = useSharedValue(0);
+  const rot = useSharedValue(0);
+  const emoji =
+    variant === 'explode'
+      ? ['🎉', '✨', '🎊', '⭐', '💫', '🌟'][index % 6]
+      : ['💨', '·', '•'][index % 3];
+
+  useEffect(() => {
+    t.value = withTiming(1, {
+      duration,
+      easing: Easing.out(Easing.cubic),
+    });
+    rot.value = withTiming(360 * (1 + (index % 3)), { duration });
+  }, [t, rot, duration, index]);
+
+  const style = useAnimatedStyle(() => {
+    const tx = targetX * t.value;
+    const ty =
+      targetY * t.value + (variant === 'explode' ? t.value * t.value * 80 : 0); // gravedad leve
+    const opacity = variant === 'explode' ? 1 - t.value * 0.9 : 1 - t.value;
+    const scale = variant === 'explode' ? 1 - t.value * 0.3 : 0.4 + t.value;
+    return {
+      opacity,
+      transform: [
+        { translateX: centerX + tx },
+        { translateY: centerY + ty },
+        { rotate: `${rot.value}deg` },
+        { scale },
+      ],
+    };
+  });
+
+  return (
+    <Animated.Text style={[styles.confetti, style]} allowFontScaling={false}>
+      {emoji}
+    </Animated.Text>
+  );
+}
+
+// ─── Lever / palanca gigante ────────────────────────────────────────────────
+
+const LEVER_WIDTH = 280;
+const LEVER_HEIGHT = 88;
+const KNOB = 76;
+
+function GiantLever({
+  active,
+  onToggle,
+}: {
+  active: boolean;
+  onToggle: () => void;
+}) {
+  const t = useSharedValue(active ? 1 : 0);
+  useEffect(() => {
+    t.value = withSpring(active ? 1 : 0, { damping: 12, stiffness: 110 });
+  }, [active, t]);
+
+  const knobStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: t.value * (LEVER_WIDTH - KNOB - 12) + 6 },
+      { rotate: `${interpolate(t.value, [0, 1], [-12, 12])}deg` },
+      { scale: 1 + Math.abs(t.value - 0.5) * 0.05 },
+    ],
+  }));
+  const trackOnStyle = useAnimatedStyle(() => ({ opacity: t.value }));
+
+  return (
+    <Pressable
+      onPress={onToggle}
+      style={styles.leverContainer}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: active }}
+      accessibilityLabel="Activar modo laboratorio (canal preview)"
+    >
+      <View style={styles.leverTrackBase}>
+        <Animated.View style={[styles.leverTrackOn, trackOnStyle]}>
+          <LinearGradient
+            colors={['#43E97B', '#FCD200', '#FE6B8B']}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={StyleSheet.absoluteFill}
+          />
+        </Animated.View>
+        <View style={styles.leverLabels} pointerEvents="none">
+          <Text style={styles.leverLabel}>MUNDANO</Text>
+          <Text style={styles.leverLabel}>ALPHA</Text>
+        </View>
+        <Animated.View style={[styles.leverKnob, knobStyle]}>
+          <Text style={styles.leverKnobIcon} allowFontScaling={false}>
+            {active ? '🧪' : '😴'}
+          </Text>
+        </Animated.View>
+      </View>
+    </Pressable>
+  );
+}
+
+// ─── Título con wobble ──────────────────────────────────────────────────────
+
+function WobblingTitle({ children }: { children: React.ReactNode }) {
+  const wobble = useSharedValue(0);
+  useEffect(() => {
+    wobble.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 520, easing: Easing.inOut(Easing.quad) }),
+        withTiming(-1, { duration: 520, easing: Easing.inOut(Easing.quad) }),
+      ),
+      -1,
+      true,
+    );
+    return () => cancelAnimation(wobble);
+  }, [wobble]);
+  const style = useAnimatedStyle(() => ({
+    transform: [
+      { rotate: `${wobble.value * 2.5}deg` },
+      { scale: 1 + Math.abs(wobble.value) * 0.04 },
+    ],
+  }));
+  return (
+    <Animated.Text style={[styles.title, style]}>{children}</Animated.Text>
+  );
+}
+
+// ─── Pulsing sparkles around title ──────────────────────────────────────────
+
+function Sparkles() {
+  const o0 = useSharedValue(0.4);
+  const o1 = useSharedValue(0.4);
+  const o2 = useSharedValue(0.4);
+  const o3 = useSharedValue(0.4);
+  useEffect(() => {
+    const seq = () =>
+      withRepeat(
+        withSequence(
+          withTiming(1, { duration: 460 }),
+          withTiming(0.2, { duration: 460 }),
+        ),
+        -1,
+        true,
+      );
+    o0.value = withDelay(0, seq());
+    o1.value = withDelay(220, seq());
+    o2.value = withDelay(440, seq());
+    o3.value = withDelay(660, seq());
+    return () => {
+      cancelAnimation(o0);
+      cancelAnimation(o1);
+      cancelAnimation(o2);
+      cancelAnimation(o3);
+    };
+  }, [o0, o1, o2, o3]);
+  const a0 = useAnimatedStyle(() => ({ opacity: o0.value }));
+  const a1 = useAnimatedStyle(() => ({ opacity: o1.value }));
+  const a2 = useAnimatedStyle(() => ({ opacity: o2.value }));
+  const a3 = useAnimatedStyle(() => ({ opacity: o3.value }));
+  return (
+    <View style={styles.sparklesRow} pointerEvents="none">
+      <Animated.Text style={[styles.sparkle, a0]}>✦</Animated.Text>
+      <Animated.Text style={[styles.sparkle, a1]}>✧</Animated.Text>
+      <Animated.Text style={[styles.sparkle, a2]}>✦</Animated.Text>
+      <Animated.Text style={[styles.sparkle, a3]}>✧</Animated.Text>
+    </View>
+  );
+}
+
+// ─── Ticker de frases rotativas ─────────────────────────────────────────────
+
+function RotatingPhrases() {
+  const [idx, setIdx] = useState(0);
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      opacity.value = withSequence(
+        withTiming(0, { duration: 350 }),
+        withTiming(1, { duration: 450 }),
+      );
+      setTimeout(() => {
+        setIdx((p) => (p + 1) % FUN_PHRASES.length);
+      }, 360);
+    }, 4200);
+    return () => clearInterval(id);
+  }, [opacity]);
+
+  const style = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return (
+    <Animated.Text style={[styles.phrase, style]} numberOfLines={2}>
+      {FUN_PHRASES[idx]}
+    </Animated.Text>
+  );
+}
+
+// ─── Modal principal ────────────────────────────────────────────────────────
+
+export function PreviewChannelModal() {
+  const { isSecretMenuOpen, closeSecretMenu, enabled, setEnabled } =
+    usePreviewChannel();
+  const insets = useSafeAreaInsets();
+  const { width, height } = useWindowDimensions();
+  const phase = useSharedValue(0);
+  const [burstKey, setBurstKey] = useState<number | null>(null);
+  const [burstVariant, setBurstVariant] = useState<'explode' | 'puff'>(
+    'explode',
+  );
+
+  // Bucle global de partículas — un solo shared value para todas.
+  useEffect(() => {
+    if (!isSecretMenuOpen) {
+      phase.value = 0;
+      return;
+    }
+    phase.value = withRepeat(
+      withTiming(Math.PI * 2, { duration: 14000, easing: Easing.linear }),
+      -1,
+      false,
+    );
+    return () => cancelAnimation(phase);
+  }, [isSecretMenuOpen, phase]);
+
+  const handleToggle = useCallback(async () => {
+    const next = !enabled;
+    if (Platform.OS !== 'web') {
+      Haptics.notificationAsync(
+        next
+          ? Haptics.NotificationFeedbackType.Success
+          : Haptics.NotificationFeedbackType.Warning,
+      ).catch(() => {});
+    }
+    setBurstVariant(next ? 'explode' : 'puff');
+    setBurstKey(Date.now());
+    await setEnabled(next);
+  }, [enabled, setEnabled]);
+
+  const handleClose = useCallback(() => {
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    }
+    closeSecretMenu();
+  }, [closeSecretMenu]);
+
+  const particles = useMemo(
+    () =>
+      Array.from({ length: 14 }).map((_, i) => (
+        <FloatingParticle
+          key={i}
+          index={i}
+          width={width}
+          height={height}
+          phase={phase}
+        />
+      )),
+    [width, height, phase],
+  );
+
+  return (
+    <Modal
+      visible={isSecretMenuOpen}
+      onRequestClose={handleClose}
+      animationType="fade"
+      transparent={false}
+      statusBarTranslucent
+    >
+      <View style={styles.root}>
+        <AnimatedGradients />
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          {particles}
+        </View>
+        {/* Capa oscura sutil para que el texto sea legible */}
+        <View style={styles.scrim} pointerEvents="none" />
+
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            {
+              paddingTop: insets.top + 24,
+              paddingBottom: insets.bottom + 32,
+            },
+          ]}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Header */}
+          <View style={styles.headerBlock}>
+            <Sparkles />
+            <WobblingTitle>🧪 LABORATORIO ALPHA 🧪</WobblingTitle>
+            <Text style={styles.subtitle}>
+              Has descubierto el portal a las novedades del futuro
+            </Text>
+            <Text style={styles.eyebrow}>· · · modo ultrasecreto · · ·</Text>
+          </View>
+
+          {/* Estado actual + lever */}
+          <View style={styles.statusBlock}>
+            <Text style={styles.statusEyebrow}>tu nivel de aventura</Text>
+            <Text style={styles.statusValue} allowFontScaling={false}>
+              {enabled ? '⚡  ZONA ALPHA  ⚡' : '☁️  Mundano  ☁️'}
+            </Text>
+            <GiantLever active={enabled} onToggle={handleToggle} />
+            <RotatingPhrases />
+          </View>
+
+          {/* Pergamino: el pacto */}
+          <View style={styles.scrollCard}>
+            <Text style={styles.scrollTitle}>🔮 EL PACTO DEL PROBADOR</Text>
+            <Text style={styles.scrollBody}>
+              Al activar este modo, tu dispositivo se suscribirá al canal{' '}
+              <Text style={styles.scrollMono}>preview</Text> de EAS Update.
+            </Text>
+            <Text style={styles.scrollBody}>
+              Recibirás antes que nadie las novedades que el equipo publica en
+              la rama <Text style={styles.scrollMono}>preview</Text> del
+              proyecto. Cosas que aún no están en App Store ni Google Play.
+              Cosas que pueden fallar. Cosas brillantes y nuevas.
+            </Text>
+            <Text style={styles.scrollBody}>
+              Cuando lo desactives, en el próximo arranque volverás al canal{' '}
+              <Text style={styles.scrollMono}>production</Text>, como el resto
+              del mundo.
+            </Text>
+            <Text style={styles.scrollFootnote}>
+              Funciona en versiones instaladas desde la store. Si algo se rompe,
+              cierra y vuelve a abrir la app, o desactiva este modo.
+            </Text>
+          </View>
+
+          {/* Cierre */}
+          <Pressable
+            onPress={handleClose}
+            style={({ pressed }) => [
+              styles.closeButton,
+              pressed && { transform: [{ scale: 0.96 }] },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Cerrar laboratorio"
+          >
+            <Text style={styles.closeButtonText}>
+              {enabled ? '✦  cerrar y disfrutar  ✦' : '↩  volver al mundo gris'}
+            </Text>
+          </Pressable>
+        </ScrollView>
+
+        {/* Burst de confeti — montado bajo demanda, se desmonta solo */}
+        {burstKey !== null && (
+          <ConfettiBurst
+            key={burstKey}
+            centerX={width / 2 - 14}
+            centerY={height / 2 - 14}
+            variant={burstVariant}
+          />
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+// ─── Estilos ────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#1A1230',
+  },
+  scrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.18)',
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    gap: 28,
+  },
+  particle: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    textShadowColor: 'rgba(0,0,0,0.35)',
+    textShadowRadius: 6,
+    textShadowOffset: { width: 0, height: 2 },
+  },
+  confetti: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    fontSize: 26,
+  },
+
+  // Header
+  headerBlock: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  sparklesRow: {
+    flexDirection: 'row',
+    gap: 14,
+    marginBottom: 4,
+  },
+  sparkle: {
+    color: '#FFF',
+    fontSize: 22,
+    textShadowColor: 'rgba(0,0,0,0.4)',
+    textShadowRadius: 8,
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: '900',
+    color: '#FFFFFF',
+    letterSpacing: 1,
+    textAlign: 'center',
+    textShadowColor: 'rgba(0,0,0,0.5)',
+    textShadowRadius: 14,
+    textShadowOffset: { width: 0, height: 4 },
+  },
+  subtitle: {
+    color: 'rgba(255,255,255,0.95)',
+    fontSize: 15,
+    fontWeight: '600',
+    textAlign: 'center',
+    paddingHorizontal: 30,
+    textShadowColor: 'rgba(0,0,0,0.4)',
+    textShadowRadius: 6,
+  },
+  eyebrow: {
+    color: 'rgba(255,255,255,0.75)',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginTop: 8,
+  },
+
+  // Estado + lever
+  statusBlock: {
+    alignItems: 'center',
+    gap: 16,
+    paddingVertical: 18,
+    paddingHorizontal: 18,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.30)',
+    width: '100%',
+    maxWidth: 420,
+    ...Platform.select({
+      web: { boxShadow: '0 12px 36px rgba(0,0,0,0.35)' } as any,
+      default: {
+        shadowColor: '#000',
+        shadowOpacity: 0.35,
+        shadowOffset: { width: 0, height: 12 },
+        shadowRadius: 22,
+        elevation: 12,
+      },
+    }),
+  },
+  statusEyebrow: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+  },
+  statusValue: {
+    color: '#FFFFFF',
+    fontSize: 22,
+    fontWeight: '900',
+    letterSpacing: 1.2,
+    textAlign: 'center',
+    textShadowColor: 'rgba(0,0,0,0.5)',
+    textShadowRadius: 10,
+    textShadowOffset: { width: 0, height: 3 },
+  },
+  phrase: {
+    color: 'rgba(255,255,255,0.95)',
+    fontSize: 13,
+    fontWeight: '600',
+    fontStyle: 'italic',
+    textAlign: 'center',
+    paddingHorizontal: 6,
+    minHeight: 36,
+  },
+
+  // Lever
+  leverContainer: {
+    width: LEVER_WIDTH,
+    alignItems: 'center',
+  },
+  leverTrackBase: {
+    width: LEVER_WIDTH,
+    height: LEVER_HEIGHT,
+    borderRadius: LEVER_HEIGHT / 2,
+    backgroundColor: 'rgba(0,0,0,0.42)',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.55)',
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
+  leverTrackOn: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: LEVER_HEIGHT / 2,
+    overflow: 'hidden',
+  },
+  leverLabels: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 18,
+  },
+  leverLabel: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '900',
+    letterSpacing: 1.6,
+    textShadowColor: 'rgba(0,0,0,0.45)',
+    textShadowRadius: 4,
+  },
+  leverKnob: {
+    position: 'absolute',
+    top: (LEVER_HEIGHT - KNOB) / 2,
+    width: KNOB,
+    height: KNOB,
+    borderRadius: KNOB / 2,
+    backgroundColor: '#FFFFFF',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 3,
+    borderColor: 'rgba(0,0,0,0.18)',
+    ...Platform.select({
+      web: { boxShadow: '0 6px 14px rgba(0,0,0,0.45)' } as any,
+      default: {
+        shadowColor: '#000',
+        shadowOpacity: 0.45,
+        shadowOffset: { width: 0, height: 6 },
+        shadowRadius: 10,
+        elevation: 10,
+      },
+    }),
+  },
+  leverKnobIcon: {
+    fontSize: 36,
+  },
+
+  // Pergamino
+  scrollCard: {
+    width: '100%',
+    maxWidth: 460,
+    padding: 22,
+    borderRadius: 22,
+    backgroundColor: 'rgba(255, 248, 220, 0.94)',
+    borderWidth: 2,
+    borderColor: 'rgba(120, 80, 30, 0.45)',
+    gap: 12,
+    ...Platform.select({
+      web: { boxShadow: '0 14px 36px rgba(0,0,0,0.35)' } as any,
+      default: {
+        shadowColor: '#000',
+        shadowOpacity: 0.35,
+        shadowOffset: { width: 0, height: 12 },
+        shadowRadius: 20,
+        elevation: 12,
+      },
+    }),
+  },
+  scrollTitle: {
+    fontSize: 17,
+    fontWeight: '900',
+    color: '#3D2A0E',
+    letterSpacing: 0.4,
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  scrollBody: {
+    color: '#3D2A0E',
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  scrollMono: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: 'monospace',
+      default: 'monospace',
+    }),
+    fontWeight: '700',
+    backgroundColor: 'rgba(61, 42, 14, 0.10)',
+    color: '#3D2A0E',
+  },
+  scrollFootnote: {
+    color: 'rgba(61, 42, 14, 0.75)',
+    fontSize: 12,
+    fontStyle: 'italic',
+    marginTop: 4,
+    lineHeight: 17,
+  },
+
+  // Cerrar
+  closeButton: {
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+    borderRadius: 26,
+    backgroundColor: 'rgba(0,0,0,0.65)',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.55)',
+    marginTop: 4,
+  },
+  closeButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '800',
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+  },
+});

--- a/mcm-app/components/SecretMenuTrigger.tsx
+++ b/mcm-app/components/SecretMenuTrigger.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Pressable, StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import { useSecretTap } from '@/hooks/useSecretTap';
+import { usePreviewChannel } from '@/contexts/PreviewChannelContext';
+
+/**
+ * Envuelve a sus hijos con un detector de "7 taps rápidos" que abre el modal
+ * secreto del canal preview. Diseñado para envolver elementos puramente
+ * visuales (textos del pie, número de versión…): no añade ningún estilo, no
+ * intercepta ningún gesto excepto el press, y no rompe el layout del padre.
+ */
+export function SecretMenuTrigger({
+  children,
+  style,
+  accessibilityLabel,
+}: {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  accessibilityLabel?: string;
+}) {
+  const { openSecretMenu } = usePreviewChannel();
+  const tap = useSecretTap(openSecretMenu, { tapsRequired: 7 });
+
+  return (
+    <Pressable
+      onPress={tap.onPress}
+      style={[styles.wrapper, style]}
+      // `none` mantiene a los hijos sin acciones de accesibilidad propias;
+      // exponemos un label discreto solo si el caller lo pide.
+      accessibilityRole={accessibilityLabel ? 'button' : undefined}
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={6}
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    // No imponer ningún estilo: el hijo manda.
+  },
+});

--- a/mcm-app/components/VersionDisplay.tsx
+++ b/mcm-app/components/VersionDisplay.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/colors';
+import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
+import { usePreviewChannel } from '@/contexts/PreviewChannelContext';
 
 export const VersionDisplay: React.FC<{ style?: any }> = ({ style }) => {
   const [updateInfo, setUpdateInfo] = useState<string>('');
@@ -33,13 +35,24 @@ export const VersionDisplay: React.FC<{ style?: any }> = ({ style }) => {
   if (!updateInfo) return null;
 
   return (
-    <View style={[styles.container, style]}>
+    <SecretMenuTrigger
+      style={[styles.container, style]}
+      accessibilityLabel="Versión de la app"
+    >
       <Text style={[styles.versionText, { color: theme.icon }]}>
         {updateInfo}
+        <PreviewBadge />
       </Text>
-    </View>
+    </SecretMenuTrigger>
   );
 };
+
+/** Pequeño indicador discreto cuando el dispositivo está suscrito a preview. */
+function PreviewBadge() {
+  const { enabled } = usePreviewChannel();
+  if (!enabled) return null;
+  return <Text style={styles.previewBadge}>{' · alpha'}</Text>;
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -51,5 +64,8 @@ const styles = StyleSheet.create({
     opacity: 0.7,
     fontFamily: 'System',
     fontWeight: '400',
+  },
+  previewBadge: {
+    fontWeight: '700',
   },
 });

--- a/mcm-app/contexts/PreviewChannelContext.tsx
+++ b/mcm-app/contexts/PreviewChannelContext.tsx
@@ -1,0 +1,161 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
+import * as Updates from 'expo-updates';
+
+/**
+ * Activa o desactiva el canal "preview" de EAS Update en tiempo de ejecución,
+ * sin tener que distribuir un binario aparte. Vive como un flag persistido en
+ * AsyncStorage. Al arrancar la app, si el flag está activo, se aplica el
+ * override de URL+headers de `expo-updates` para que el próximo `checkForUpdate`
+ * pida bundles publicados en la branch `preview` de EAS Update.
+ *
+ * El override es **inocuo** mientras `runtimeVersion` del binario coincida con
+ * la del bundle preview. Si divergen, EAS simplemente no entrega nada y la app
+ * sigue funcionando con su bundle actual. Reversible: al desactivar el flag y
+ * reiniciar, la app vuelve a su canal nativo (`production`).
+ */
+
+const STORAGE_KEY = '@mcm_preview_channel_enabled';
+const PREVIEW_CHANNEL = 'preview';
+
+interface PreviewChannelContextValue {
+  /** ¿Está el dispositivo suscrito al canal preview? */
+  enabled: boolean;
+  /** Persistido y override aplicados — listo para usarse. */
+  hydrated: boolean;
+  /** Cambiar la suscripción. Para que tenga efecto, reiniciar la app. */
+  setEnabled: (next: boolean) => Promise<void>;
+  /** Modal espectacular para activar/desactivar. */
+  openSecretMenu: () => void;
+  closeSecretMenu: () => void;
+  isSecretMenuOpen: boolean;
+}
+
+const PreviewChannelContext = createContext<PreviewChannelContextValue>({
+  enabled: false,
+  hydrated: false,
+  setEnabled: async () => {},
+  openSecretMenu: () => {},
+  closeSecretMenu: () => {},
+  isSecretMenuOpen: false,
+});
+
+function readUpdateUrl(): string | null {
+  // Preferimos la URL del manifest que está embebida en el binario. En dev/web
+  // suele ser `undefined`, y entonces no aplicamos override (no haría nada).
+  const url =
+    (Constants.expoConfig as { updates?: { url?: string } } | null)?.updates
+      ?.url ??
+    (
+      Constants.manifest2 as {
+        extra?: { expoClient?: { updates?: { url?: string } } };
+      } | null
+    )?.extra?.expoClient?.updates?.url ??
+    null;
+  return typeof url === 'string' && url.length > 0 ? url : null;
+}
+
+function applyPreviewOverride(active: boolean) {
+  if (Platform.OS === 'web') return;
+  if (__DEV__) return; // dev client: el override no hace nada útil
+  try {
+    if (!active) {
+      Updates.setUpdateURLAndRequestHeadersOverride(null);
+      return;
+    }
+    const updateUrl = readUpdateUrl();
+    if (!updateUrl) return;
+    Updates.setUpdateURLAndRequestHeadersOverride({
+      updateUrl,
+      requestHeaders: { 'expo-channel-name': PREVIEW_CHANNEL },
+    });
+  } catch {
+    // No bloqueante: si el override falla, la app sigue en su canal nativo.
+  }
+}
+
+export function PreviewChannelProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [enabled, setEnabledState] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const [isSecretMenuOpen, setSecretMenuOpen] = useState(false);
+  const overrideAppliedRef = useRef(false);
+
+  // Hidratar el flag y aplicar override en el primer arranque.
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((v) => {
+        if (cancelled) return;
+        const active = v === '1';
+        setEnabledState(active);
+        if (active && !overrideAppliedRef.current) {
+          applyPreviewOverride(true);
+          overrideAppliedRef.current = true;
+        }
+        setHydrated(true);
+      })
+      .catch(() => {
+        if (!cancelled) setHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setEnabled = useCallback(async (next: boolean) => {
+    setEnabledState(next);
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, next ? '1' : '0');
+    } catch {
+      // ignore — el estado en memoria es la fuente principal durante la sesión
+    }
+    applyPreviewOverride(next);
+    overrideAppliedRef.current = next;
+  }, []);
+
+  const openSecretMenu = useCallback(() => setSecretMenuOpen(true), []);
+  const closeSecretMenu = useCallback(() => setSecretMenuOpen(false), []);
+
+  const value = useMemo(
+    () => ({
+      enabled,
+      hydrated,
+      setEnabled,
+      openSecretMenu,
+      closeSecretMenu,
+      isSecretMenuOpen,
+    }),
+    [
+      enabled,
+      hydrated,
+      setEnabled,
+      openSecretMenu,
+      closeSecretMenu,
+      isSecretMenuOpen,
+    ],
+  );
+
+  return (
+    <PreviewChannelContext.Provider value={value}>
+      {children}
+    </PreviewChannelContext.Provider>
+  );
+}
+
+export function usePreviewChannel(): PreviewChannelContextValue {
+  return useContext(PreviewChannelContext);
+}

--- a/mcm-app/hooks/useSecretTap.ts
+++ b/mcm-app/hooks/useSecretTap.ts
@@ -1,0 +1,78 @@
+import { useCallback, useRef } from 'react';
+import { Platform } from 'react-native';
+import * as Haptics from 'expo-haptics';
+
+/**
+ * Cuenta taps consecutivos dentro de una ventana de tiempo. Cuando se alcanza
+ * `tapsRequired`, dispara `onUnlock`. La ventana se reinicia si el usuario tarda
+ * demasiado entre taps.
+ *
+ * A partir del 4º tap se emite haptic con intensidad creciente para señalar al
+ * usuario que está pasando algo y vale la pena seguir tocando.
+ */
+export interface UseSecretTapOptions {
+  tapsRequired?: number;
+  /** Tiempo máximo entre taps (ms) antes de reiniciar la cuenta. */
+  resetAfterMs?: number;
+  /** Si false, no se emite ningún haptic intermedio. */
+  haptics?: boolean;
+}
+
+export interface UseSecretTapApi {
+  /** Conectar al `onPress` del elemento objetivo. */
+  onPress: () => void;
+  /** Resetear el contador manualmente (p.ej. al desmontar el modal). */
+  reset: () => void;
+}
+
+export function useSecretTap(
+  onUnlock: () => void,
+  options: UseSecretTapOptions = {},
+): UseSecretTapApi {
+  const { tapsRequired = 7, resetAfterMs = 1500, haptics = true } = options;
+  const countRef = useRef(0);
+  const lastTapRef = useRef(0);
+
+  const reset = useCallback(() => {
+    countRef.current = 0;
+    lastTapRef.current = 0;
+  }, []);
+
+  const triggerHaptic = useCallback(
+    (style: Haptics.ImpactFeedbackStyle) => {
+      if (!haptics || Platform.OS === 'web') return;
+      Haptics.impactAsync(style).catch(() => {});
+    },
+    [haptics],
+  );
+
+  const onPress = useCallback(() => {
+    const now = Date.now();
+    if (now - lastTapRef.current > resetAfterMs) {
+      countRef.current = 0;
+    }
+    lastTapRef.current = now;
+    countRef.current += 1;
+
+    // Haptic ramp creciente desde el 4º tap — pista creciente de que algo viene.
+    if (countRef.current >= 4 && countRef.current < tapsRequired) {
+      const remaining = tapsRequired - countRef.current;
+      if (remaining <= 1) triggerHaptic(Haptics.ImpactFeedbackStyle.Heavy);
+      else if (remaining <= 2)
+        triggerHaptic(Haptics.ImpactFeedbackStyle.Medium);
+      else triggerHaptic(Haptics.ImpactFeedbackStyle.Light);
+    }
+
+    if (countRef.current >= tapsRequired) {
+      reset();
+      if (Platform.OS !== 'web') {
+        Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        ).catch(() => {});
+      }
+      onUnlock();
+    }
+  }, [onUnlock, tapsRequired, resetAfterMs, triggerHaptic, reset]);
+
+  return { onPress, reset };
+}


### PR DESCRIPTION
## Resumen

Añade una forma de suscribir un dispositivo concreto al canal **`preview`** de EAS Update **desde dentro de la app ya instalada en stores**, sin necesidad de distribuir un binario aparte. Mientras esté activo, los OTAs vienen de la rama `preview` (que ya publica `.github/workflows/ota-preview.yml`); al desactivarlo, en el siguiente arranque el dispositivo vuelve al canal `production`.

## Cómo se descubre

- **7 taps rápidos** (ventana de 1.5s) sobre el número de versión (`VersionDisplay`) o sobre el tagline "Movimiento Consolación para el Mundo" del pie de Home y de Más.
- A partir del 4º tap se siente un haptic creciente (Light → Medium → Heavy → Success) como pista. Si se pausa > 1.5s, el contador se reinicia sin ruido.
- En el pie aparece un sutilísimo `· alpha` junto a la versión cuando está activo, para identificar el dispositivo de un vistazo.

## El modal "Laboratorio Alpha"

Deliberadamente exagerado, festivo y opuesto al estilo minimalista del resto de la app:

- Gradiente que muta entre 3 paletas (atardecer → cósmico → bosque) en ciclo continuo
- 14 emojis flotando (🚀 ✨ 🌈 🪄 🎉 🧪 🔮 ⭐ 💫 🌟 🎈 🛸) con trayectorias sinusoidales, rotación y escala pulsante
- Título "🧪 LABORATORIO ALPHA 🧪" con wobble continuo y respiración de escala, coronado por 4 ✦/✧ parpadeando
- Palanca gigante MUNDANO ↔ ALPHA con knob que rota y se desplaza con spring
- Frase rotatoria cada 4.2s con crossfade ("Pueden caer novedades sin previo aviso 🪂", etc.)
- Pergamino con la explicación técnica del pacto
- Burst de 26 emojis explotando al activar / "puff" de implosión al desactivar
- Haptic Success/Warning según corresponda

## Mecánica técnica

`Updates.setUpdateURLAndRequestHeadersOverride({ updateUrl, requestHeaders: { 'expo-channel-name': 'preview' } })`. Flag persistido en `AsyncStorage`. Se aplica al hidratar el provider **antes** de que `useOTAUpdate` haga su primer `checkForUpdateAsync` (2.5s de delay, sobra tiempo). Inocuo si la `runtimeVersion` del binario no coincide con la del bundle preview (EAS no entrega nada y la app sigue tal cual). Reversible.

## Archivos

**Nuevos:**
- `hooks/useSecretTap.ts` — contador de taps con ventana y haptic ramp
- `contexts/PreviewChannelContext.tsx` — flag persistido + override de canal + estado del modal
- `components/SecretMenuTrigger.tsx` — wrapper Pressable transparente que añade el gesto sin afectar layout
- `components/PreviewChannelModal.tsx` — el modal "Laboratorio Alpha" con Reanimated + LinearGradient

**Modificados:**
- `app/_layout.tsx` (provider + montaje del modal)
- `components/VersionDisplay.tsx` (envuelto + indicador "· alpha" cuando activo)
- `app/(tabs)/index.tsx` y `app/screens/MasHomeScreen.tsx` (tagline envuelto)

## Test plan

- [ ] Tap 7 veces rápido en la versión del Home → se abre el modal
- [ ] Tap 7 veces rápido en el tagline del Home → se abre el modal
- [ ] Tap 7 veces rápido en la versión y tagline del Más → se abre el modal
- [ ] Pausar > 1.5s entre taps → no se abre, contador reset
- [ ] Activar la palanca → confeti, haptic, indicador "· alpha" aparece en el pie
- [ ] Cerrar la app, reabrir → flag y override persisten
- [ ] Publicar un OTA al canal `preview` desde GitHub → el dispositivo con flag activo lo recibe
- [ ] Desactivar la palanca + reiniciar → vuelve a recibir del canal `production`
- [ ] Web: el modal abre pero el override no se aplica (no afecta; web no usa OTAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSVDY91EiwKKp1t3VzrAev)_