### PR TITLE
calendario: detalles de evento + parser ICS enriquecido

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-05-28 — Calendario: detalles de evento + parser ICS enriquecido
+
+- **Detalles de evento al hacer tap**: cada tarjeta de evento ahora abre un `EventDetailsBottomSheet` (nuevo componente) con fecha y hora, ubicación con botón "Abrir en Mapas/Maps", videollamada destacada (Meet/Zoom/Teams/Webex/Jitsi), descripción con saltos de línea y URLs tappables, y enlace "Abrir en Google Calendar" si el evento trae `URL`.
+- **Parser ICS enriquecido** (`hooks/useCalendarEvents.ts`): el tipo `CalendarEvent` añade `startTime`, `endTime` y `conferenceUrl`. `DTSTART`/`DTEND` ahora extraen también la hora (`HH:MM`). Se detectan videollamadas vía `X-GOOGLE-CONFERENCE` y, como fallback, regex sobre `DESCRIPTION` (Meet, Zoom, Teams, Webex, GoToMeeting, Whereby, Jitsi). `DESCRIPTION` conserva los saltos de línea originales.
+- **FAB "Hoy" rediseñado**: sustituido el `GlassFAB` flotante por una píldora compacta "Volver a hoy" en el header de la sección de eventos (modo Mes) y sobre la lista (modo Agenda). Aparece solo cuando la fecha/mes seleccionado no es el actual.
+- **Hora en la tarjeta del día**: si el evento tiene `startTime`, se muestra `HH:MM – HH:MM` con icono de reloj en la tarjeta de la lista del día.
+- Archivos nuevos: `components/EventDetailsBottomSheet.tsx`.
+- Archivos modificados: `hooks/useCalendarEvents.ts`, `app/(tabs)/calendario.tsx`.
+
+---
+
 ## 2026-05-27 — Onboarding edge-to-edge
 
 - El onboarding ahora ocupa la pantalla completa, incluida la zona del notch / status bar / home indicator. El fondo del paso actual (azul marca en la bienvenida, blanco en los siguientes) cubre todo el shell sin recortes blancos arriba.

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -25,12 +25,12 @@ import useCalendarEvents, { CalendarEvent } from '@/hooks/useCalendarEvents';
 import { useCalendarConfig } from '@/contexts/CalendarConfigContext';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import OfflineBanner from '@/components/OfflineBanner';
-import GlassFAB from '@/components/ui/GlassFAB';
 import { useLocalSearchParams } from 'expo-router';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { hexAlpha } from '@/utils/colorUtils';
 import { h } from '@/utils/haptics';
 import CalendarSubscribeBottomSheet from '@/components/CalendarSubscribeBottomSheet';
+import EventDetailsBottomSheet from '@/components/EventDetailsBottomSheet';
 
 LocaleConfig.locales['es'] = {
   monthNames: [
@@ -94,6 +94,7 @@ export default function Calendario() {
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
   const [viewMode, setViewMode] = useState<'calendar' | 'agenda'>('calendar');
   const [subscribeOpen, setSubscribeOpen] = useState(false);
+  const [detailsEvent, setDetailsEvent] = useState<CalendarEvent | null>(null);
 
   useEffect(() => {
     if (params.date && typeof params.date === 'string') {
@@ -249,11 +250,23 @@ export default function Calendario() {
   ) => {
     const calColor = calendarConfigs[ev.calendarIndex]?.color || colors.info;
 
+    const timeLabel = ev.startTime
+      ? ev.endTime
+        ? `${ev.startTime} – ${ev.endTime}`
+        : ev.startTime
+      : null;
+
     return (
       <TouchableOpacity
         key={index}
         activeOpacity={0.7}
         style={[styles.eventCard, isPast && styles.pastEventCard]}
+        onPress={() => {
+          h.tap();
+          setDetailsEvent(ev);
+        }}
+        accessibilityRole="button"
+        accessibilityLabel={`Ver detalles de ${ev.title}`}
       >
         <View style={[styles.eventColorBar, { backgroundColor: calColor }]} />
         <View style={styles.eventCardBody}>
@@ -281,6 +294,17 @@ export default function Calendario() {
               </Text>
             </View>
           </View>
+          {timeLabel ? (
+            <View style={styles.eventMeta}>
+              <MaterialIcons name="schedule" size={14} color="#8E8E93" />
+              <Text
+                style={[styles.eventLocation, isPast && styles.pastText]}
+                numberOfLines={1}
+              >
+                {timeLabel}
+              </Text>
+            </View>
+          ) : null}
           {ev.location ? (
             <View style={styles.eventMeta}>
               <MaterialIcons name="place" size={14} color="#8E8E93" />
@@ -509,6 +533,9 @@ export default function Calendario() {
                   )}
                 </View>
               </View>
+              {selectedDate !== todayStr && (
+                <BackToTodayPill onPress={goToToday} styles={styles} />
+              )}
             </View>
 
             {eventsForSelected.length > 0 ? (
@@ -561,6 +588,12 @@ export default function Calendario() {
 
           {/* Filter chips */}
           {renderFilterChips()}
+
+          {selectedDate.slice(0, 7) !== todayStr.slice(0, 7) && (
+            <View style={styles.agendaBackToTodayRow}>
+              <BackToTodayPill onPress={goToToday} styles={styles} />
+            </View>
+          )}
 
           <SectionList
             sections={agendaSectionsFiltered}
@@ -652,23 +685,44 @@ export default function Calendario() {
         </View>
       )}
 
-      {/* FAB to go to today */}
-      {selectedDate !== todayStr ? (
-        <GlassFAB
-          icon="today"
-          onPress={goToToday}
-          tintColor={colors.info}
-          iconColor="#fff"
-          label="Hoy"
-        />
-      ) : null}
-
       <CalendarSubscribeBottomSheet
         visible={subscribeOpen}
         onClose={() => setSubscribeOpen(false)}
         calendars={calendarConfigs}
       />
+
+      <EventDetailsBottomSheet
+        visible={!!detailsEvent}
+        onClose={() => setDetailsEvent(null)}
+        event={detailsEvent}
+        calendarConfig={
+          detailsEvent ? calendarConfigs[detailsEvent.calendarIndex] : undefined
+        }
+      />
     </TabScreenWrapper>
+  );
+}
+
+interface BackToTodayPillProps {
+  onPress: () => void;
+  styles: ReturnType<typeof createStyles>;
+}
+
+function BackToTodayPill({ onPress, styles }: BackToTodayPillProps) {
+  return (
+    <TouchableOpacity
+      style={styles.backToTodayPill}
+      onPress={() => {
+        h.tap();
+        onPress();
+      }}
+      activeOpacity={0.75}
+      accessibilityRole="button"
+      accessibilityLabel="Volver a hoy"
+    >
+      <MaterialIcons name="today" size={14} color={colors.info} />
+      <Text style={styles.backToTodayLabel}>Volver a hoy</Text>
+    </TouchableOpacity>
   );
 }
 
@@ -801,8 +855,35 @@ const createStyles = (scheme: 'light' | 'dark') => {
     eventSectionHeader: {
       flexDirection: 'row',
       alignItems: 'center',
+      justifyContent: 'space-between',
       marginBottom: 12,
       marginTop: 4,
+      gap: 8,
+    },
+    backToTodayPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 5,
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      borderRadius: radii.pill,
+      backgroundColor: hexAlpha(colors.info, '12'),
+      borderWidth: 1,
+      borderColor: hexAlpha(colors.info, '30'),
+      alignSelf: 'flex-start',
+    },
+    backToTodayLabel: {
+      fontSize: 12,
+      fontWeight: '600',
+      color: colors.info,
+      letterSpacing: -0.1,
+    },
+    agendaBackToTodayRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      paddingHorizontal: 16,
+      paddingTop: 4,
+      paddingBottom: 6,
     },
     eventSectionLeft: {
       flexDirection: 'row',

--- a/mcm-app/components/EventDetailsBottomSheet.tsx
+++ b/mcm-app/components/EventDetailsBottomSheet.tsx
@@ -1,0 +1,428 @@
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Linking,
+  Platform,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import BottomSheet from '@/components/BottomSheet';
+import { useToast } from '@/contexts/AppToastContext';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import colors, { Colors } from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import { radii } from '@/constants/uiStyles';
+import { hexAlpha } from '@/utils/colorUtils';
+import { h } from '@/utils/haptics';
+import type { CalendarEvent } from '@/hooks/useCalendarEvents';
+import type { CalendarConfig } from '@/hooks/useCalendarConfigs';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  event: CalendarEvent | null;
+  calendarConfig: CalendarConfig | undefined;
+}
+
+// Matches http(s) URLs to make description links tappable.
+const URL_PATTERN = 'https?:\\/\\/[^\\s<>"\')]+';
+
+type DescriptionToken = { key: string; text: string; isUrl: boolean };
+
+function tokenizeDescription(text: string): DescriptionToken[] {
+  const regex = new RegExp(URL_PATTERN, 'gi');
+  const tokens: DescriptionToken[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let i = 0;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({
+        key: `t${i++}`,
+        text: text.slice(lastIndex, match.index),
+        isUrl: false,
+      });
+    }
+    tokens.push({ key: `u${i++}`, text: match[0], isUrl: true });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    tokens.push({
+      key: `t${i++}`,
+      text: text.slice(lastIndex),
+      isUrl: false,
+    });
+  }
+  return tokens;
+}
+
+function formatLongDate(dateStr: string): string {
+  const label = new Date(dateStr + 'T00:00:00').toLocaleDateString('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function buildMapsUrl(location: string): string {
+  const q = encodeURIComponent(location);
+  if (Platform.OS === 'ios') {
+    return `http://maps.apple.com/?q=${q}`;
+  }
+  return `https://www.google.com/maps/search/?api=1&query=${q}`;
+}
+
+function conferenceLabel(url: string): string {
+  if (/meet\.google\.com/i.test(url)) return 'Google Meet';
+  if (/zoom\.us/i.test(url)) return 'Zoom';
+  if (/teams\.(microsoft|live)\.com/i.test(url)) return 'Microsoft Teams';
+  if (/webex\.com/i.test(url)) return 'Webex';
+  if (/jit\.si/i.test(url)) return 'Jitsi';
+  return 'Videollamada';
+}
+
+export default function EventDetailsBottomSheet({
+  visible,
+  onClose,
+  event,
+  calendarConfig,
+}: Props) {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const theme = Colors[scheme ?? 'light'];
+  const { toast } = useToast();
+
+  const accentColor = calendarConfig?.color || colors.info;
+  const surfaceBg = isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.04)';
+
+  const descriptionParts = useMemo(
+    () => (event?.description ? tokenizeDescription(event.description) : null),
+    [event?.description],
+  );
+
+  const handleOpenUrl = async (
+    url: string,
+    errorMsg = 'No se pudo abrir el enlace.',
+  ) => {
+    h.tap();
+    try {
+      await Linking.openURL(url);
+    } catch {
+      toast.show({ variant: 'danger', label: errorMsg });
+    }
+  };
+
+  if (!event) {
+    return (
+      <BottomSheet visible={visible} onClose={onClose} title="Evento">
+        <View />
+      </BottomSheet>
+    );
+  }
+
+  const showDateRange = event.endDate && event.endDate !== event.startDate;
+  const timeRange = event.startTime
+    ? event.endTime
+      ? `${event.startTime} – ${event.endTime}`
+      : event.startTime
+    : null;
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} dragFromContent>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Header: calendar badge + title */}
+        <View
+          style={[
+            styles.calendarBadge,
+            { backgroundColor: hexAlpha(accentColor, '18') },
+          ]}
+        >
+          <View
+            style={[styles.calendarDot, { backgroundColor: accentColor }]}
+          />
+          <Text
+            style={[styles.calendarName, { color: accentColor }]}
+            numberOfLines={1}
+          >
+            {calendarConfig?.name || 'Evento'}
+          </Text>
+        </View>
+
+        <Text style={[styles.title, { color: theme.text }]}>{event.title}</Text>
+
+        {/* Date + time */}
+        <View style={[styles.infoRow, { backgroundColor: surfaceBg }]}>
+          <View
+            style={[
+              styles.infoIconWrap,
+              { backgroundColor: hexAlpha(accentColor, '18') },
+            ]}
+          >
+            <MaterialIcons name="event" size={18} color={accentColor} />
+          </View>
+          <View style={styles.infoTextWrap}>
+            <Text style={[styles.infoPrimary, { color: theme.text }]}>
+              {formatLongDate(event.startDate)}
+            </Text>
+            {timeRange ? (
+              <Text style={[styles.infoSecondary, { color: theme.icon }]}>
+                {timeRange}
+              </Text>
+            ) : event.isAllDay ? (
+              <Text style={[styles.infoSecondary, { color: theme.icon }]}>
+                Todo el día
+              </Text>
+            ) : null}
+            {showDateRange ? (
+              <Text style={[styles.infoSecondary, { color: theme.icon }]}>
+                Hasta {formatLongDate(event.endDate as string)}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        {/* Location */}
+        {event.location ? (
+          <TouchableOpacity
+            style={[styles.infoRow, { backgroundColor: surfaceBg }]}
+            onPress={() =>
+              handleOpenUrl(
+                buildMapsUrl(event.location as string),
+                'No se pudo abrir el mapa.',
+              )
+            }
+            activeOpacity={0.75}
+            accessibilityRole="button"
+            accessibilityLabel={`Abrir ubicación en mapas: ${event.location}`}
+          >
+            <View
+              style={[
+                styles.infoIconWrap,
+                { backgroundColor: hexAlpha(accentColor, '18') },
+              ]}
+            >
+              <MaterialIcons name="place" size={18} color={accentColor} />
+            </View>
+            <View style={styles.infoTextWrap}>
+              <Text
+                style={[styles.infoPrimary, { color: theme.text }]}
+                numberOfLines={3}
+              >
+                {event.location}
+              </Text>
+              <Text style={[styles.infoLink, { color: colors.info }]}>
+                Abrir en {Platform.OS === 'ios' ? 'Mapas' : 'Maps'}
+              </Text>
+            </View>
+            <MaterialIcons
+              name="chevron-right"
+              size={20}
+              color={theme.icon}
+              style={{ opacity: 0.5 }}
+            />
+          </TouchableOpacity>
+        ) : null}
+
+        {/* Conference call */}
+        {event.conferenceUrl ? (
+          <TouchableOpacity
+            style={styles.conferenceBtn}
+            onPress={() =>
+              handleOpenUrl(
+                event.conferenceUrl as string,
+                'No se pudo abrir la videollamada.',
+              )
+            }
+            activeOpacity={0.85}
+            accessibilityRole="button"
+            accessibilityLabel="Unirse a la videollamada"
+          >
+            <MaterialIcons name="videocam" size={20} color="#fff" />
+            <Text style={styles.conferenceBtnLabel}>
+              Unirse a {conferenceLabel(event.conferenceUrl)}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+
+        {/* Description */}
+        {event.description ? (
+          <View style={styles.descriptionWrap}>
+            <Text style={[styles.sectionLabel, { color: theme.icon }]}>
+              DESCRIPCIÓN
+            </Text>
+            <Text style={[styles.descriptionText, { color: theme.text }]}>
+              {descriptionParts?.map((p) => {
+                if (p.isUrl) {
+                  return (
+                    <Text
+                      key={p.key}
+                      style={{
+                        color: colors.info,
+                        textDecorationLine: 'underline',
+                      }}
+                      onPress={() => handleOpenUrl(p.text)}
+                    >
+                      {p.text}
+                    </Text>
+                  );
+                }
+                return <Text key={p.key}>{p.text}</Text>;
+              })}
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Google Calendar link */}
+        {event.url ? (
+          <TouchableOpacity
+            style={[
+              styles.secondaryBtn,
+              { borderColor: hexAlpha(colors.info, '40') },
+            ]}
+            onPress={() =>
+              handleOpenUrl(
+                event.url as string,
+                'No se pudo abrir Google Calendar.',
+              )
+            }
+            activeOpacity={0.75}
+            accessibilityRole="button"
+            accessibilityLabel="Abrir evento en Google Calendar"
+          >
+            <MaterialIcons name="open-in-new" size={16} color={colors.info} />
+            <Text style={[styles.secondaryBtnLabel, { color: colors.info }]}>
+              Abrir en Google Calendar
+            </Text>
+          </TouchableOpacity>
+        ) : null}
+      </ScrollView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    maxHeight: 600,
+  } as ViewStyle,
+  scrollContent: {
+    paddingBottom: 32,
+    gap: spacing.sm,
+  } as ViewStyle,
+
+  calendarBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: radii.pill,
+    gap: 6,
+  } as ViewStyle,
+  calendarDot: {
+    width: 8,
+    height: 8,
+    borderRadius: radii.pillFull,
+  } as ViewStyle,
+  calendarName: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.2,
+  } as TextStyle,
+
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    letterSpacing: -0.4,
+    marginTop: spacing.xs,
+    marginBottom: spacing.sm,
+  } as TextStyle,
+
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.sm + 2,
+    borderRadius: radii.md,
+  } as ViewStyle,
+  infoIconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as ViewStyle,
+  infoTextWrap: {
+    flex: 1,
+    gap: 2,
+  } as ViewStyle,
+  infoPrimary: {
+    fontSize: 15,
+    fontWeight: '600',
+  } as TextStyle,
+  infoSecondary: {
+    fontSize: 13,
+    fontWeight: '500',
+  } as TextStyle,
+  infoLink: {
+    fontSize: 12,
+    fontWeight: '600',
+    marginTop: 2,
+  } as TextStyle,
+
+  conferenceBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: colors.info,
+    borderRadius: radii.md,
+    paddingVertical: 14,
+    marginTop: spacing.xs,
+  } as ViewStyle,
+  conferenceBtnLabel: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+    letterSpacing: -0.1,
+  } as TextStyle,
+
+  descriptionWrap: {
+    marginTop: spacing.sm,
+    gap: spacing.xs + 2,
+  } as ViewStyle,
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  } as TextStyle,
+  descriptionText: {
+    fontSize: 14,
+    lineHeight: 20,
+  } as TextStyle,
+
+  secondaryBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 11,
+    borderRadius: radii.sm,
+    borderWidth: 1.5,
+    marginTop: spacing.xs,
+  } as ViewStyle,
+  secondaryBtnLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+  } as TextStyle,
+});

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -6,14 +6,20 @@ import type { CalendarConfig } from './useCalendarConfigs';
 export interface CalendarEvent {
   startDate: string; // YYYY-MM-DD
   endDate?: string; // YYYY-MM-DD
+  startTime?: string; // HH:MM (only present for non all-day events)
+  endTime?: string; // HH:MM
   title: string;
   description?: string;
   location?: string;
   url?: string;
+  conferenceUrl?: string; // Detected Meet/Zoom/Teams link
   calendarIndex: number;
   isAllDay?: boolean; // Track if this is an all-day event
   isSingleDay?: boolean; // Track if this is effectively a single day event (after corrections)
 }
+
+const CONFERENCE_URL_REGEX =
+  /https?:\/\/(?:[\w-]+\.)*(?:meet\.google\.com|zoom\.us|teams\.microsoft\.com|teams\.live\.com|webex\.com|gotomeeting\.com|whereby\.com|jit\.si|meet\.jit\.si)\/[^\s<>"')]+/i;
 
 function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
   // Unfold lines that start with a space as specified in RFC 5545
@@ -64,10 +70,20 @@ function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
     } else if (line.startsWith('SUMMARY:')) {
       current.title = line.slice('SUMMARY:'.length).trim();
     } else if (line.startsWith('DESCRIPTION:')) {
-      current.description = line
+      const raw = line
         .slice('DESCRIPTION:'.length)
-        .replace(/\\n/g, ' ')
+        .replace(/\\n/g, '\n')
+        .replace(/\\,/g, ',')
+        .replace(/\\;/g, ';')
         .trim();
+      current.description = raw || undefined;
+      // If we haven't found a conference URL yet, try to detect one in the description
+      if (!current.conferenceUrl && raw) {
+        const match = raw.match(CONFERENCE_URL_REGEX);
+        if (match) current.conferenceUrl = match[0];
+      }
+    } else if (line.startsWith('X-GOOGLE-CONFERENCE:')) {
+      current.conferenceUrl = line.slice('X-GOOGLE-CONFERENCE:'.length).trim();
     } else if (line.startsWith('LOCATION:')) {
       current.location =
         line
@@ -91,13 +107,17 @@ function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
           current.isAllDay = true;
         }
 
-        // Solo nos quedamos con la parte de fecha (sin hora)
         const datePart = value.replace(/T.*$/, '');
         if (/^\d{8}$/.test(datePart)) {
           const year = datePart.substring(0, 4);
           const month = datePart.substring(4, 6);
           const day = datePart.substring(6, 8);
           current.startDate = `${year}-${month}-${day}`;
+        }
+
+        const timeMatch = value.match(/T(\d{2})(\d{2})/);
+        if (timeMatch && !isDateOnly) {
+          current.startTime = `${timeMatch[1]}:${timeMatch[2]}`;
         }
       }
     } else if (line.startsWith('DTEND')) {
@@ -110,6 +130,11 @@ function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
           const month = datePart.substring(4, 6);
           const day = datePart.substring(6, 8);
           current.endDate = `${year}-${month}-${day}`;
+        }
+
+        const timeMatch = value.match(/T(\d{2})(\d{2})/);
+        if (timeMatch && !value.match(/^\d{8}$/)) {
+          current.endTime = `${timeMatch[1]}:${timeMatch[2]}`;
         }
       }
     }


### PR DESCRIPTION
- Tap en evento abre nuevo EventDetailsBottomSheet con fecha/hora,
  ubicación (botón Maps), videollamada (Meet/Zoom/Teams/Webex/Jitsi),
  descripción con URLs tappables y enlace a Google Calendar.
- Parser ICS amplía CalendarEvent con startTime/endTime y conferenceUrl;
  detecta X-GOOGLE-CONFERENCE y links de videollamada en DESCRIPTION;
  preserva saltos de línea de la descripción.
- Sustituido el GlassFAB "Hoy" por una píldora compacta "Volver a hoy"
  en el header del modo Mes y sobre la lista del modo Agenda.
- La tarjeta del día muestra la hora cuando el evento la trae.

https://claude.ai/code/session_01JNMDj2ZDfoGtHPYe3mWbMn