### PR TITLE
Modo Carismochito: easter egg verde al agitar el móvil

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,22 @@
 
 ---
 
+## 2026-05-25 — Modo Carismochito (easter egg por shake)
+
+Easter egg: al agitar el móvil aparece una cuenta atrás de 5 segundos que, si no se cancela, activa el "Modo Carismochito" — un guiño a la mascota del MCM tintando toda la app de un verde lima deliberadamente exagerado. Se desactiva agitando otra vez o tocando el badge flotante.
+
+- **Detección de shake**: nuevo `hooks/useShakeDetector.ts` basado en `expo-sensors` (carga perezosa para no romper en web). Umbral configurable (~3 picos > 1.9g en 700ms, cooldown 1.2s).
+- **Estado global**: `contexts/CarismochitoContext.tsx` con tres estados (`idle`, `countingDown`, `active`); una sola acción de "shake" se interpreta como activar / cancelar / desactivar según el estado actual.
+- **UI**: `components/CarismochitoOverlay.tsx` renderiza:
+  - Pantalla de cuenta atrás con la mascota SVG (verde slime con ojos negros, lengua rosa), número pulsante, halo verde y botón "Cancelar".
+  - Cuando está activo: tinte verde lima (`#7FFF00`) sobre toda la app con viñeta superior/inferior + badge flotante "MODO CARISMOCHITO" que también permite desactivar al tocarlo.
+- **Wiring**: `CarismochitoProvider` añadido al árbol de providers y `<CarismochitoOverlay />` al final de `InnerLayout` (encima de tabs, debajo del toast).
+- **Nueva dependencia nativa**: `expo-sensors ~55.0.8` — **requiere un nuevo build EAS** para que funcione en dispositivo (en web queda inerte).
+- Archivos nuevos: `hooks/useShakeDetector.ts`, `contexts/CarismochitoContext.tsx`, `components/CarismochitoOverlay.tsx`.
+- Archivos modificados: `app/_layout.tsx`, `package.json`.
+
+---
+
 ## 2026-05-25 — Activación de React Compiler
 
 - **Qué cambia**: se activa `babel-plugin-react-compiler` (React 19 + Babel 7.25). El compilador memoiza automáticamente componentes y valores derivados, eliminando re-renders innecesarios sin necesidad de `useMemo`/`useCallback`/`React.memo` manuales.

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -48,6 +48,8 @@ import OTAUpdatePrompt from '@/components/OTAUpdatePrompt';
 import { OTAProvider, useOTAContext } from '@/contexts/OTAContext';
 import { PreviewChannelProvider } from '@/contexts/PreviewChannelContext';
 import { PreviewChannelModal } from '@/components/PreviewChannelModal';
+import { CarismochitoProvider } from '@/contexts/CarismochitoContext';
+import CarismochitoOverlay from '@/components/CarismochitoOverlay';
 // Importar iconos para asegurar que se incluyan en el build
 import '@/constants/iconAssets';
 
@@ -69,7 +71,9 @@ export default function RootLayout() {
                             <CalendarConfigProvider>
                               <PreviewChannelProvider>
                                 <OTAProvider>
-                                  <InnerLayout />
+                                  <CarismochitoProvider>
+                                    <InnerLayout />
+                                  </CarismochitoProvider>
                                 </OTAProvider>
                               </PreviewChannelProvider>
                             </CalendarConfigProvider>
@@ -225,6 +229,7 @@ function InnerLayout() {
         onLater={() => setDismissed(true)}
       />
       <PreviewChannelModal />
+      <CarismochitoOverlay />
     </NavThemeProvider>
   );
 }

--- a/mcm-app/components/CarismochitoOverlay.tsx
+++ b/mcm-app/components/CarismochitoOverlay.tsx
@@ -1,0 +1,500 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Easing,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import Svg, { Circle, Ellipse, Path } from 'react-native-svg';
+import { useCarismochito } from '@/contexts/CarismochitoContext';
+import { useShakeDetector } from '@/hooks/useShakeDetector';
+import { h } from '@/utils/haptics';
+
+// Verdes deliberadamente exagerados — guiño a la mascota MCM.
+const SLIME = '#7FFF00'; // verde lima eléctrico ("muy feo")
+const SLIME_DEEP = '#5BC700';
+const SLIME_DARK = '#0D2E00';
+
+/* -------------------------------------------------------------------------- */
+/* Mascota                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function CarismochitoFace({ size = 140 }: { size?: number }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 120 120">
+      {/* Aura — anillo translúcido */}
+      <Circle cx="60" cy="62" r="58" fill={SLIME} opacity={0.18} />
+      {/* Cuerpo */}
+      <Path
+        d="M60 10 C32 10 14 36 14 64 C14 90 32 110 60 110 C88 110 106 90 106 64 C106 36 88 10 60 10 Z"
+        fill={SLIME}
+      />
+      {/* Brillo */}
+      <Ellipse cx="42" cy="32" rx="14" ry="7" fill="#E8FFB8" opacity={0.85} />
+      {/* Ojos */}
+      <Circle cx="44" cy="56" r="9" fill={SLIME_DARK} />
+      <Circle cx="76" cy="56" r="9" fill={SLIME_DARK} />
+      <Circle cx="47" cy="53" r="3" fill="#fff" />
+      <Circle cx="79" cy="53" r="3" fill="#fff" />
+      {/* Sonrisa */}
+      <Path
+        d="M40 74 Q60 92 80 74"
+        stroke={SLIME_DARK}
+        strokeWidth={4}
+        strokeLinecap="round"
+        fill="none"
+      />
+      {/* Lengua */}
+      <Path d="M52 82 Q60 90 68 82 Q60 88 52 82 Z" fill="#FF6B9D" />
+      {/* Mejillas */}
+      <Circle cx="26" cy="72" r="6" fill={SLIME_DEEP} opacity={0.55} />
+      <Circle cx="94" cy="72" r="6" fill={SLIME_DEEP} opacity={0.55} />
+    </Svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pantalla de cuenta atrás                                                   */
+/* -------------------------------------------------------------------------- */
+
+function CountdownScreen({
+  countdown,
+  onCancel,
+}: {
+  countdown: number;
+  onCancel: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  // Pop-in del modal al aparecer
+  const enter = useRef(new Animated.Value(0)).current;
+  // Pulso del número en cada tick
+  const numberScale = useRef(new Animated.Value(1)).current;
+  // Bobbing de la mascota
+  const bob = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.spring(enter, {
+      toValue: 1,
+      tension: 90,
+      friction: 10,
+      useNativeDriver: true,
+    }).start();
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bob, {
+          toValue: 1,
+          duration: 900,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bob, {
+          toValue: 0,
+          duration: 900,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [enter, bob]);
+
+  useEffect(() => {
+    // Pulso en cada cambio del número
+    numberScale.setValue(0.6);
+    Animated.spring(numberScale, {
+      toValue: 1,
+      tension: 80,
+      friction: 6,
+      useNativeDriver: true,
+    }).start();
+    h.tap();
+  }, [countdown, numberScale]);
+
+  const enterOpacity = enter;
+  const enterScale = enter.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.92, 1],
+  });
+  const bobY = bob.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, -10],
+  });
+
+  return (
+    <Animated.View
+      style={[styles.countdownRoot, { opacity: enterOpacity }]}
+      pointerEvents="auto"
+    >
+      {/* Fondo en degradado verde-oscuro */}
+      <LinearGradient
+        colors={['#001A00', SLIME_DARK, '#0D4400']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+      {/* Halo de lima */}
+      <View pointerEvents="none" style={styles.haloOuter}>
+        <View style={styles.halo} />
+      </View>
+
+      <Animated.View
+        style={[
+          styles.countdownContent,
+          { transform: [{ scale: enterScale }] },
+          { paddingTop: insets.top + 24, paddingBottom: insets.bottom + 24 },
+        ]}
+      >
+        <Animated.View style={{ transform: [{ translateY: bobY }] }}>
+          <CarismochitoFace size={150} />
+        </Animated.View>
+
+        <Text style={styles.activatingLabel}>activando modo</Text>
+        <Text style={styles.carismoTitle}>CARISMOCHITO</Text>
+
+        <Animated.Text
+          style={[styles.number, { transform: [{ scale: numberScale }] }]}
+        >
+          {countdown}
+        </Animated.Text>
+
+        <Text style={styles.subtle}>
+          Agita otra vez o pulsa Cancelar para cortar
+        </Text>
+
+        <Pressable
+          onPress={() => {
+            h.remove();
+            onCancel();
+          }}
+          style={({ pressed }) => [
+            styles.cancelBtn,
+            pressed && { opacity: 0.75, transform: [{ scale: 0.98 }] },
+          ]}
+          hitSlop={8}
+        >
+          <Text style={styles.cancelText}>Cancelar</Text>
+        </Pressable>
+      </Animated.View>
+    </Animated.View>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tinte + badge flotante mientras está activo                                */
+/* -------------------------------------------------------------------------- */
+
+function ActiveTint() {
+  const fade = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fade, {
+      toValue: 1,
+      duration: 700,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [fade]);
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[StyleSheet.absoluteFill, styles.tintRoot, { opacity: fade }]}
+    >
+      {/* Capa verde plana — el "wash" general */}
+      <View style={[StyleSheet.absoluteFill, styles.tintFlat]} />
+      {/* Viñeta superior */}
+      <LinearGradient
+        colors={[`${SLIME}CC`, 'transparent']}
+        style={[StyleSheet.absoluteFill, { height: '40%' }]}
+      />
+      {/* Viñeta inferior */}
+      <LinearGradient
+        colors={['transparent', `${SLIME}CC`]}
+        style={[StyleSheet.absoluteFill, { top: '60%', height: '40%' }]}
+      />
+    </Animated.View>
+  );
+}
+
+function FloatingBadge({ onDeactivate }: { onDeactivate: () => void }) {
+  const insets = useSafeAreaInsets();
+  const enter = useRef(new Animated.Value(0)).current;
+  const bob = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.spring(enter, {
+      toValue: 1,
+      tension: 80,
+      friction: 9,
+      useNativeDriver: true,
+    }).start();
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bob, {
+          toValue: 1,
+          duration: 1100,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bob, {
+          toValue: 0,
+          duration: 1100,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [enter, bob]);
+
+  const translateY = Animated.add(
+    enter.interpolate({
+      inputRange: [0, 1],
+      outputRange: [-60, 0],
+    }),
+    bob.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, -4],
+    }),
+  );
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      style={[
+        styles.badgeRoot,
+        { top: insets.top + 8, opacity: enter, transform: [{ translateY }] },
+      ]}
+    >
+      <Pressable
+        onPress={() => {
+          h.toggle();
+          onDeactivate();
+        }}
+        style={({ pressed }) => [
+          styles.badge,
+          pressed && { transform: [{ scale: 0.97 }], opacity: 0.92 },
+        ]}
+        hitSlop={6}
+      >
+        <CarismochitoFace size={36} />
+        <View style={styles.badgeText}>
+          <Text style={styles.badgeTitle}>MODO CARISMOCHITO</Text>
+          <Text style={styles.badgeSubtitle}>Agita o tócame para salir</Text>
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Overlay principal                                                          */
+/* -------------------------------------------------------------------------- */
+
+export default function CarismochitoOverlay() {
+  const { state, countdown, toggleByShake, cancelCountdown, deactivate } =
+    useCarismochito();
+
+  // Listener de shake siempre activo — el contexto decide qué hacer según estado.
+  useShakeDetector(toggleByShake);
+
+  // Haptic + log al entrar en activo
+  useEffect(() => {
+    if (state === 'active') h.formSuccess();
+  }, [state]);
+
+  return (
+    <>
+      {state === 'active' ? <ActiveTint /> : null}
+      {state === 'active' ? <FloatingBadge onDeactivate={deactivate} /> : null}
+      {state === 'countingDown' ? (
+        <View style={styles.modalRoot} pointerEvents="auto">
+          <CountdownScreen countdown={countdown} onCancel={cancelCountdown} />
+        </View>
+      ) : null}
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Estilos                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const styles = StyleSheet.create({
+  /* Tinte activo */
+  tintRoot: {
+    zIndex: 50,
+    elevation: 50,
+  },
+  tintFlat: {
+    backgroundColor: SLIME,
+    opacity: 0.32,
+  },
+
+  /* Badge flotante */
+  badgeRoot: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 9500,
+    elevation: 60,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: SLIME_DARK,
+    borderRadius: 28,
+    paddingVertical: 6,
+    paddingLeft: 6,
+    paddingRight: 16,
+    gap: 10,
+    borderWidth: 2,
+    borderColor: SLIME,
+    ...Platform.select({
+      ios: {
+        shadowColor: SLIME,
+        shadowOffset: { width: 0, height: 6 },
+        shadowOpacity: 0.55,
+        shadowRadius: 18,
+      },
+      android: {
+        elevation: 16,
+      },
+      default: {
+        // @ts-ignore - web only
+        boxShadow: `0px 6px 22px ${SLIME}AA`,
+      },
+    }),
+  },
+  badgeText: {
+    paddingRight: 4,
+  },
+  badgeTitle: {
+    color: SLIME,
+    fontWeight: '900',
+    fontSize: 12,
+    letterSpacing: 1.4,
+  },
+  badgeSubtitle: {
+    color: '#D4F5A0',
+    fontSize: 10,
+    marginTop: 2,
+    letterSpacing: 0.3,
+  },
+
+  /* Modal de cuenta atrás */
+  modalRoot: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9998,
+    elevation: 80,
+  },
+  countdownRoot: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  countdownContent: {
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  haloOuter: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  halo: {
+    width: 420,
+    height: 420,
+    borderRadius: 210,
+    backgroundColor: SLIME,
+    opacity: 0.18,
+    ...Platform.select({
+      ios: {
+        shadowColor: SLIME,
+        shadowOpacity: 0.7,
+        shadowRadius: 80,
+        shadowOffset: { width: 0, height: 0 },
+      },
+      android: { elevation: 0 },
+      default: {
+        // @ts-ignore - web only
+        boxShadow: `0px 0px 120px ${SLIME}`,
+      },
+    }),
+  },
+  activatingLabel: {
+    color: SLIME,
+    fontSize: 14,
+    fontWeight: '600',
+    letterSpacing: 4,
+    textTransform: 'uppercase',
+    marginTop: 18,
+    opacity: 0.85,
+  },
+  carismoTitle: {
+    color: '#E8FFB8',
+    fontSize: 28,
+    fontWeight: '900',
+    letterSpacing: 3,
+    marginTop: 4,
+    textShadowColor: SLIME,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 18,
+  },
+  number: {
+    color: SLIME,
+    fontSize: 140,
+    fontWeight: '900',
+    marginTop: 8,
+    textShadowColor: SLIME,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 24,
+    includeFontPadding: false,
+    lineHeight: 150,
+  },
+  subtle: {
+    color: '#A3D86E',
+    fontSize: 13,
+    marginTop: 4,
+    marginBottom: 28,
+    textAlign: 'center',
+    opacity: 0.85,
+  },
+  cancelBtn: {
+    paddingVertical: 14,
+    paddingHorizontal: 36,
+    borderRadius: 30,
+    backgroundColor: '#ffffff',
+    borderWidth: 2,
+    borderColor: SLIME,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.3,
+        shadowRadius: 10,
+      },
+      android: { elevation: 8 },
+      default: {
+        // @ts-ignore - web only
+        boxShadow: '0px 4px 14px rgba(0,0,0,0.3)',
+      },
+    }),
+  },
+  cancelText: {
+    color: SLIME_DARK,
+    fontWeight: '800',
+    fontSize: 16,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+  },
+});

--- a/mcm-app/contexts/CarismochitoContext.tsx
+++ b/mcm-app/contexts/CarismochitoContext.tsx
@@ -1,0 +1,115 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export type CarismochitoState = 'idle' | 'countingDown' | 'active';
+
+interface CarismochitoContextValue {
+  state: CarismochitoState;
+  /** Segundos restantes durante la cuenta atrás (5 → 0). */
+  countdown: number;
+  isActive: boolean;
+  /** Acción asociada a "agitar el móvil": activa, cancela o desactiva según estado. */
+  toggleByShake: () => void;
+  /** Cancela la cuenta atrás (botón "Cancelar"). */
+  cancelCountdown: () => void;
+  /** Desactiva el modo (tocando el badge flotante). */
+  deactivate: () => void;
+}
+
+const COUNTDOWN_SECONDS = 5;
+
+const Ctx = createContext<CarismochitoContextValue | null>(null);
+
+export function useCarismochito() {
+  const v = useContext(Ctx);
+  if (!v) {
+    throw new Error(
+      'useCarismochito debe usarse dentro de CarismochitoProvider',
+    );
+  }
+  return v;
+}
+
+export function CarismochitoProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [state, setState] = useState<CarismochitoState>('idle');
+  const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const startCountdown = useCallback(() => {
+    stopTimer();
+    setCountdown(COUNTDOWN_SECONDS);
+    setState('countingDown');
+    intervalRef.current = setInterval(() => {
+      setCountdown((c) => {
+        if (c <= 1) {
+          stopTimer();
+          setState('active');
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
+  }, [stopTimer]);
+
+  const cancelCountdown = useCallback(() => {
+    stopTimer();
+    setCountdown(COUNTDOWN_SECONDS);
+    setState('idle');
+  }, [stopTimer]);
+
+  const deactivate = useCallback(() => {
+    stopTimer();
+    setCountdown(COUNTDOWN_SECONDS);
+    setState('idle');
+  }, [stopTimer]);
+
+  const toggleByShake = useCallback(() => {
+    setState((prev) => {
+      if (prev === 'idle') {
+        startCountdown();
+        return 'countingDown';
+      }
+      if (prev === 'countingDown') {
+        cancelCountdown();
+        return 'idle';
+      }
+      // active → desactivar
+      deactivate();
+      return 'idle';
+    });
+  }, [startCountdown, cancelCountdown, deactivate]);
+
+  useEffect(() => () => stopTimer(), [stopTimer]);
+
+  return (
+    <Ctx.Provider
+      value={{
+        state,
+        countdown,
+        isActive: state === 'active',
+        toggleByShake,
+        cancelCountdown,
+        deactivate,
+      }}
+    >
+      {children}
+    </Ctx.Provider>
+  );
+}

--- a/mcm-app/hooks/useShakeDetector.ts
+++ b/mcm-app/hooks/useShakeDetector.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+/**
+ * Detecta cuándo el usuario agita el dispositivo midiendo picos del
+ * acelerómetro. Se considera "shake" cuando se acumulan varios picos
+ * por encima del umbral dentro de una ventana corta.
+ *
+ * Usa `expo-sensors` cargado dinámicamente para no romper el bundle en
+ * plataformas donde no esté disponible (web, simuladores sin sensores).
+ */
+export interface UseShakeDetectorOptions {
+  /** Aceleración mínima (en g) para contar como pico. 2.0 = sacudida media. */
+  threshold?: number;
+  /** Cuántos picos en `windowMs` para disparar `onShake`. */
+  peaksRequired?: number;
+  /** Ventana de tiempo para acumular picos (ms). */
+  windowMs?: number;
+  /** Tiempo mínimo entre detecciones (ms) para evitar repeticiones. */
+  cooldownMs?: number;
+  /** Si `false`, no se suscribe al acelerómetro. */
+  enabled?: boolean;
+}
+
+export function useShakeDetector(
+  onShake: () => void,
+  options: UseShakeDetectorOptions = {},
+) {
+  const {
+    threshold = 1.9,
+    peaksRequired = 3,
+    windowMs = 700,
+    cooldownMs = 1200,
+    enabled = true,
+  } = options;
+
+  const callbackRef = useRef(onShake);
+  callbackRef.current = onShake;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (Platform.OS === 'web') return; // expo-sensors poco fiable en web
+
+    let subscription: { remove: () => void } | null = null;
+    let cancelled = false;
+
+    // Carga perezosa para que la app arranque aunque el módulo nativo no esté.
+    import('expo-sensors')
+      .then(({ Accelerometer }) => {
+        if (cancelled) return;
+        Accelerometer.setUpdateInterval(80);
+        const peaks: number[] = [];
+        let lastFireAt = 0;
+        subscription = Accelerometer.addListener(({ x, y, z }) => {
+          const magnitude = Math.sqrt(x * x + y * y + z * z);
+          const now = Date.now();
+          // Limpia picos fuera de la ventana.
+          while (peaks.length && now - peaks[0] > windowMs) peaks.shift();
+          if (magnitude >= threshold) {
+            peaks.push(now);
+            if (
+              peaks.length >= peaksRequired &&
+              now - lastFireAt >= cooldownMs
+            ) {
+              lastFireAt = now;
+              peaks.length = 0;
+              callbackRef.current();
+            }
+          }
+        });
+      })
+      .catch(() => {
+        // expo-sensors no disponible — feature degrada en silencio.
+      });
+
+    return () => {
+      cancelled = true;
+      subscription?.remove();
+    };
+  }, [enabled, threshold, peaksRequired, windowMs, cooldownMs]);
+}

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -40,6 +40,7 @@
         "expo-notifications": "~55.0.11",
         "expo-print": "~55.0.15",
         "expo-router": "~55.0.4",
+        "expo-sensors": "~55.0.8",
         "expo-sharing": "~55.0.11",
         "expo-splash-screen": "~55.0.10",
         "expo-status-bar": "~55.0.4",
@@ -50,7 +51,6 @@
         "firebase": "^12.10.0",
         "heroui-native": "^1.0.0",
         "jest": "~29.7.0",
-        "lodash": "^4.17.21",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.6",
@@ -10425,6 +10425,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-sensors": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-sensors/-/expo-sensors-55.0.15.tgz",
+      "integrity": "sha512-kQ4JsgnkM4niP5IHzC8cqs94Lngp9SIuKbaFI2rauXiON8iGndodUAl/Pccpe8W1UHS4NQu6kcrAOi0rpIiowg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-server": {

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -48,6 +48,7 @@
     "expo-notifications": "~55.0.11",
     "expo-print": "~55.0.15",
     "expo-router": "~55.0.4",
+    "expo-sensors": "~55.0.8",
     "expo-sharing": "~55.0.11",
     "expo-splash-screen": "~55.0.10",
     "expo-status-bar": "~55.0.4",


### PR DESCRIPTION
Agitar el dispositivo dispara una cuenta atrás de 5 segundos que activa
un tinte verde lima sobre toda la app, guiño a la mascota MCM. Cancelable
desde la propia cuenta atrás o agitando de nuevo. Una vez activo se
desactiva agitando o tocando el badge flotante.

- hooks/useShakeDetector con expo-sensors (carga perezosa, web inerte)
- contexts/CarismochitoContext: state machine idle/countingDown/active
- components/CarismochitoOverlay: countdown con mascota SVG + tinte
  + viñetas verticales + badge flotante con bobbing

Requiere nuevo build EAS por la dependencia nativa expo-sensors.