### PR TITLE
feat(onboarding): pantalla completa edge-to-edge + retoques visuales

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,15 @@
 
 ---
 
+## 2026-05-27 — Onboarding edge-to-edge
+
+- El onboarding ahora ocupa la pantalla completa, incluida la zona del notch / status bar / home indicator. El fondo del paso actual (azul marca en la bienvenida, blanco en los siguientes) cubre todo el shell sin recortes blancos arriba.
+- `app/_layout.tsx`: la pantalla `onboarding` pasa de `presentation: 'modal'` a `presentation: 'fullScreenModal'` y se le fija `contentStyle.backgroundColor` al azul de marca para evitar parpadeos blancos al abrir.
+- `app/onboarding.tsx`: sustituido el `SafeAreaView` exterior por un `View` con fondo dinámico por paso; cada step gestiona sus propios `insets` vía `useSafeAreaInsets`. La status bar se conmuta a `light` durante la bienvenida.
+- Pequeños retoques de diseño (no funcionales): badge "Te damos la bienvenida", logo con flotación suave, copy más cálido ("¡Vamos allá!"), icono `celebration` y pequeño pop en la pantalla de éxito.
+
+---
+
 ## 2026-05-26 — Limpieza de warnings iOS 26
 
 - Silenciado el log informativo `HeroUI Native Styling Principles` en arranque: `HeroUINativeProvider` ahora recibe `config={{ devInfo: { stylingPrinciples: false } }}` en `app/_layout.tsx`.

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -190,7 +190,11 @@ function InnerLayout() {
         <Stack.Screen name="notifications" options={{ headerShown: false }} />
         <Stack.Screen
           name="onboarding"
-          options={{ headerShown: false, presentation: 'modal' }}
+          options={{
+            headerShown: false,
+            presentation: 'fullScreenModal',
+            contentStyle: { backgroundColor: '#253883' },
+          }}
         />
         <Stack.Screen
           name="wordle"

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -11,8 +11,9 @@ import {
   TextStyle,
   Platform,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
 import { MaterialIcons } from '@expo/vector-icons';
 import Animated, {
   Easing,
@@ -308,9 +309,17 @@ const skipBtnStyles = StyleSheet.create({
    Welcome screen
 ─────────────────────────────────────── */
 
-function WelcomeScreen({ onStart }: { onStart: () => void }) {
+function WelcomeScreen({
+  onStart,
+  applySafeArea,
+}: {
+  onStart: () => void;
+  applySafeArea: boolean;
+}) {
+  const insets = useSafeAreaInsets();
   const ripple1 = useSharedValue(0);
   const ripple2 = useSharedValue(0);
+  const float = useSharedValue(0);
 
   useEffect(() => {
     ripple1.value = withDelay(
@@ -329,7 +338,21 @@ function WelcomeScreen({ onStart }: { onStart: () => void }) {
         false,
       ),
     );
-  }, [ripple1, ripple2]);
+    float.value = withRepeat(
+      withSequence(
+        withTiming(1, {
+          duration: 2200,
+          easing: Easing.inOut(Easing.quad),
+        }),
+        withTiming(0, {
+          duration: 2200,
+          easing: Easing.inOut(Easing.quad),
+        }),
+      ),
+      -1,
+      false,
+    );
+  }, [ripple1, ripple2, float]);
 
   const ripple1Style = useAnimatedStyle(() => ({
     opacity: 0.35 * (1 - ripple1.value),
@@ -339,13 +362,20 @@ function WelcomeScreen({ onStart }: { onStart: () => void }) {
     opacity: 0.28 * (1 - ripple2.value),
     transform: [{ scale: 1 + ripple2.value * 1.4 }],
   }));
+  const floatStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: -6 * float.value }],
+  }));
+
+  const padTop = applySafeArea ? insets.top : 0;
+  const padBottom = applySafeArea ? insets.bottom : 0;
 
   return (
     <Animated.View
       style={[welcomeStyles.root, { backgroundColor: T.primary }]}
       entering={FadeIn.duration(420)}
     >
-      {/* decorative circles */}
+      <StatusBar style="light" animated />
+      {/* decorative circles — pueden invadir el notch sin problema */}
       <View
         style={[
           welcomeStyles.deco,
@@ -395,72 +425,108 @@ function WelcomeScreen({ onStart }: { onStart: () => void }) {
         ]}
       />
 
-      <View style={welcomeStyles.center}>
-        <Animated.View
-          entering={FadeIn.duration(550).easing(
-            Easing.bezier(0.34, 1.56, 0.64, 1),
-          )}
-          style={welcomeStyles.logoWrap}
-        >
-          <Animated.View style={[welcomeStyles.ripple, ripple1Style]} />
-          <Animated.View
-            style={[
-              welcomeStyles.ripple,
-              ripple2Style,
-              { top: 10, left: 10, right: 10, bottom: 10 },
-            ]}
-          />
-          <View style={welcomeStyles.logoCircle}>
-            <Image
-              source={require('@/assets/images/icon.png')}
-              style={welcomeStyles.logoImg}
-              resizeMode="contain"
-            />
-          </View>
-        </Animated.View>
-
-        <Animated.Text
-          entering={FadeInUp.delay(80).duration(420)}
-          style={welcomeStyles.title}
-        >
-          Bienvenido/a a{'\n'}MCM App
-        </Animated.Text>
-
-        <Animated.Text
-          entering={FadeInUp.delay(160).duration(420)}
-          style={welcomeStyles.tagline}
-        >
-          Movimiento Consolación para el Mundo
-        </Animated.Text>
-
-        <Animated.Text
-          entering={FadeInUp.delay(240).duration(420)}
-          style={welcomeStyles.body}
-        >
-          Mantente al día con las novedades. Revisa el calendario, accede a la
-          Plataforma Comunica, mira fotos o sigue las actividades.
-        </Animated.Text>
-      </View>
-
-      <Animated.View
-        entering={FadeInUp.delay(340).duration(420)}
-        style={welcomeStyles.cta}
+      <View
+        style={[
+          welcomeStyles.safeContent,
+          { paddingTop: padTop, paddingBottom: padBottom },
+        ]}
       >
-        <PrimaryButton
-          label="Comenzar"
-          onPress={onStart}
-          color="#ffffff"
-          textColor={T.primary}
-          shimmer
-        />
-      </Animated.View>
+        <View style={welcomeStyles.center}>
+          <Animated.View
+            entering={FadeInDown.delay(60)
+              .duration(420)
+              .easing(Easing.bezier(0.22, 1, 0.36, 1))}
+            style={welcomeStyles.badge}
+          >
+            <MaterialIcons name="favorite" size={12} color="#FCD200" />
+            <Text style={welcomeStyles.badgeText}>Te damos la bienvenida</Text>
+          </Animated.View>
+
+          <Animated.View
+            entering={FadeIn.duration(550).easing(
+              Easing.bezier(0.34, 1.56, 0.64, 1),
+            )}
+            style={[welcomeStyles.logoWrap, floatStyle]}
+          >
+            <Animated.View style={[welcomeStyles.ripple, ripple1Style]} />
+            <Animated.View
+              style={[
+                welcomeStyles.ripple,
+                ripple2Style,
+                { top: 10, left: 10, right: 10, bottom: 10 },
+              ]}
+            />
+            <View style={welcomeStyles.logoCircle}>
+              <Image
+                source={require('@/assets/images/icon.png')}
+                style={welcomeStyles.logoImg}
+                resizeMode="contain"
+              />
+            </View>
+          </Animated.View>
+
+          <Animated.Text
+            entering={FadeInUp.delay(120).duration(420)}
+            style={welcomeStyles.title}
+          >
+            ¡Hola!{'\n'}Bienvenido/a a MCM
+          </Animated.Text>
+
+          <Animated.Text
+            entering={FadeInUp.delay(200).duration(420)}
+            style={welcomeStyles.tagline}
+          >
+            Movimiento Consolación para el Mundo
+          </Animated.Text>
+
+          <Animated.Text
+            entering={FadeInUp.delay(280).duration(420)}
+            style={welcomeStyles.body}
+          >
+            Tu comunidad en el bolsillo: calendario, cantoral, fotos,
+            reflexiones y mucho más. ¿Vamos?
+          </Animated.Text>
+        </View>
+
+        <Animated.View
+          entering={FadeInUp.delay(360).duration(420)}
+          style={welcomeStyles.cta}
+        >
+          <PrimaryButton
+            label="¡Vamos allá!"
+            onPress={onStart}
+            color="#ffffff"
+            textColor={T.primary}
+            shimmer
+          />
+        </Animated.View>
+      </View>
     </Animated.View>
   );
 }
 
 const welcomeStyles = StyleSheet.create({
   root: { flex: 1, position: 'relative', overflow: 'hidden' } as ViewStyle,
+  safeContent: { flex: 1 } as ViewStyle,
   deco: { position: 'absolute', borderRadius: 999 } as ViewStyle,
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.14)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.25)',
+    marginBottom: 18,
+  } as ViewStyle,
+  badgeText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  } as TextStyle,
   center: {
     flex: 1,
     alignItems: 'center',
@@ -528,7 +594,7 @@ const welcomeStyles = StyleSheet.create({
   cta: {
     paddingHorizontal: 24,
     paddingTop: 16,
-    paddingBottom: 36,
+    paddingBottom: 24,
   } as ViewStyle,
 });
 
@@ -543,6 +609,7 @@ function ProfileScreen({
   onContinue,
   onSkip,
   animDir,
+  applySafeArea,
 }: {
   profiles: { id: OnboardingProfileId; label: string; description: string }[];
   selected: OnboardingProfileId | null;
@@ -550,16 +617,22 @@ function ProfileScreen({
   onContinue: () => void;
   onSkip: () => void;
   animDir: 'forward' | 'back';
+  applySafeArea: boolean;
 }) {
   const TT = useThemeT();
+  const insets = useSafeAreaInsets();
   const Entering = animDir === 'back' ? SlideInLeft : SlideInRight;
+  const topPad = (applySafeArea ? insets.top : 0) + 8;
+  const bottomPad =
+    (applySafeArea ? insets.bottom : 0) + (Platform.OS === 'ios' ? 12 : 24);
 
   return (
     <Animated.View
       entering={Entering.duration(320).easing(Easing.bezier(0.22, 1, 0.36, 1))}
       style={[stepStyles.root, { backgroundColor: TT.bg }]}
     >
-      <View style={stepStyles.topBar}>
+      <StatusBar style={TT.isDark ? 'light' : 'dark'} animated />
+      <View style={[stepStyles.topBar, { paddingTop: topPad }]}>
         <View />
         <SkipButton onPress={onSkip} />
       </View>
@@ -624,7 +697,10 @@ function ProfileScreen({
                   >
                     {p.label}
                   </Text>
-                  <Text style={[cardStyles.cardDesc, { color: TT.muted }]} numberOfLines={3}>
+                  <Text
+                    style={[cardStyles.cardDesc, { color: TT.muted }]}
+                    numberOfLines={3}
+                  >
                     {p.description}
                   </Text>
                 </View>
@@ -641,7 +717,12 @@ function ProfileScreen({
         })}
       </ScrollView>
 
-      <View style={stepStyles.footer}>
+      <View
+        style={[
+          stepStyles.footer,
+          { paddingBottom: bottomPad, borderTopColor: TT.border },
+        ]}
+      >
         <PrimaryButton
           label="Continuar"
           onPress={onContinue}
@@ -663,6 +744,7 @@ function DelegationScreen({
   onFinish,
   onBack,
   onSkip,
+  applySafeArea,
 }: {
   delegations: { id: string; label: string; description?: string }[];
   selected: string | null;
@@ -670,8 +752,14 @@ function DelegationScreen({
   onFinish: () => void;
   onBack: () => void;
   onSkip: () => void;
+  applySafeArea: boolean;
 }) {
   const TT = useThemeT();
+  const insets = useSafeAreaInsets();
+  const topPad = (applySafeArea ? insets.top : 0) + 8;
+  const bottomPad =
+    (applySafeArea ? insets.bottom : 0) + (Platform.OS === 'ios' ? 12 : 24);
+
   return (
     <Animated.View
       entering={SlideInRight.duration(320).easing(
@@ -679,7 +767,8 @@ function DelegationScreen({
       )}
       style={[stepStyles.root, { backgroundColor: TT.bg }]}
     >
-      <View style={stepStyles.topBar}>
+      <StatusBar style={TT.isDark ? 'light' : 'dark'} animated />
+      <View style={[stepStyles.topBar, { paddingTop: topPad }]}>
         <Pressable onPress={onBack} hitSlop={12} style={stepStyles.backBtn}>
           <MaterialIcons name="arrow-back-ios" size={16} color={TT.primary} />
           <Text style={[stepStyles.backLabel, { color: TT.primary }]}>
@@ -762,7 +851,12 @@ function DelegationScreen({
         })}
       </ScrollView>
 
-      <View style={[stepStyles.footer, { borderTopColor: TT.border }]}>
+      <View
+        style={[
+          stepStyles.footer,
+          { paddingBottom: bottomPad, borderTopColor: TT.border },
+        ]}
+      >
         <PrimaryButton
           label="¡Empezar!"
           onPress={onFinish}
@@ -782,13 +876,17 @@ function SuccessScreen({
   profile,
   delegation,
   onContinue,
+  applySafeArea,
 }: {
   profile: { id: OnboardingProfileId; label: string } | null;
   delegation: { id: string; label: string } | null;
   onContinue: () => void;
+  applySafeArea: boolean;
 }) {
   const TT = useThemeT();
+  const insets = useSafeAreaInsets();
   const ripple = useSharedValue(0);
+  const wiggle = useSharedValue(0);
   useEffect(() => {
     ripple.value = withDelay(
       300,
@@ -798,26 +896,47 @@ function SuccessScreen({
         false,
       ),
     );
-  }, [ripple]);
+    wiggle.value = withSequence(
+      withDelay(
+        120,
+        withTiming(1, { duration: 220, easing: Easing.out(Easing.back(2)) }),
+      ),
+      withTiming(0, { duration: 260, easing: Easing.inOut(Easing.quad) }),
+    );
+  }, [ripple, wiggle]);
   const rippleStyle = useAnimatedStyle(() => ({
     opacity: 0.4 * (1 - ripple.value),
     transform: [{ scale: 1 + ripple.value * 1.6 }],
   }));
+  const wiggleStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: 1 + wiggle.value * 0.08 }],
+  }));
+
+  const padTop = applySafeArea ? insets.top : 0;
+  const padBottom = applySafeArea ? insets.bottom : 0;
 
   return (
     <Animated.View
       entering={FadeIn.duration(380)}
-      style={[successStyles.root, { backgroundColor: TT.bg }]}
+      style={[
+        successStyles.root,
+        {
+          backgroundColor: TT.bg,
+          paddingTop: padTop + 28,
+          paddingBottom: padBottom + 28,
+        },
+      ]}
     >
+      <StatusBar style={TT.isDark ? 'light' : 'dark'} animated />
       <Animated.View
         entering={FadeIn.duration(550).easing(
           Easing.bezier(0.34, 1.56, 0.64, 1),
         )}
-        style={successStyles.iconWrap}
+        style={[successStyles.iconWrap, wiggleStyle]}
       >
         <Animated.View style={[successStyles.iconRipple, rippleStyle]} />
         <View style={successStyles.iconCircle}>
-          <MaterialIcons name="check-circle" size={48} color={TT.success} />
+          <MaterialIcons name="celebration" size={48} color={TT.success} />
         </View>
       </Animated.View>
 
@@ -831,7 +950,7 @@ function SuccessScreen({
         entering={FadeInDown.delay(180).duration(380)}
         style={[successStyles.sub, { color: TT.muted }]}
       >
-        ¡Gracias! Tu comunidad te espera.
+        Tu comunidad te espera. ¡A disfrutarla!
       </Animated.Text>
 
       {(profile || delegation) && (
@@ -1218,14 +1337,29 @@ export default function OnboardingScreen() {
     : ('100%' as const);
   const frameHeight = isWide ? Math.min(screenH * 0.88, 740) : undefined;
 
+  // El shell se pinta del color del paso actual para que el safe-area
+  // (notch / status bar / home indicator) quede del mismo color que el
+  // contenido. Cuando estamos en modo "wide" (tableta/desktop) la pantalla
+  // se muestra como tarjeta centrada y el fondo del shell es la moqueta gris.
+  const shellBg = isWide
+    ? TT.isDark
+      ? '#0F1320'
+      : '#EBEEf6'
+    : step === 'welcome'
+      ? T.primary
+      : TT.bg;
+
+  // En "wide" la tarjeta es de ancho fijo y NO está pegada a los bordes, así
+  // que no necesitamos aplicar safe-area dentro de cada paso.
+  const applySafeArea = !isWide;
+
   return (
-    <SafeAreaView
+    <View
       style={[
         shellStyles.safe,
-        { backgroundColor: TT.bg },
         isWide && shellStyles.safeWide,
+        { backgroundColor: shellBg },
       ]}
-      edges={['top', 'bottom']}
     >
       <View
         style={[
@@ -1235,7 +1369,12 @@ export default function OnboardingScreen() {
           isWide && frameHeight ? { height: frameHeight } : undefined,
         ]}
       >
-        {step === 'welcome' && <WelcomeScreen onStart={() => go('profile')} />}
+        {step === 'welcome' && (
+          <WelcomeScreen
+            onStart={() => go('profile')}
+            applySafeArea={applySafeArea}
+          />
+        )}
         {step === 'profile' && (
           <ProfileScreen
             profiles={profileEntries}
@@ -1244,6 +1383,7 @@ export default function OnboardingScreen() {
             animDir={animDir}
             onContinue={handleProfileContinue}
             onSkip={handleSkip}
+            applySafeArea={applySafeArea}
           />
         )}
         {step === 'delegation' && (
@@ -1254,12 +1394,14 @@ export default function OnboardingScreen() {
             onFinish={handleFinishToSuccess}
             onBack={() => go('profile', 'back')}
             onSkip={handleSkip}
+            applySafeArea={applySafeArea}
           />
         )}
         {step === 'success' && (
           <SuccessScreen
             profile={profile}
             delegation={delegation}
+            applySafeArea={applySafeArea}
             onContinue={() => {
               const resolved = resolveOnboardingValues(
                 profileType,
@@ -1274,7 +1416,7 @@ export default function OnboardingScreen() {
           />
         )}
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
## Resumen

El onboarding ahora ocupa **toda la pantalla**, incluida la zona del notch / status bar / home indicator en iPhone, y se ve correctamente edge-to-edge también en web y tableta.

### Cambios principales

- **`app/_layout.tsx`**: la pantalla `onboarding` pasa de `presentation: 'modal'` a `'fullScreenModal'`. En iOS 13+, `modal` la renderizaba como sheet con bordes redondeados y la status bar visible alrededor. También se fija `contentStyle.backgroundColor` al azul de marca (#253883) para evitar parpadeos blancos al abrir.
- **`app/onboarding.tsx`**: sustituido el `SafeAreaView` exterior (que tenía fondo blanco) por un `View` con fondo dinámico que coincide con el paso actual (azul en bienvenida, blanco en perfil/delegación/éxito). Cada step gestiona sus propios `insets` vía `useSafeAreaInsets`, así el azul de la bienvenida llega hasta el borde del notch sin recortes.
- **StatusBar**: se conmuta a `light` durante la bienvenida para que los iconos se vean blancos sobre el azul.

### Retoques de diseño (sin pasarse)

- Badge "Te damos la bienvenida" con corazoncito amarillo arriba del logo
- Logo con flotación suave (translateY ±6px, ciclo 4.4s)
- Copy más cálido: "¡Hola! Bienvenido/a a MCM" + botón "¡Vamos allá!"
- Pantalla de éxito: icono `celebration` con pequeño pop al aparecer

## Test plan

- [ ] iPhone con notch: el azul de la bienvenida cubre la zona del notch y el home indicator
- [ ] iPhone sin notch: la status bar queda con fondo azul y iconos blancos
- [ ] Android: la status bar es azul, iconos blancos
- [ ] Web: el onboarding ocupa todo el viewport sin franjas blancas
- [ ] Tableta / desktop (>=640px): se mantiene el diseño de tarjeta centrada
- [ ] Modo oscuro: los pasos 2-3 (perfil, delegación, éxito) usan el fondo oscuro correcto
- [ ] Pulsando "Saltar" o completando el flujo se vuelve a la home sin glitches

https://claude.ai/code/session_01HDk5mvvDYoSuygqAdd1eTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDk5mvvDYoSuygqAdd1eTF)_