### PR TITLE
Perf: implement memo, reduce splash delay, and clean up redundant effects

### DIFF
--- a/MEJORAS.md
+++ b/MEJORAS.md
@@ -8,6 +8,17 @@
 
 ---
 
+## ✅ Ya implementado
+
+| ID  | Mejora                                        | Commit / fecha      |
+| --- | --------------------------------------------- | ------------------- |
+| 1.7 | `freezeOnBlur: true` en stacks de `cancionero.tsx` y `mas.tsx` | Previo al análisis |
+| 1.8 | HelloWave: 2 reps (600 ms) + skip tras primer arranque (`seenWelcomeOnce`) | 2026-05-25 |
+| 1.9 | `React.memo` en `SongSearch`, `AlbumCard`, `EventItem` | 2026-05-25 |
+| 1.11a | `SettingsContext`: eliminado `useEffect` redundante de guardado al desmontar | 2026-05-25 |
+
+---
+
 ## Resumen ejecutivo por áreas
 
 | Área                                | Estado actual                           | Acciones más relevantes                                   |
@@ -109,35 +120,35 @@ React 19 + Babel 7.25 soportan `babel-plugin-react-compiler`. La app ya está en
 
 **Propuesta:** instalar `babel-plugin-react-compiler` y añadirlo al `plugins`. Validar en `npm run lint` y benchmark de arranque. Revisar orden con reanimated si hay warnings.
 
-### 1.7 Stacks anidados sin `freezeOnBlur`
+### ~~1.7 Stacks anidados sin `freezeOnBlur`~~ ✅ HECHO
 
 **Archivos:** `mcm-app/app/_layout.tsx:182-202`, stacks internos de `cancionero.tsx` y `mas.tsx`.
 
-Añadir `screenOptions={{ freezeOnBlur: true }}` en los stacks de tabs no visibles libera CPU/memoria al cambiar de tab. Validar que no rompe estado al volver.
+`freezeOnBlur: true` ya estaba aplicado en ambos stacks antes del análisis. Las pantallas no visibles se congelan al cambiar de tab, liberando CPU/memoria.
 
-### 1.8 Splash post-launch de 900 ms (HelloWave)
+### ~~1.8 Splash post-launch de 900 ms (HelloWave)~~ ✅ HECHO
 
 **Archivos:** `mcm-app/components/HelloWave.tsx:22`, `mcm-app/app/_layout.tsx:116-121`
 
-3 repeticiones × 300 ms + `setTimeout(900)`. Reducir a 2 (600 ms) o saltar tras el primer arranque (`AsyncStorage` flag `seenWelcomeOnce`).
+Reducido a 2 repeticiones × 300 ms (600 ms). Además, el splash se salta por completo en arranques posteriores al primero mediante el flag `seenWelcomeOnce` en AsyncStorage.
 
-### 1.9 Componentes sin `React.memo` que sí lo necesitan
+### ~~1.9 Componentes sin `React.memo` que sí lo necesitan~~ ✅ HECHO
 
-- `mcm-app/components/SongSearch.tsx` — re-render en cada keystroke del padre.
-- `mcm-app/components/AlbumCard.tsx` — N renders en galerías.
-- `mcm-app/components/EventItem.tsx` — verificar.
+- `mcm-app/components/SongSearch.tsx` — envuelto en `React.memo`.
+- `mcm-app/components/AlbumCard.tsx` — envuelto en `React.memo`.
+- `mcm-app/components/EventItem.tsx` — envuelto en `React.memo` (ya usaba `useMemo` para estilos).
 
-`SongListItem.tsx:45` ya usa `React.memo` (referencia de buen patrón).
+`SongListItem.tsx:45` ya usaba `React.memo` como referencia de buen patrón.
 
 ### 1.10 Dependencias muertas o pesadas
 
 - `lodash` (`^4.17.21`) — **0 importaciones**. Eliminar.
 - `react-native-render-html` (`^6.3.4`) — solo en `FormattedContent.tsx`. Si BBCode simple bastara, ahorraría peso.
 
-### 1.11 Otros
+### 1.11 Otros (parcialmente resuelto)
 
-- `mcm-app/contexts/SettingsContext.tsx:85-117` — dos `useEffect` guardan settings (uno redundante).
-- 12 providers anidados en `mcm-app/app/_layout.tsx:51-83`. Considerar agrupar contextos relacionados.
+- ~~`mcm-app/contexts/SettingsContext.tsx:85-117` — dos `useEffect` guardan settings (uno redundante).~~ ✅ HECHO — eliminado el tercer `useEffect` de guardado al desmontar; el segundo ya persiste los settings en cada cambio.
+- `mcm-app/app/_layout.tsx:51-83` — **pendiente**: 12 providers anidados. Considerar agrupar contextos relacionados (ej. `UserProfile` + `ProfileConfig`) para reducir re-renders en cascada. Cambio de mayor envergadura, no trivial.
 
 ### 1.12 Plan recomendado (rendimiento)
 

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -4,6 +4,7 @@ import '../notifications/NotificationHandler'; // Inicializa el handler de notif
 import usePushNotifications from '../notifications/usePushNotifications'; // Hook para notificaciones push
 
 import React, { useState, useEffect, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { View, StyleSheet, Platform } from 'react-native';
 import Constants from 'expo-constants';
@@ -118,9 +119,19 @@ function InnerLayout() {
   const navigationTheme = scheme === 'dark' ? DarkTheme : DefaultTheme;
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setShowAnimation(false);
-    }, 900);
+    let timer: ReturnType<typeof setTimeout>;
+    AsyncStorage.getItem('seenWelcomeOnce')
+      .then((seen) => {
+        if (seen) {
+          setShowAnimation(false);
+          return;
+        }
+        AsyncStorage.setItem('seenWelcomeOnce', '1').catch(() => {});
+        timer = setTimeout(() => setShowAnimation(false), 600);
+      })
+      .catch(() => {
+        timer = setTimeout(() => setShowAnimation(false), 600);
+      });
     return () => clearTimeout(timer);
   }, []);
 

--- a/mcm-app/components/AlbumCard.tsx
+++ b/mcm-app/components/AlbumCard.tsx
@@ -148,4 +148,4 @@ const createStyles = (screenWidth: number) =>
     },
   });
 
-export default AlbumCard;
+export default React.memo(AlbumCard);

--- a/mcm-app/components/EventItem.tsx
+++ b/mcm-app/components/EventItem.tsx
@@ -18,7 +18,7 @@ export interface EventItemData {
   materiales?: boolean; // Si tiene materiales disponibles
 }
 
-export default function EventItem({
+const EventItem = React.memo(function EventItem({
   event,
   dayIndex,
   onNavigateToMateriales,
@@ -128,7 +128,9 @@ export default function EventItem({
       </Card.Body>
     </Card>
   );
-}
+});
+
+export default EventItem;
 
 const createStyles = (scheme: 'light' | 'dark' | null, scale: number) => {
   const isDark = scheme === 'dark';

--- a/mcm-app/components/HelloWave.tsx
+++ b/mcm-app/components/HelloWave.tsx
@@ -19,7 +19,7 @@ export function HelloWave() {
         withTiming(25, { duration: 150 }),
         withTiming(0, { duration: 150 }),
       ),
-      3, // Run the animation 3 times (300ms each = 900ms total)
+      2, // Run the animation 2 times (300ms each = 600ms total)
     );
   }, [rotationAnimation]);
 

--- a/mcm-app/components/SongSearch.tsx
+++ b/mcm-app/components/SongSearch.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SearchField } from 'heroui-native';
 
 interface SongSearchProps {
@@ -5,7 +6,7 @@ interface SongSearchProps {
   setSearchText: (text: string) => void;
 }
 
-export default function SongSearch({
+const SongSearch = React.memo(function SongSearch({
   searchText,
   setSearchText,
 }: SongSearchProps) {
@@ -18,4 +19,6 @@ export default function SongSearch({
       </SearchField.Group>
     </SearchField>
   );
-}
+});
+
+export default SongSearch;

--- a/mcm-app/contexts/SettingsContext.tsx
+++ b/mcm-app/contexts/SettingsContext.tsx
@@ -99,23 +99,6 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({
     saveSettings();
   }, [settings, isLoadingSettings]);
 
-  // Ensure latest settings are persisted if the provider unmounts before
-  // the save effect above runs (e.g. user quickly leaves the screen)
-  useEffect(() => {
-    return () => {
-      if (isLoadingSettings) return;
-      AsyncStorage.setItem(
-        SETTINGS_STORAGE_KEY,
-        JSON.stringify(settings),
-      ).catch((error) => {
-        console.error(
-          'Failed to save settings to AsyncStorage on unmount:',
-          error,
-        );
-      });
-    };
-  }, [settings, isLoadingSettings]);
-
   const handleSetSettings = useCallback((newValues: Partial<SongSettings>) => {
     setAppSettings((prevSettings) => ({
       ...prevSettings,


### PR DESCRIPTION
## Summary

Implements four performance improvements identified in the technical analysis (MEJORAS.md):
- Wraps frequently re-rendered components in `React.memo`
- Reduces HelloWave splash animation from 900ms to 600ms and skips it on subsequent app launches
- Removes redundant `useEffect` from SettingsContext that was persisting settings on unmount

## Key Changes

- **SongSearch, AlbumCard, EventItem**: Wrapped in `React.memo` to prevent unnecessary re-renders when parent updates
  - `SongSearch.tsx`: Memoized to avoid re-renders on every keystroke in parent
  - `AlbumCard.tsx`: Memoized to optimize gallery rendering with multiple cards
  - `EventItem.tsx`: Memoized (already used `useMemo` for styles)

- **HelloWave splash optimization** (`HelloWave.tsx`, `_layout.tsx`):
  - Reduced animation from 3 repetitions (900ms) to 2 repetitions (600ms)
  - Added `seenWelcomeOnce` flag in AsyncStorage to skip splash entirely on subsequent launches
  - First launch: shows 600ms animation
  - Subsequent launches: splash hidden immediately

- **SettingsContext cleanup** (`SettingsContext.tsx`):
  - Removed redundant `useEffect` that persisted settings on component unmount
  - Kept the primary effect that saves settings on every change
  - Reduces unnecessary AsyncStorage writes and simplifies cleanup logic

## Implementation Details

- All memoization uses standard `React.memo()` wrapper pattern (consistent with existing `SongListItem.tsx`)
- AsyncStorage operations in `_layout.tsx` include proper error handling with fallback to 600ms timeout
- No breaking changes to component APIs or behavior

https://claude.ai/code/session_011wvVZgD9NABmFBVgX7FNz4