### PR TITLE
feat: añadir haptic feedback divertido en toda la app

### DIFF
--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -516,3 +516,5 @@ npx heroui-cli@latest agents-md --native --output AGENTS.md
 - Splash screen: HelloWave con 3 repeticiones (900ms total)
 - Sistema de Perfiles: reemplaza al viejo `featureFlags.ts`. Ver `types/profileConfig.ts` + `utils/resolveProfileConfig.ts`
 - Sistema de notificaciones push: ver `NOTIFICACIONES.md` en la raíz del monorepo
+- **Wordle:** `app/screens/WordleScreen.tsx` y `app/wordle.tsx` son código histórico sin uso activo. Nadie accede a él actualmente. No tocar ni añadirle funcionalidades hasta que se decida reactivarlo.
+- **Haptics:** `utils/haptics.ts` centraliza todo el feedback háptico. Usar las funciones semánticas de `h` (h.tap, h.add, h.remove, h.select, h.toggle, h.formSuccess…) en lugar de llamar a expo-haptics directamente.

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -30,6 +30,7 @@ import GlassFAB from '@/components/ui/GlassFAB';
 import { useLocalSearchParams } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { hexAlpha } from '@/utils/colorUtils';
+import { h } from '@/utils/haptics';
 
 LocaleConfig.locales['es'] = {
   monthNames: [
@@ -434,6 +435,7 @@ export default function Calendario() {
                 current={selectedDate}
                 onDayPress={(day) => {
                   if (day.dateString !== selectedDate) {
+                    h.select();
                     setSelectedDate(day.dateString);
                   }
                 }}

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/services/pushNotificationService';
 import { useCalendarConfig } from '@/contexts/CalendarConfigContext';
 import { useOTAContext } from '@/contexts/OTAContext';
+import { h } from '@/utils/haptics';
 import useCalendarEvents from '@/hooks/useCalendarEvents';
 import type { CalendarEvent } from '@/hooks/useCalendarEvents';
 
@@ -785,6 +786,7 @@ export default function Home() {
                     accessibilityLabel={item.label}
                     accessibilityRole="button"
                     onPress={() => {
+                      h.tap();
                       if (item.key === 'comunica') {
                         setPendingMasScreen('Comunica');
                       } else if (item.key === 'fotos') {

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ScrollView, StyleSheet, View, Platform, Text } from 'react-native';
 import { PressableFeedback, Skeleton } from 'heroui-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { h } from '@/utils/haptics';
 import FormattedContent from '@/components/FormattedContent';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -72,7 +73,7 @@ export default function ProfundizaScreen() {
             {data.paginas.map((p, idx) => (
               <View key={idx} style={styles.accordionWrapper}>
                 <PressableFeedback
-                  onPress={() => setOpenIdx(openIdx === idx ? null : idx)}
+                  onPress={() => { h.toggle(); setOpenIdx(openIdx === idx ? null : idx); }}
                   style={[
                     styles.accordion,
                     { backgroundColor: p.color || colors.primary },

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -25,6 +25,7 @@ import { useCurrentEvent } from '@/hooks/useCurrentEvent';
 import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
 import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/utils/firebaseApp';
+import { h } from '@/utils/haptics';
 import { useUserProfile } from '@/contexts/UserProfileContext';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import GlassFAB from '@/components/ui/GlassFAB';
@@ -139,6 +140,7 @@ export default function ReflexionesScreen() {
 
   async function addReflexion() {
     if (!fecha) return;
+    h.tap();
     setSaving(true);
     const nuevo: Reflexion = {
       id: Date.now().toString(),
@@ -157,6 +159,7 @@ export default function ReflexionesScreen() {
         Date.now().toString(),
       );
       setList([nuevo, ...list]);
+      h.formSuccess();
     } catch (e) {
       console.error('Error adding post', e);
     }

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -17,6 +17,7 @@ import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
 import * as Clipboard from 'expo-clipboard';
 import { Colors } from '@/constants/colors';
 import { durations } from '@/constants/animations';
+import { h } from '@/utils/haptics';
 
 // Apple iOS system green — used as a "selected/done" tint inside the
 // add/remove song button. Not part of the MCM brand palette: it's an
@@ -295,6 +296,7 @@ export default function SongDetailScreen({
       typeof currentIndex === 'number' &&
       currentIndex > 0
     ) {
+      h.navigate();
       const prevSong = navigationList[currentIndex - 1];
       animateAndSet(
         { ...prevSong, navigationList, currentIndex: currentIndex - 1, source },
@@ -309,6 +311,7 @@ export default function SongDetailScreen({
       typeof currentIndex === 'number' &&
       currentIndex < navigationList.length - 1
     ) {
+      h.navigate();
       const nextSong = navigationList[currentIndex + 1];
       animateAndSet(
         { ...nextSong, navigationList, currentIndex: currentIndex + 1, source },
@@ -348,8 +351,8 @@ export default function SongDetailScreen({
           Platform.OS !== 'ios' && { backgroundColor: floatBtnBg },
         ]}
         onPress={() => {
-          if (isSelected) removeSong(filename);
-          else addSong(filename);
+          if (isSelected) { h.remove(); removeSong(filename); }
+          else { h.add(); addSong(filename); }
         }}
         activeOpacity={0.7}
         accessibilityLabel={isSelected ? 'Quitar de selección' : 'Añadir a selección'}

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -8,6 +8,7 @@ import {
   Pressable,
   TouchableOpacity,
 } from 'react-native';
+import { h } from '@/utils/haptics';
 import { PressableFeedback } from 'heroui-native';
 import GlassSurface from '@/components/ui/GlassSurface';
 import { useToast } from '@/contexts/AppToastContext';
@@ -110,6 +111,7 @@ const SongControls: React.FC<SongControlsProps> = ({
 
   const toggleMenu = () => {
     const toOpen = !showActionButtons;
+    toOpen ? h.menuOpen() : h.menuClose();
     setShowActionButtons(toOpen);
     Animated.spring(rotateAnim, {
       toValue: toOpen ? 1 : 0,
@@ -175,7 +177,7 @@ const SongControls: React.FC<SongControlsProps> = ({
         isActive &&
           (isDark ? styles.actionButtonActiveDark : styles.actionButtonActive),
       ]}
-      onPress={onPress}
+      onPress={() => { h.tap(); onPress(); }}
     >
       <PressableFeedback.Highlight />
       <MaterialIcons

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { useSelectedSongs } from '../contexts/SelectedSongsContext';
+import { h } from '@/utils/haptics';
 import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useContextMenu } from '@/hooks/useContextMenu';
@@ -146,10 +147,10 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
 
     const cleanTitle = song.title.replace(/^\d+\.\s*/, '');
 
-    const contextHandler = useCallback(
-      () => onLongPress?.(song),
-      [onLongPress, song],
-    );
+    const contextHandler = useCallback(() => {
+      h.tap();
+      onLongPress?.(song);
+    }, [onLongPress, song]);
     const contextMenuProps = useContextMenu(
       onLongPress ? contextHandler : undefined,
     );
@@ -161,9 +162,11 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
         renderLeftActions={isSelected ? renderLeftActions : undefined}
         onSwipeableOpen={(direction) => {
           if (direction === 'right' && !isSelected) {
+            h.add();
             addSong(song.filename);
             swipeableRow.current?.close();
           } else if (direction === 'left' && isSelected) {
+            h.remove();
             removeSong(song.filename);
             swipeableRow.current?.close();
           }

--- a/mcm-app/components/TransposeBottomSheet.tsx
+++ b/mcm-app/components/TransposeBottomSheet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
+import { h } from '@/utils/haptics';
 import { MaterialIcons } from '@expo/vector-icons';
 import BottomSheet from './BottomSheet';
 import { Colors } from '@/constants/colors';
@@ -127,7 +128,7 @@ export default function TransposeBottomSheet({
                         ? styles.toneBtnDownDark
                         : styles.toneBtnDown,
                   ]}
-                  onPress={() => onSetTranspose(currentTranspose + step.value)}
+                  onPress={() => { h.select(); onSetTranspose(currentTranspose + step.value); }}
                 >
                   <PressableFeedback.Highlight />
                   <Text
@@ -206,7 +207,7 @@ export default function TransposeBottomSheet({
                   isDark ? styles.toneBtnDownDark : styles.toneBtnDown,
                   effectiveCapo <= 0 && styles.capoStepBtnDisabled,
                 ]}
-                onPress={handleCapoMinus}
+                onPress={() => { h.select(); handleCapoMinus(); }}
                 isDisabled={effectiveCapo <= 0}
               >
                 <PressableFeedback.Highlight />
@@ -270,7 +271,7 @@ export default function TransposeBottomSheet({
                   styles.capoStepBtn,
                   isDark ? styles.toneBtnUpDark : styles.toneBtnUp,
                 ]}
-                onPress={handleCapoPlus}
+                onPress={() => { h.select(); handleCapoPlus(); }}
               >
                 <PressableFeedback.Highlight />
                 <MaterialIcons

--- a/mcm-app/components/playlist/PlaylistRow.tsx
+++ b/mcm-app/components/playlist/PlaylistRow.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { h } from '@/utils/haptics';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -106,6 +107,7 @@ const PlaylistRow: React.FC<Props> = ({
       renderLeftActions={renderLeftActions}
       onSwipeableOpen={(direction, swipeable) => {
         if (direction === 'left') {
+          h.remove();
           swipeable.close();
           onRemove();
         }
@@ -211,7 +213,7 @@ const PlaylistRow: React.FC<Props> = ({
                 styles.reorderBtn,
                 !canMoveUp && styles.reorderBtnDisabled,
               ]}
-              onPress={onMoveUp}
+              onPress={() => { h.select(); onMoveUp?.(); }}
               disabled={!canMoveUp}
               hitSlop={6}
             >
@@ -234,7 +236,7 @@ const PlaylistRow: React.FC<Props> = ({
                 styles.reorderBtn,
                 !canMoveDown && styles.reorderBtnDisabled,
               ]}
-              onPress={onMoveDown}
+              onPress={() => { h.select(); onMoveDown?.(); }}
               disabled={!canMoveDown}
               hitSlop={6}
             >

--- a/mcm-app/utils/haptics.ts
+++ b/mcm-app/utils/haptics.ts
@@ -1,0 +1,69 @@
+import { Platform } from 'react-native';
+import * as Haptics from 'expo-haptics';
+
+const isNative = Platform.OS !== 'web';
+
+export const h = {
+  tap: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {}),
+
+  select: () =>
+    isNative &&
+    (Platform.OS === 'ios'
+      ? Haptics.selectionAsync().catch(() => {})
+      : Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {})),
+
+  add: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {}),
+
+  remove: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Rigid).catch(() => {}),
+
+  success: () =>
+    isNative &&
+    Haptics.notificationAsync(
+      Haptics.NotificationFeedbackType.Success,
+    ).catch(() => {}),
+
+  error: () =>
+    isNative &&
+    Haptics.notificationAsync(
+      Haptics.NotificationFeedbackType.Error,
+    ).catch(() => {}),
+
+  toggle: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Rigid).catch(() => {}),
+
+  menuOpen: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {}),
+
+  menuClose: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {}),
+
+  navigate: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {}),
+
+  formSuccess: () => {
+    if (!isNative) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    setTimeout(
+      () =>
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {}),
+      100,
+    );
+    setTimeout(
+      () =>
+        Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        ).catch(() => {}),
+      250,
+    );
+  },
+};


### PR DESCRIPTION
Crea utils/haptics.ts como utilidad central con funciones semánticas
(h.tap, h.add, h.remove, h.select, h.toggle, h.navigate, h.formSuccess…)
que encapsulan expo-haptics y garantizan que nunca se vibra en web.

Puntos donde se añade feedback háptico:
- SongListItem: Medium al añadir canción por swipe, Rigid al quitar
- SongListItem: tap suave al activar menú contextual (long press)
- SongControls (FAB): Medium al abrir menú, Light al cerrarlo;
  Light en cada botón de acción del menú
- TransposeBottomSheet: selectionAsync (efecto ratchet) en botones ±semitono
  y ±cejilla — como girar un dial mecánico
- SongDetailScreen: add/remove song con Medium/Rigid; Light al navegar
  entre canciones con swipe horizontal
- PlaylistRow: Rigid al quitar canción por swipe;
  selectionAsync (ratchet) en botones ↑↓ de reorden
- ProfundizaScreen: Rigid en cada acordeón al abrirse/cerrarse
- Calendario: selectionAsync al seleccionar un día
- Home: Light al tocar cualquier quick action del grid
- ReflexionesScreen: tap al iniciar envío + secuencia celebratoria
  (Light→Medium→Success) al guardarse la reflexión en Firebase

Documenta en CLAUDE.md que el Wordle es código histórico inactivo
y que haptics centralizado está en utils/haptics.ts.

https://claude.ai/code/session_019Jm9SPRsrNJgHRXajQMh2j