### PR TITLE
Refactor auto-scroll speed selector to vertical layout

### DIFF
--- a/mcm-app/app/screens/SongFullscreenScreen.tsx
+++ b/mcm-app/app/screens/SongFullscreenScreen.tsx
@@ -111,21 +111,20 @@ function AutoScrollControls({
 
   return (
     <View style={[styles.controlsCluster, { bottom }]} pointerEvents="box-none">
-      {/* Selector de velocidad — pill horizontal, sólo visible al interactuar */}
+      {/* Selector de velocidad — pill vertical, sólo visible al interactuar */}
       <Animated.View
         style={[styles.speedPanel, { opacity: fadeAnim }]}
         pointerEvents={expanded ? 'auto' : 'none'}
       >
         <TranslucentBg isDark={isDark} style={styles.speedPanelBg} />
-        <Text style={styles.speedHeading} numberOfLines={1}>
-          {currentLabel}
-        </Text>
+        {/* Segmentos del 5 (arriba/rápido) al 1 (abajo/lento) */}
         <View
-          style={styles.segmentRow}
+          style={styles.segmentColumn}
           accessibilityRole="adjustable"
           accessibilityLabel={`Velocidad de auto-scroll: ${currentLabel}`}
         >
-          {AUTO_SCROLL_SPEEDS.map((s, i) => {
+          {[...AUTO_SCROLL_SPEEDS].reverse().map((s, reversedI) => {
+            const i = AUTO_SCROLL_SPEEDS.length - 1 - reversedI;
             const selected = i === speedIndex;
             return (
               <Pressable
@@ -152,6 +151,9 @@ function AutoScrollControls({
             );
           })}
         </View>
+        <Text style={styles.speedHeading} numberOfLines={1}>
+          {currentLabel}
+        </Text>
       </Animated.View>
 
       {/* Play / Pause + acceso al selector con long-press */}
@@ -422,26 +424,26 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  /* Cluster inferior derecha */
+  /* Cluster inferior derecha — columna vertical alineada a la derecha */
   controlsCluster: {
     position: 'absolute',
     right: 16,
     flexDirection: 'column',
-    alignItems: 'flex-end',
-    gap: 10,
+    alignItems: 'center',
+    gap: 8,
     zIndex: 3,
   },
-  /* Panel horizontal con selector de velocidad */
+  /* Panel vertical con selector de velocidad */
   speedPanel: {
-    flexDirection: 'row',
+    flexDirection: 'column',
     alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
     borderRadius: 22,
     overflow: 'hidden',
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(255,255,255,0.22)',
-    gap: 10,
+    gap: 6,
     ...Platform.select({
       web: { boxShadow: '0 4px 18px rgba(0,0,0,0.28)' } as any,
       default: {
@@ -457,23 +459,22 @@ const styles = StyleSheet.create({
     borderRadius: 22,
   },
   speedHeading: {
-    color: 'rgba(255,255,255,0.92)',
-    fontSize: 11,
+    color: 'rgba(255,255,255,0.70)',
+    fontSize: 9,
     fontWeight: '700',
-    letterSpacing: 0.4,
+    letterSpacing: 0.3,
     textTransform: 'uppercase',
-    minWidth: 64,
-    textAlign: 'right',
+    textAlign: 'center',
   },
-  segmentRow: {
-    flexDirection: 'row',
+  segmentColumn: {
+    flexDirection: 'column',
     alignItems: 'center',
-    gap: 4,
+    gap: 5,
   },
   segment: {
-    width: 26,
-    height: 26,
-    borderRadius: 13,
+    width: 30,
+    height: 30,
+    borderRadius: 15,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(255,255,255,0.10)',

--- a/mcm-app/hooks/useAutoScroller.ts
+++ b/mcm-app/hooks/useAutoScroller.ts
@@ -45,30 +45,24 @@ const STORAGE_KEY = '@mcm_song_autoscroll_speed_index';
  */
 export const AUTO_SCROLL_CONTROLLER_JS = `(function(){
   if (window.__mcmScrollInstalled) return; window.__mcmScrollInstalled = true;
-  var target = 0;       // px/s objetivo
-  var current = 0;      // px/s real (con rampa suave)
-  var acc = 0;          // acumulador sub-píxel
+  var target = 0;
+  var current = 0;
   var lastT = 0;
   var raf = null;
-  var RAMP = 600;       // px/s por segundo (rampa de aceleración/frenado)
+  var RAMP = 600;
+  var scrollEl = document.scrollingElement || document.documentElement;
   function post(type){ try { window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: type })); } catch(e){} }
   function atBottom(){
-    var sy = window.scrollY || window.pageYOffset || document.documentElement.scrollTop || 0;
-    var vh = window.innerHeight || document.documentElement.clientHeight || 0;
-    var sh = Math.max(document.documentElement.scrollHeight || 0, document.body ? document.body.scrollHeight : 0);
-    return sy + vh >= sh - 1;
+    return scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 2;
   }
   function step(t){
     if (!lastT) lastT = t;
-    var dt = Math.min((t - lastT) / 1000, 0.05); // cap 50ms (evita saltos tras un freeze)
+    var dt = Math.min((t - lastT) / 1000, 0.05);
     lastT = t;
-    // Rampa suave hacia el objetivo
     if (current < target) current = Math.min(target, current + RAMP * dt);
     else if (current > target) current = Math.max(target, current - RAMP * dt);
     if (current > 0) {
-      acc += current * dt;
-      var px = Math.floor(acc);
-      if (px > 0) { window.scrollBy(0, px); acc -= px; }
+      scrollEl.scrollTop += current * dt;
       if (atBottom()) { target = 0; current = 0; raf = null; lastT = 0; post('scroll-end'); return; }
       raf = requestAnimationFrame(step);
     } else if (target <= 0) {
@@ -81,7 +75,6 @@ export const AUTO_SCROLL_CONTROLLER_JS = `(function(){
     target = +v || 0;
     if (target > 0 && !raf) { lastT = 0; raf = requestAnimationFrame(step); }
   };
-  // Interacción manual del usuario → pausar inmediatamente
   var onUserScroll = function(){
     if (target > 0) { target = 0; current = 0; post('user-paused'); }
   };
@@ -181,8 +174,7 @@ export function useAutoScroller({
 
     let raf: number | null = null;
     let lastT = 0;
-    let acc = 0;
-    let current = 0; // px/s con rampa suave
+    let current = 0;
     const RAMP = 600;
 
     const step = (t: number) => {
@@ -196,14 +188,9 @@ export function useAutoScroller({
         current = Math.max(target, current - RAMP * dt);
 
       if (current > 0) {
-        acc += current * dt;
-        const px = Math.floor(acc);
-        if (px > 0) {
-          el.scrollBy({ top: px });
-          acc -= px;
-        }
-        // Auto-pausa al llegar al final
-        const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+        el.scrollTop += current * dt;
+        const atBottom =
+          el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
         if (atBottom) {
           setIsPlaying(false);
           raf = null;


### PR DESCRIPTION
## Summary
Restructured the auto-scroll speed selector UI from a horizontal pill layout to a vertical column layout, improving visual hierarchy and interaction patterns. Also simplified the scroll animation logic by removing sub-pixel accumulation in favor of direct scroll position updates.

## Key Changes

### UI Layout (SongFullscreenScreen.tsx)
- **Speed panel orientation**: Changed from horizontal (`flexDirection: 'row'`) to vertical (`flexDirection: 'column'`)
- **Speed segments**: Reversed order so fastest speed (5) appears at top and slowest (1) at bottom, with segments displayed vertically
- **Label positioning**: Moved speed heading from top-left to bottom-center, styled smaller (9px, 0.70 opacity) for secondary visual hierarchy
- **Spacing adjustments**: Updated padding, gaps, and segment sizes to accommodate vertical layout (30×30px segments, 5px gap)
- **Alignment**: Changed `controlsCluster` from `alignItems: 'flex-end'` to `alignItems: 'center'` for centered vertical stacking

### Scroll Animation Logic (useAutoScroller.ts)
- **Removed sub-pixel accumulation**: Eliminated `acc` (accumulator) variable and `Math.floor()` logic
- **Direct scroll updates**: Changed from `window.scrollBy(0, px)` to direct `scrollEl.scrollTop += current * dt` assignment
- **Simplified scroll detection**: Consolidated scroll element references and bottom detection logic
- **Code cleanup**: Removed verbose comments while maintaining functionality

Both web (JavaScript) and native (TypeScript) implementations were updated consistently.

## Implementation Details
- Speed values still range 1–5 (slow to fast), but UI now displays them top-to-bottom (5 at top, 1 at bottom) via `.reverse()` with index remapping
- Smooth ramping acceleration/deceleration (600 px/s²) is preserved
- Auto-pause on scroll end and user-scroll detection remain unchanged
- All accessibility labels and roles maintained

https://claude.ai/code/session_01XYHHnTheA8kfZDCc8WEXgq