### PR TITLE
⚡ Bolt: [performance improvement] Hoist Context to prevent O(N) list re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-05-04 - [React Native Performance] FlatList header unmounting
 **Learning:** Defining a functional component for a `FlatList` header *inside* the parent component's scope (e.g., `const ListHeader = () => ...`) causes the header's component type reference to change on every parent render. This forces React to completely unmount and remount the header element, triggering unnecessary garbage collection, losing state (like input focus), and degrading scroll performance.
 **Action:** Always either define sub-components outside the parent scope, or memoize the rendered JSX element using `useMemo` (e.g., `const listHeaderComponent = useMemo(() => (...), [...])`) before passing it to `ListHeaderComponent`.
+
+## 2026-05-24 - [React Native Context Performance] Avoid context consumption deep in list items
+**Learning:** Consuming context (e.g., `useSelectedSongs()`) inside list item components (like `SongListItem`) completely defeats `React.memo`. When the context changes (e.g. a user adds a song to the list), *every single item* in the `FlatList` re-renders, causing an O(N) performance bottleneck for simple list interactions.
+**Action:** Keep list item components pure. Extract context consumption to the parent list component (e.g., `SongListScreen`) and pass only the necessary scalar values or stable callbacks down to the list items via props. This allows `React.memo` to successfully prevent re-renders for the N-1 untouched items.

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -100,7 +100,7 @@ export default function SongsListScreen({
     [scheme, insets.bottom, layout.isWide, layout.readableMaxWidth],
   );
   const isDark = scheme === 'dark';
-  const { addSong, removeSong, isSongSelected } = useSelectedSongs();
+  const { addSong, removeSong, isSongSelected, getSelectedSong } = useSelectedSongs();
   const [search, setSearch] = useState('');
   const [searchVisible, setSearchVisible] = useState(false);
   const [songs, setSongs] = useState<Song[]>([]);
@@ -394,9 +394,21 @@ export default function SongsListScreen({
         onPress={handleSongPress}
         onLongPress={handleSongLongPress}
         isSearchAllMode={isSearchAll}
+        isSelected={isSongSelected(item.filename)}
+        selectedTranspose={getSelectedSong(item.filename)?.transpose ?? 0}
+        onAddSong={addSong}
+        onRemoveSong={removeSong}
       />
     ),
-    [handleSongPress, handleSongLongPress, isSearchAll],
+    [
+      handleSongPress,
+      handleSongLongPress,
+      isSearchAll,
+      isSongSelected,
+      getSelectedSong,
+      addSong,
+      removeSong,
+    ],
   );
 
   if ((isLoading || loadingSongs) && songs.length === 0) {

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -7,7 +7,6 @@ import {
   Animated,
 } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
-import { useSelectedSongs } from '../contexts/SelectedSongsContext';
 import { h } from '@/utils/haptics';
 import { IconSymbol } from './ui/IconSymbol';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -41,6 +40,10 @@ interface SongListItemProps {
   onPress: (song: Song) => void;
   onLongPress?: (song: Song) => void;
   isSearchAllMode?: boolean;
+  isSelected: boolean;
+  selectedTranspose: number;
+  onAddSong: (filename: string) => void;
+  onRemoveSong: (filename: string) => void;
 }
 
 const SongListItem: React.FC<SongListItemProps> = React.memo(
@@ -49,20 +52,17 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
     onPress,
     onLongPress,
     isSearchAllMode = false,
+    isSelected,
+    selectedTranspose,
+    onAddSong,
+    onRemoveSong,
   }) {
-    const { addSong, removeSong, isSongSelected, getSelectedSong } =
-      useSelectedSongs();
     const { settings } = useSettings();
     const { notation } = settings;
     const scheme = useColorScheme();
     const styles = useMemo(() => createStyles(scheme || 'light'), [scheme]);
     const isDark = scheme === 'dark';
     const swipeableRow = useRef<Swipeable>(null);
-    const isSelected = isSongSelected(song.filename);
-    const selectedMeta = isSelected
-      ? getSelectedSong(song.filename)
-      : undefined;
-    const selectedTranspose = selectedMeta?.transpose ?? 0;
     const backgroundColorAnim = useRef(
       new Animated.Value(isSelected ? 1 : 0),
     ).current;
@@ -98,7 +98,7 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
         <TouchableOpacity
           style={styles.rightAction}
           onPress={() => {
-            addSong(song.filename);
+            onAddSong(song.filename);
             swipeableRow.current?.close();
           }}
         >
@@ -128,7 +128,7 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
         <TouchableOpacity
           style={styles.leftAction}
           onPress={() => {
-            removeSong(song.filename);
+            onRemoveSong(song.filename);
             swipeableRow.current?.close();
           }}
         >
@@ -163,11 +163,11 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
         onSwipeableOpen={(direction) => {
           if (direction === 'right' && !isSelected) {
             h.add();
-            addSong(song.filename);
+            onAddSong(song.filename);
             swipeableRow.current?.close();
           } else if (direction === 'left' && isSelected) {
             h.remove();
-            removeSong(song.filename);
+            onRemoveSong(song.filename);
             swipeableRow.current?.close();
           }
         }}


### PR DESCRIPTION
💡 **What:** Refactored `SongListItem` to accept `isSelected`, `selectedTranspose`, `onAddSong`, and `onRemoveSong` as explicit props instead of consuming `SelectedSongsContext` internally via the `useSelectedSongs()` hook. The context consumption was hoisted up to `SongListScreen`, which now passes down these derived primitives.

🎯 **Why:** Consuming a context that changes frequently (like `SelectedSongsContext` when a song is added/removed) directly inside a `FlatList` item defeats `React.memo()`. Whenever the selection changed, the context updated, forcing **every single** `SongListItem` in the list to re-render, creating an $O(N)$ re-render bottleneck for basic list interactions. By isolating the list item from the context and passing primitives, `React.memo()` can now successfully prevent re-renders for all unchanged items.

📊 **Impact:** Reduces re-renders from $N$ (number of rendered list items) to 1 (only the single item that was toggled). Greatly improves responsiveness when interacting with long song lists.

🔬 **Measurement:**
1. Open a category with a large number of songs (e.g. `__ALL__`).
2. Add a song to the selection by swiping right or long-pressing.
3. Observe that the list interaction is instantaneous and doesn't drop frames, as only the modified item re-renders.

---
*PR created automatically by Jules for task [1071763094618617308](https://jules.google.com/task/1071763094618617308) started by @mcmespana*