### PR TITLE
chore: protección OTA para paquetes nativos + flag [skip-ota]

### DIFF
--- a/.github/workflows/ota-preview.yml
+++ b/.github/workflows/ota-preview.yml
@@ -12,6 +12,11 @@ concurrency:
 
 jobs:
   publish-preview:
+    # Salta si el mensaje del commit contiene [skip-ota] (p.ej. cuando se añaden paquetes nativos)
+    # En workflow_dispatch siempre corre (el usuario lo lanzó explícitamente)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.head_commit.message, '[skip-ota]')
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} # yamllint disable-line

--- a/.github/workflows/ota-production.yml
+++ b/.github/workflows/ota-production.yml
@@ -12,6 +12,11 @@ concurrency:
 
 jobs:
   publish-prod:
+    # Salta si el mensaje del commit contiene [skip-ota] (p.ej. cuando se añaden paquetes nativos)
+    # En workflow_dispatch siempre corre (el usuario lo lanzó explícitamente)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.head_commit.message, '[skip-ota]')
     runs-on: ubuntu-latest
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }} # yamllint disable-line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,63 @@
 └── EVENTOS.md             ← Cómo crear eventos (Jubileo, encuentros, retiros…) y estructura Firebase
 ```
 
+## 🚨🚨🚨 CRÍTICO: OTA vs Build de Tienda 🚨🚨🚨
+
+> **LEE ESTO ANTES DE CUALQUIER CAMBIO QUE AÑADA PAQUETES**
+
+### ⚠️ Cuándo NO se puede usar OTA (EAS Update)
+
+Los **OTA updates** (Expo/EAS Update) sólo envían el **bundle JavaScript**. NO incluyen código nativo.
+
+**Si el cambio añade cualquiera de estas cosas, la OTA ROMPERÁ LA APP en producción:**
+
+- ❌ Un paquete npm nuevo que tenga módulos nativos (la mayoría de `expo-*`, `react-native-*`)
+- ❌ Una actualización de SDK de Expo a una versión mayor
+- ❌ Cualquier cambio en `app.json` que afecte a la capa nativa (permisos, plugins, etc.)
+- ❌ Cambios en `package.json` que incluyan paquetes con código nativo nuevo
+
+**Por qué crashea:** el bundle JS llama a un módulo nativo que no existe en el binario instalado → crash inmediato al arrancar.
+
+### ✅ Regla para agentes
+
+**ANTES de proponer o hacer commit de un cambio que añada paquetes:**
+
+1. 🔍 **Investiga** si el paquete tiene código nativo (busca `ios/` o `android/` en su repo, o `"nativeModulesDir"` en `package.json`)
+2. 🛑 Si tiene código nativo → **el cambio NO puede desplegarse por OTA**
+3. 📢 **Avisa al usuario con el bloque de advertencia de abajo**
+4. 🏷️ **Añade `[skip-ota]` al mensaje del commit** (o al merge commit) para que el workflow de GitHub Actions NO lance el OTA automático
+
+### 🚫 Bloque de advertencia obligatorio para el usuario
+
+Cuando detectes que un cambio incluye paquetes nativos, COPIA y MUESTRA este mensaje al usuario:
+
+---
+
+> 🚨🚨🚨 **ATENCIÓN: ESTE CAMBIO REQUIERE BUILD DE TIENDA** 🚨🚨🚨
+>
+> ⛔ **NO se puede desplegar por OTA.** Se han añadido paquetes con código nativo:
+> `<lista de paquetes>`
+>
+> 📦 **Para que funcione en producción hay que:**
+> 1. Hacer un **build de producción** (`npm run eas:build -- --profile production`) y subir a App Store / Play Store
+> 2. El commit de merge a `production` lleva `[skip-ota]` en el mensaje → el workflow OTA quedará en pausa automáticamente ✅
+>
+> ⚠️ Si haces merge a `production` sin `[skip-ota]` y sin haber subido el build a tienda, **la app crasheará para todos los usuarios.**
+
+---
+
+### 🏷️ Cómo usar `[skip-ota]`
+
+Incluye `[skip-ota]` en el **mensaje del commit** (o del merge commit a `production`/`preview`):
+
+```
+feat: añadir expo-camera para escanear QR [skip-ota]
+```
+
+El workflow `.github/workflows/ota-production.yml` detecta esto y **no lanza el OTA**, evitando el crash. En `workflow_dispatch` manual siempre corre (asumiendo que el usuario lo lanzó a propósito).
+
+---
+
 ## Reglas para agentes
 
 1. **Trabaja siempre desde `mcm-app/`** para cualquier cambio de código
@@ -21,6 +78,7 @@
 3. **Documenta cambios importantes en `mcm-app/CHANGELOG.md`** — NO documentes cambios cosméticos (colores, padding, etc.), SÍ documenta: nuevas pantallas, cambios de navegación, cambios de lógica de datos, cambios en feature flags, nuevas dependencias, cambios en Firebase
 4. **Consulta `mcm-app/TODO.md`** para ver la lista de tareas pendientes de mantenimiento y mejora
 5. **No toques archivos `.env.local`** — contienen credenciales de Firebase
+6. **Si añades paquetes nativos → añade `[skip-ota]` al commit y avisa al usuario** (ver sección crítica arriba)
 
 ## Comandos rápidos (desde mcm-app/)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,63 +14,6 @@
 └── EVENTOS.md             ← Cómo crear eventos (Jubileo, encuentros, retiros…) y estructura Firebase
 ```
 
-## 🚨🚨🚨 CRÍTICO: OTA vs Build de Tienda 🚨🚨🚨
-
-> **LEE ESTO ANTES DE CUALQUIER CAMBIO QUE AÑADA PAQUETES**
-
-### ⚠️ Cuándo NO se puede usar OTA (EAS Update)
-
-Los **OTA updates** (Expo/EAS Update) sólo envían el **bundle JavaScript**. NO incluyen código nativo.
-
-**Si el cambio añade cualquiera de estas cosas, la OTA ROMPERÁ LA APP en producción:**
-
-- ❌ Un paquete npm nuevo que tenga módulos nativos (la mayoría de `expo-*`, `react-native-*`)
-- ❌ Una actualización de SDK de Expo a una versión mayor
-- ❌ Cualquier cambio en `app.json` que afecte a la capa nativa (permisos, plugins, etc.)
-- ❌ Cambios en `package.json` que incluyan paquetes con código nativo nuevo
-
-**Por qué crashea:** el bundle JS llama a un módulo nativo que no existe en el binario instalado → crash inmediato al arrancar.
-
-### ✅ Regla para agentes
-
-**ANTES de proponer o hacer commit de un cambio que añada paquetes:**
-
-1. 🔍 **Investiga** si el paquete tiene código nativo (busca `ios/` o `android/` en su repo, o `"nativeModulesDir"` en `package.json`)
-2. 🛑 Si tiene código nativo → **el cambio NO puede desplegarse por OTA**
-3. 📢 **Avisa al usuario con el bloque de advertencia de abajo**
-4. 🏷️ **Añade `[skip-ota]` al mensaje del commit** (o al merge commit) para que el workflow de GitHub Actions NO lance el OTA automático
-
-### 🚫 Bloque de advertencia obligatorio para el usuario
-
-Cuando detectes que un cambio incluye paquetes nativos, COPIA y MUESTRA este mensaje al usuario:
-
----
-
-> 🚨🚨🚨 **ATENCIÓN: ESTE CAMBIO REQUIERE BUILD DE TIENDA** 🚨🚨🚨
->
-> ⛔ **NO se puede desplegar por OTA.** Se han añadido paquetes con código nativo:
-> `<lista de paquetes>`
->
-> 📦 **Para que funcione en producción hay que:**
-> 1. Hacer un **build de producción** (`npm run eas:build -- --profile production`) y subir a App Store / Play Store
-> 2. El commit de merge a `production` lleva `[skip-ota]` en el mensaje → el workflow OTA quedará en pausa automáticamente ✅
->
-> ⚠️ Si haces merge a `production` sin `[skip-ota]` y sin haber subido el build a tienda, **la app crasheará para todos los usuarios.**
-
----
-
-### 🏷️ Cómo usar `[skip-ota]`
-
-Incluye `[skip-ota]` en el **mensaje del commit** (o del merge commit a `production`/`preview`):
-
-```
-feat: añadir expo-camera para escanear QR [skip-ota]
-```
-
-El workflow `.github/workflows/ota-production.yml` detecta esto y **no lanza el OTA**, evitando el crash. En `workflow_dispatch` manual siempre corre (asumiendo que el usuario lo lanzó a propósito).
-
----
-
 ## Reglas para agentes
 
 1. **Trabaja siempre desde `mcm-app/`** para cualquier cambio de código
@@ -78,7 +21,7 @@ El workflow `.github/workflows/ota-production.yml` detecta esto y **no lanza el 
 3. **Documenta cambios importantes en `mcm-app/CHANGELOG.md`** — NO documentes cambios cosméticos (colores, padding, etc.), SÍ documenta: nuevas pantallas, cambios de navegación, cambios de lógica de datos, cambios en feature flags, nuevas dependencias, cambios en Firebase
 4. **Consulta `mcm-app/TODO.md`** para ver la lista de tareas pendientes de mantenimiento y mejora
 5. **No toques archivos `.env.local`** — contienen credenciales de Firebase
-6. **Si añades paquetes nativos → añade `[skip-ota]` al commit y avisa al usuario** (ver sección crítica arriba)
+6. **Si añades paquetes con código nativo → añade `[skip-ota]` al commit y avisa al usuario** (ver OTA en `mcm-app/CLAUDE.md`)
 
 ## Comandos rápidos (desde mcm-app/)
 

--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -22,47 +22,19 @@ npm test               # Jest (sin tests escritos aún)
 npx tsc --noEmit       # Verificar tipos TypeScript
 ```
 
-## 🚨🚨🚨 CRÍTICO: OTA vs Build de Tienda 🚨🚨🚨
+## OTA vs Build de tienda
 
-### ⚠️ Cuándo NO se puede usar OTA (EAS Update)
+Los OTA updates (EAS Update) solo envían el **bundle JS** — no incluyen código nativo. Si añades un paquete con módulos nativos (`expo-*`, `react-native-*` con carpeta `ios/` o `android/`) y haces OTA, **la app crashea** porque el binario instalado no tiene ese módulo.
 
-Los **OTA updates** sólo envían el **bundle JavaScript**. **NO incluyen código nativo.**
+Cuando añadas un paquete nativo:
+1. Añade `[skip-ota]` al mensaje del commit → el workflow `ota-production.yml` se salta automáticamente
+2. Avisa al usuario de que necesita un **build de producción** antes de mergear a `production`:
+   ```
+   ⚠️ Este cambio incluye paquetes nativos ([lista]). Requiere build de tienda antes del merge a production. El commit lleva [skip-ota] para no lanzar la OTA.
+   ```
+3. Comando para el build: `npm run eas:build -- --profile production`
 
-Si el cambio añade cualquiera de estas cosas, la OTA **ROMPERÁ LA APP** en producción:
-
-- ❌ Un paquete npm nuevo con módulos nativos (mayoría de `expo-*`, `react-native-*`)
-- ❌ Actualización de SDK de Expo a versión mayor
-- ❌ Cambios en `app.json` que afecten la capa nativa (permisos, plugins)
-
-**Por qué crashea:** el bundle JS llama a un módulo nativo que no existe en el binario instalado → crash inmediato.
-
-### ✅ Protocolo obligatorio cuando añadas paquetes nativos
-
-1. 🔍 Verifica si el paquete tiene código nativo (busca `ios/` o `android/` en su repositorio)
-2. 🏷️ Añade `[skip-ota]` al mensaje del commit para bloquear el workflow OTA automático
-3. 📢 Muestra al usuario este aviso:
-
-> 🚨🚨🚨 **ATENCIÓN: ESTE CAMBIO REQUIERE BUILD DE TIENDA** 🚨🚨🚨
->
-> ⛔ **NO se puede desplegar por OTA.** Se han añadido paquetes con código nativo:
-> `<lista de paquetes>`
->
-> 📦 Para que funcione en producción hay que hacer un **build de producción** y subir a App Store / Play Store:
-> ```bash
-> npm run eas:build -- --profile production
-> ```
->
-> ✅ El commit lleva `[skip-ota]` → el workflow OTA quedará en pausa automáticamente.
->
-> ⚠️ Si haces merge a `production` sin `[skip-ota]` y sin subir el build a tienda, **la app crasheará para todos los usuarios.**
-
-### 🏷️ Sintaxis de `[skip-ota]`
-
-```
-feat: añadir expo-camera para escanear QR [skip-ota]
-```
-
-El workflow `.github/workflows/ota-production.yml` detecta `[skip-ota]` en el mensaje del commit y no lanza el OTA. En `workflow_dispatch` manual siempre corre.
+En `workflow_dispatch` manual la OTA siempre corre independientemente del flag.
 
 ---
 

--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -22,6 +22,50 @@ npm test               # Jest (sin tests escritos aún)
 npx tsc --noEmit       # Verificar tipos TypeScript
 ```
 
+## 🚨🚨🚨 CRÍTICO: OTA vs Build de Tienda 🚨🚨🚨
+
+### ⚠️ Cuándo NO se puede usar OTA (EAS Update)
+
+Los **OTA updates** sólo envían el **bundle JavaScript**. **NO incluyen código nativo.**
+
+Si el cambio añade cualquiera de estas cosas, la OTA **ROMPERÁ LA APP** en producción:
+
+- ❌ Un paquete npm nuevo con módulos nativos (mayoría de `expo-*`, `react-native-*`)
+- ❌ Actualización de SDK de Expo a versión mayor
+- ❌ Cambios en `app.json` que afecten la capa nativa (permisos, plugins)
+
+**Por qué crashea:** el bundle JS llama a un módulo nativo que no existe en el binario instalado → crash inmediato.
+
+### ✅ Protocolo obligatorio cuando añadas paquetes nativos
+
+1. 🔍 Verifica si el paquete tiene código nativo (busca `ios/` o `android/` en su repositorio)
+2. 🏷️ Añade `[skip-ota]` al mensaje del commit para bloquear el workflow OTA automático
+3. 📢 Muestra al usuario este aviso:
+
+> 🚨🚨🚨 **ATENCIÓN: ESTE CAMBIO REQUIERE BUILD DE TIENDA** 🚨🚨🚨
+>
+> ⛔ **NO se puede desplegar por OTA.** Se han añadido paquetes con código nativo:
+> `<lista de paquetes>`
+>
+> 📦 Para que funcione en producción hay que hacer un **build de producción** y subir a App Store / Play Store:
+> ```bash
+> npm run eas:build -- --profile production
+> ```
+>
+> ✅ El commit lleva `[skip-ota]` → el workflow OTA quedará en pausa automáticamente.
+>
+> ⚠️ Si haces merge a `production` sin `[skip-ota]` y sin subir el build a tienda, **la app crasheará para todos los usuarios.**
+
+### 🏷️ Sintaxis de `[skip-ota]`
+
+```
+feat: añadir expo-camera para escanear QR [skip-ota]
+```
+
+El workflow `.github/workflows/ota-production.yml` detecta `[skip-ota]` en el mensaje del commit y no lanza el OTA. En `workflow_dispatch` manual siempre corre.
+
+---
+
 ### Builds EAS (IMPORTANTE)
 
 **NUNCA uses `npx eas-cli build` directamente.** Usa siempre los scripts npm que limpian los symlinks de skills de Claude Code (`.agent/`, `.agents/`) antes de comprimir. Sin esto, EAS falla en Windows con error `EPERM: operation not permitted, symlink`.


### PR DESCRIPTION
## Qué hace este PR

Protege contra crashes en producción cuando se añaden paquetes con código nativo y se despliega por OTA.

## Cambios

**Workflows** (`ota-production.yml` y `ota-preview.yml`):
- Si el mensaje del commit contiene `[skip-ota]`, el job se salta automáticamente
- En `workflow_dispatch` siempre corre (lanzado explícitamente)

**Documentación** (`CLAUDE.md` raíz y `mcm-app/CLAUDE.md`):
- Explica por qué los paquetes nativos crashean con OTA
- Documenta el protocolo: `[skip-ota]` en el commit + avisar al usuario de que necesita build de tienda

## Uso

```
feat: añadir expo-camera [skip-ota]
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0154sfi3fVuWWwDHC8VnJrxg)_