### PR TITLE
Add notification permission banner with smart re-registration

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,22 @@
 
 ---
 
+## 2026-05-24 — Banner de permisos de notificaciones
+
+- **Qué hace**: cuando el usuario aún no ha concedido permisos de notificaciones, aparece un banner en Home y en la pantalla de Notificaciones invitando a activarlas. Se descarta durante 7 días al pulsar la X.
+- **Estados manejados**: se muestra en `undetermined` (CTA "Activar" dispara el prompt nativo del sistema) y en `denied` (CTA "Abrir Ajustes" abre los Ajustes de la app con `Linking.openSettings()`). Se oculta en `granted` y `provisional`. En web no se muestra nunca.
+- **Persistencia**: timestamp de descarte en AsyncStorage (`@mcm_notif_permission_banner_dismissed_at`). El banner reaparece pasados 7 días.
+- **Reconsulta**: el banner vuelve a comprobar el estado de permisos cuando la app vuelve al foreground (`AppState 'active'`), de modo que se oculta automáticamente al volver de Ajustes tras conceder los permisos.
+- **Registro inmediato del token**: `usePushNotifications` ahora expone `tryRegisterPushToken()` y registra un listener de `AppState` que reintenta `registerAndSaveToken` al volver al foreground. Resultado: al conceder permisos (en-app o vía Ajustes), el token Expo Push se registra en Firebase sin esperar al siguiente arranque.
+- **Archivos nuevos**:
+  - `components/NotificationPermissionBanner.tsx`: componente reutilizable con prop `placement: 'home' | 'notifications'`.
+- **Archivos modificados**:
+  - `notifications/usePushNotifications.ts`: nuevo export `tryRegisterPushToken()`, espejo de metadata a nivel de módulo, listener de `AppState` para re-registro idempotente al foregroundear.
+  - `app/(tabs)/index.tsx`: inserta el banner en la columna izquierda, justo antes de la tarjeta de Novedades.
+  - `app/notifications.tsx`: inserta el banner justo debajo del header.
+
+---
+
 ## 2026-05-22 — Canal "preview" en caliente: modo Laboratorio Alpha (7 taps)
 
 - **Qué hace**: permite a un dispositivo suscribirse al canal `preview` de EAS Update desde dentro de la app instalada en stores, sin necesidad de un binario aparte. Mientras esté activo, los OTAs vienen de la rama `preview` (que ya publica `/.github/workflows/ota-preview.yml`); al desactivarlo, en el siguiente arranque vuelve al canal `production`.

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -40,6 +40,7 @@ import { useToast } from '@/contexts/AppToastContext';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
 import AppFeedbackModal from '@/components/AppFeedbackModal';
 import NotificationsBottomSheet from '@/components/NotificationsBottomSheet';
+import NotificationPermissionBanner from '@/components/NotificationPermissionBanner';
 import { VersionDisplay } from '@/components/VersionDisplay';
 import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
@@ -620,6 +621,9 @@ export default function Home() {
                 />
               </TouchableOpacity>
             )}
+
+            {/* ── Banner de permisos de notificaciones (denied / undetermined) ── */}
+            <NotificationPermissionBanner placement="home" />
 
             {/* ── Novedades ── */}
             <View style={styles.section}>

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/services/pushNotificationService';
 import { NotificationData, ReceivedNotification } from '@/types/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
+import NotificationPermissionBanner from '@/components/NotificationPermissionBanner';
 
 // Mapeo de rutas internas a nombres legibles
 const ROUTE_LABELS: Record<string, { label: string; icon: string }> = {
@@ -460,6 +461,8 @@ export default function NotificationsScreen() {
           <View style={styles.headerRight} />
         )}
       </View>
+
+      <NotificationPermissionBanner placement="notifications" />
 
       {loading ? (
         <View style={styles.emptyState}>

--- a/mcm-app/components/NotificationPermissionBanner.tsx
+++ b/mcm-app/components/NotificationPermissionBanner.tsx
@@ -1,0 +1,257 @@
+// components/NotificationPermissionBanner.tsx
+//
+// Banner que invita a activar las notificaciones cuando el usuario aún no las
+// ha concedido (estados `undetermined` y `denied`). Se descarta durante 7 días.
+//
+// - undetermined → CTA dispara el prompt nativo (Notifications.requestPermissionsAsync)
+// - denied       → CTA abre Ajustes del sistema (Linking.openSettings)
+// - granted / provisional → no se muestra
+// - web → no se muestra
+//
+// Tras concederse en cualquier flujo (en-app o desde Ajustes al volver al
+// foreground), se llama a `tryRegisterPushToken()` para registrar el token
+// sin esperar al siguiente arranque.
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  AppState,
+  AppStateStatus,
+  Linking,
+  Platform,
+  StyleSheet,
+  Text,
+  TextStyle,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import colors, { Colors } from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import { radii } from '@/constants/uiStyles';
+import { hexAlpha } from '@/utils/colorUtils';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { tryRegisterPushToken } from '@/notifications/usePushNotifications';
+
+const DISMISSED_KEY = '@mcm_notif_permission_banner_dismissed_at';
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+type Status = 'loading' | 'granted' | 'denied' | 'undetermined' | 'hidden';
+
+async function readPermissionStatus(): Promise<Exclude<Status, 'loading'>> {
+  try {
+    const res = (await Notifications.getPermissionsAsync()) as any;
+    if (res?.granted) return 'granted';
+    // iOS provisional: notificaciones silenciosas concedidas implícitamente
+    if (res?.ios?.status === 3 /* provisional */) return 'granted';
+    if (res?.status === 'denied' || res?.canAskAgain === false) return 'denied';
+    return 'undetermined';
+  } catch {
+    return 'hidden';
+  }
+}
+
+async function isWithinCooldown(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(DISMISSED_KEY);
+    if (!raw) return false;
+    const ts = Number(raw);
+    if (!Number.isFinite(ts)) return false;
+    return Date.now() - ts < COOLDOWN_MS;
+  } catch {
+    return false;
+  }
+}
+
+export default function NotificationPermissionBanner({
+  placement = 'home',
+}: {
+  placement?: 'home' | 'notifications';
+}) {
+  const scheme = useColorScheme() || 'light';
+  const theme = Colors[scheme];
+  const [status, setStatus] = useState<Status>('loading');
+
+  const refresh = useCallback(async () => {
+    if (Platform.OS === 'web') {
+      setStatus('hidden');
+      return;
+    }
+    const perm = await readPermissionStatus();
+    if (perm === 'granted' || perm === 'hidden') {
+      setStatus(perm);
+      return;
+    }
+    if (await isWithinCooldown()) {
+      setStatus('hidden');
+      return;
+    }
+    setStatus(perm);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Reconsultar al volver al foreground: cubre el caso de "vuelvo de Ajustes
+  // tras conceder permisos" sin tener que reiniciar la app.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (next === 'active') refresh();
+    });
+    return () => sub.remove();
+  }, [refresh]);
+
+  const handleActivate = useCallback(async () => {
+    if (status === 'undetermined') {
+      try {
+        const res = (await Notifications.requestPermissionsAsync()) as any;
+        if (res?.granted) {
+          // El usuario acaba de aceptar dentro de la app: registramos el
+          // token sin esperar al siguiente arranque.
+          tryRegisterPushToken().catch(() => {});
+          setStatus('granted');
+          return;
+        }
+      } catch {}
+      // Si tras pedirlo no quedó concedido (p. ej. denegó o ya no se puede
+      // volver a preguntar), refrescamos para mostrar la variante "Ajustes".
+      await refresh();
+      return;
+    }
+    // status === 'denied' → abrir Ajustes del sistema
+    try {
+      await Linking.openSettings();
+    } catch {}
+  }, [status, refresh]);
+
+  const handleDismiss = useCallback(async () => {
+    try {
+      await AsyncStorage.setItem(DISMISSED_KEY, String(Date.now()));
+    } catch {}
+    setStatus('hidden');
+  }, []);
+
+  if (status === 'loading' || status === 'hidden' || status === 'granted') {
+    return null;
+  }
+
+  const accentColor = scheme === 'dark' ? colors.info : colors.primary;
+  const ctaLabel = status === 'denied' ? 'Abrir Ajustes' : 'Activar';
+
+  const isNotifications = placement === 'notifications';
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: hexAlpha(accentColor, '12'),
+          borderColor: hexAlpha(accentColor, '30'),
+          marginHorizontal: isNotifications ? spacing.md : 0,
+          marginTop: isNotifications ? spacing.sm : 0,
+          marginBottom: isNotifications ? 0 : spacing.md,
+        },
+      ]}
+      accessibilityRole="alert"
+    >
+      <View
+        style={[
+          styles.iconCircle,
+          { backgroundColor: hexAlpha(accentColor, '18') },
+        ]}
+      >
+        <MaterialIcons
+          name="notifications-active"
+          size={20}
+          color={accentColor}
+        />
+      </View>
+      <View style={styles.textBlock}>
+        <Text style={[styles.title, { color: theme.text }]}>
+          Activa las notificaciones
+        </Text>
+        <Text style={[styles.body, { color: theme.icon }]} numberOfLines={3}>
+          No te pierdas nada. La app funciona mejor con avisos en tiempo real.
+        </Text>
+        <TouchableOpacity
+          onPress={handleActivate}
+          style={[styles.cta, { backgroundColor: hexAlpha(accentColor, '18') }]}
+          accessibilityRole="button"
+          accessibilityLabel={ctaLabel}
+        >
+          <Text style={[styles.ctaText, { color: accentColor }]}>
+            {ctaLabel}
+          </Text>
+          <MaterialIcons
+            name={status === 'denied' ? 'open-in-new' : 'arrow-forward'}
+            size={14}
+            color={accentColor}
+          />
+        </TouchableOpacity>
+      </View>
+      <TouchableOpacity
+        onPress={handleDismiss}
+        style={styles.close}
+        accessibilityRole="button"
+        accessibilityLabel="Descartar"
+        hitSlop={8}
+      >
+        <MaterialIcons name="close" size={18} color={theme.icon} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    padding: spacing.sm + 4,
+    paddingRight: spacing.md,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+  } as ViewStyle,
+  iconCircle: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    marginTop: 1,
+  } as ViewStyle,
+  textBlock: {
+    flex: 1,
+    gap: 4,
+  } as ViewStyle,
+  title: {
+    fontSize: 13,
+    fontWeight: '700',
+  } as TextStyle,
+  body: {
+    fontSize: 11,
+    lineHeight: 15,
+    opacity: 0.85,
+  } as TextStyle,
+  cta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: 5,
+    marginTop: spacing.xs,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: radii.pill,
+  } as ViewStyle,
+  ctaText: {
+    fontSize: 12,
+    fontWeight: '700',
+  } as TextStyle,
+  close: {
+    padding: 2,
+    marginLeft: 2,
+  } as ViewStyle,
+});

--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -11,7 +11,7 @@
 //      b. notificationResponse — usuario toca la notificación: navega a la ruta correspondiente y marca como leída
 //
 import { useEffect, useMemo, useRef } from 'react';
-import { Platform } from 'react-native';
+import { AppState, AppStateStatus, Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 import {
@@ -65,6 +65,25 @@ const ACTION_ROUTES: Record<string, string> = {
   view_photos: '/(tabs)/fotos',
 };
 
+// Metadata más reciente conocida del perfil. Se mantiene a nivel de módulo
+// para que `tryRegisterPushToken()` (invocado desde el banner de permisos)
+// pueda registrar el token con los topics correctos sin tener que pasar
+// la metadata como argumento.
+let latestMetadata: TokenProfileMetadata | null = null;
+
+/**
+ * Intenta registrar el token push usando la metadata de perfil más reciente
+ * conocida por el hook. Es idempotente y seguro de llamar desde cualquier
+ * punto: si los permisos no están concedidos, devuelve sin error.
+ *
+ * Pensado para el flujo del banner de permisos: tras conceder los permisos
+ * (in-app prompt o vuelta desde Ajustes), se llama esta función para que el
+ * token quede registrado sin esperar al siguiente arranque de la app.
+ */
+export async function tryRegisterPushToken(): Promise<void> {
+  await registerAndSaveToken(latestMetadata);
+}
+
 export default function usePushNotifications() {
   const notificationListener = useRef<any>(null);
   const responseListener = useRef<any>(null);
@@ -90,6 +109,8 @@ export default function usePushNotifications() {
   const metadataRef = useRef(profileMetadata);
   useEffect(() => {
     metadataRef.current = profileMetadata;
+    // Espejo a nivel de módulo para `tryRegisterPushToken()`.
+    latestMetadata = profileMetadata;
   }, [profileMetadata]);
 
   useEffect(() => {
@@ -207,13 +228,28 @@ export default function usePushNotifications() {
   useEffect(() => {
     updateLastActive(profileMetadata).catch(() => {});
   }, [profileMetadata]);
+
+  // Al volver al foreground, reintenta el registro. Cubre el caso de
+  // "vuelvo de Ajustes tras conceder permisos": `registerAndSaveToken`
+  // es idempotente (no-op si los permisos siguen denegados, refresca
+  // token y guarda en Firebase si pasaron a granted).
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (next === 'active') {
+        registerAndSaveToken(metadataRef.current).catch(() => {});
+      }
+    });
+    return () => sub.remove();
+  }, []);
 }
 
 /**
  * Flujo completo: permisos → token → guardar en Firebase
  * Con logging detallado para diagnosticar problemas
  */
-async function registerAndSaveToken(profileMetadata: TokenProfileMetadata) {
+async function registerAndSaveToken(
+  profileMetadata: TokenProfileMetadata | null,
+) {
   if (Platform.OS === 'web') return;
 
   try {
@@ -261,6 +297,6 @@ async function registerAndSaveToken(profileMetadata: TokenProfileMetadata) {
     await cachePushToken(token);
 
     // 5. Guardar en Firebase
-    await saveTokenToFirebase(token, profileMetadata);
+    await saveTokenToFirebase(token, profileMetadata ?? undefined);
   } catch {}
 }


### PR DESCRIPTION
## Summary

Implements a notification permission banner that prompts users to enable notifications when permissions are `undetermined` or `denied`. The banner appears on Home and Notifications screens, dismisses for 7 days when closed, and automatically re-checks permissions when the app returns to foreground. Additionally, push token registration now happens immediately after permissions are granted (either via in-app prompt or system Settings) rather than waiting for the next app launch.

## Key Changes

- **New component**: `NotificationPermissionBanner.tsx`
  - Shows on `undetermined` state with "Activar" CTA that triggers native permission prompt
  - Shows on `denied` state with "Abrir Ajustes" CTA that opens system Settings
  - Hides on `granted`/`provisional` states and web platform
  - Dismissal persists for 7 days via AsyncStorage
  - Re-checks permission status when app returns to foreground (`AppState` listener)
  - Accepts `placement` prop (`'home'` | `'notifications'`) for layout adjustments

- **Enhanced `usePushNotifications` hook**:
  - Exports new `tryRegisterPushToken()` function for immediate token registration
  - Maintains module-level `latestMetadata` mirror so banner can trigger registration without prop drilling
  - Adds `AppState` listener to retry `registerAndSaveToken` on foreground, making the flow idempotent
  - Allows `registerAndSaveToken` to accept `null` metadata (for banner use case)

- **Integration**:
  - Banner inserted in `app/(tabs)/index.tsx` (Home screen, left column before News card)
  - Banner inserted in `app/notifications.tsx` (Notifications screen, below header)

## Implementation Details

- **Idempotent registration**: `registerAndSaveToken` safely handles being called multiple times; if permissions remain denied, it's a no-op; if they became granted, it refreshes the token and saves to Firebase
- **No race conditions**: Module-level metadata is kept in sync via `useEffect` in the hook, ensuring the banner always has the latest profile context
- **Accessibility**: Banner marked as `alert` role; CTA and close button have proper labels and hit slop
- **Theme-aware**: Uses accent color (info in dark mode, primary in light mode) with alpha-blended backgrounds
- **Web-safe**: Component gracefully hides on web; `registerAndSaveToken` returns early on web

## Files Modified

- `components/NotificationPermissionBanner.tsx` (new)
- `notifications/usePushNotifications.ts`
- `app/(tabs)/index.tsx`
- `app/notifications.tsx`
- `CHANGELOG.md`

https://claude.ai/code/session_01QZ6J3rGiMuXQMh4d7MjfUZ