### PR TITLE
Add Visita Papa 2026 event + archived events system

### DIFF
--- a/PROMPT_MCMPANEL_VISITAPAPA.md
+++ b/PROMPT_MCMPANEL_VISITAPAPA.md
@@ -1,0 +1,85 @@
+# Prompt para el agente de **mcmpanel** — Visita Papa León XIV 2026
+
+> Contexto: en la app MCM (repo `mcmapp`, carpeta `mcm-app/`) se ha añadido el
+> evento **"Visita Papa León XIV 2026"** (`visitapapa26`, datos en Firebase bajo
+> `activities/visitapapa26`) y un sistema de **eventos activos/archivados**. El
+> panel `mcmpanel` debe poder gestionarlo. Este documento describe qué cambió en
+> la app y qué hay que implementar/ajustar en el panel.
+
+---
+
+## 1. Qué cambió en la app (contexto para el panel)
+
+- **Catálogo de tabs** ahora incluye `visitapapa`. El catálogo de items de "Más"
+  cambia `jubileo` por `eventos-pasados`. El catálogo de botones de Home incluye
+  `visitapapa`. IDs canónicos (en `mcm-app/constants/profileCatalog.ts`):
+  - `KNOWN_TABS`: …, `visitapapa`, …
+  - `KNOWN_HOME_BUTTONS`: …, `visitapapa`, …
+  - `KNOWN_MAS_ITEMS`: `comunica`, `comunica-gestion`, `jubileo`,
+    `eventos-pasados`
+- **Evento activo (modo evento)**: hoy está fijado en código
+  (`mcm-app/constants/events.ts` → `ACTIVE_EVENT_ID = 'visitapapa26'`, y cada
+  evento tiene `status: 'active' | 'archived'`). El evento activo se resalta con
+  tab propia + botón Home + banner; los archivados se ven en "Más > Eventos
+  pasados".
+- **Secciones de evento**: una sección puede ser un **enlace externo** (campo
+  `url`) en vez de una pantalla (ej. "Comida de Domingo" → lista de Google Maps).
+
+## 2. Cambios necesarios en el panel (gestión de perfiles)
+
+El panel ya edita `/profileConfig/data/profiles/*`. Hay que:
+
+1. Ofrecer `visitapapa` en los multiselects de **tabs** y **homeButtons**.
+2. Sustituir `jubileo` por `eventos-pasados` en el multiselect de **masItems**
+   (mantener `jubileo` reconocido por compatibilidad con configs antiguas).
+3. Al guardar, recalcular `/profileConfig` y refrescar `updatedAt` (patrón
+   existente). Seed de referencia: `mcm-app/firebase-seed/profileConfig.json`
+   (monitor y miembro ya traen `visitapapa` en tabs+homeButtons; todos los
+   perfiles usan `eventos-pasados`).
+
+## 3. Gestión de secciones del evento `visitapapa26`
+
+Mismo patrón que Jubileo: cada sección vive en
+`activities/visitapapa26/<seccion>` con forma `{ updatedAt, data, hidden? }`.
+Secciones actuales: `horario`, `materiales`, `visitas`, `profundiza`, `grupos`,
+`contactos`, `apps`, `compartiendo` (reflexiones). El panel debe poder
+crear/editar/ocultar (`hidden: true`) estas secciones.
+
+> "Comida de Domingo" **no** es una sección de Firebase: es una sección-enlace
+> definida en código que abre una URL de Google Maps. Si en el futuro se quiere
+> editar esa URL desde el panel, ver el paso 4.
+
+## 4. SIGUIENTES PASOS — mover "evento activo/archivado" a Firebase (nodo `activities/`)
+
+Hoy el evento activo y el estado (`active`/`archived`) están en código. El
+objetivo es gestionarlos desde el panel sin desplegar la app. Plan propuesto:
+
+1. **Modelo en Firebase** (bajo `activities/`):
+   - `activities/_meta` → `{ activeEventId: 'visitapapa26', updatedAt }`
+     (qué evento entra en "modo evento": tab + banner + por defecto).
+   - `activities/<evento>/_meta` → `{ status: 'active' | 'archived',
+     title, tintColor, bannerText, updatedAt }` (metadatos por evento, hoy en
+     `EventConfig` de `constants/events.ts`).
+   - Opcional: permitir secciones-enlace editables, p.ej.
+     `activities/<evento>/_sections` con entradas `{ label, emoji, url, ... }`
+     para no tocar código al cambiar la URL de "Comida de Domingo".
+2. **Lado app** (cuando se implemente): un hook `useFirebaseData` que lea
+   `activities/_meta` y `activities/<evento>/_meta` y **sobrescriba** los valores
+   de `constants/events.ts` (el código queda como fallback offline). Resolver:
+   - `ACTIVE_EVENT_ID` ← `activities/_meta.activeEventId`.
+   - `status` por evento ← `_meta.status` (decide tab/banner vs "Eventos pasados").
+3. **Panel**: UI para (a) marcar un evento como **activo** (modo evento) o
+   **archivado**, (b) editar `title`/`tintColor`/`bannerText`, y (c) gestionar
+   secciones-enlace. Al cambiar, escribir el nodo correspondiente + `updatedAt`.
+4. **Generalizar actividades-tab**: hoy añadir una actividad como tab requiere un
+   archivo `app/(tabs)/<evento>.tsx` + entradas de catálogo. Valorar un registro
+   dinámico (la app crea la tab a partir de `activities/<evento>/_meta`) para que
+   lanzar un evento futuro sea 100% desde el panel.
+
+## 5. Checklist rápido
+
+- [ ] `visitapapa` disponible en tabs y homeButtons del editor de perfiles.
+- [ ] `eventos-pasados` disponible en masItems (y `jubileo` aún reconocido).
+- [ ] Edición de secciones de `activities/visitapapa26/*` con `hidden`.
+- [ ] (Siguiente fase) nodo `activities/_meta` + `_meta` por evento y UI para
+      activar/archivar eventos.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,19 @@
 
 ---
 
+## 2026-05-29 — Visita Papa León XIV 2026: evento activo + eventos pasados
+
+- **Nueva tab "Visita Papa"** (`app/(tabs)/visitapapa.tsx`): el evento `visitapapa26` (Firebase `activities/visitapapa26`) tiene su propia pestaña antes de Calendario, con su hub y sub-pantallas (Horario, Materiales, Visitas, Profundiza, Grupos, Contactos, Apps, Reflexiones). Color de marca `#FCD200`.
+- **Modo evento**: `visitapapa26` es el evento activo/destacado (`ACTIVE_EVENT_ID` y evento por defecto en `constants/events.ts`). Se anuncia con un banner en la Home (`app/(tabs)/index.tsx`) y un botón de acceso rápido, ambos visibles solo para perfiles con acceso al evento.
+- **Sección-enlace "Comida de Domingo"**: nuevo campo `url` en `EventSection`. Si está presente, la tarjeta abre un enlace externo (Google Maps) con `Linking.openURL` en vez de navegar a una pantalla (`app/screens/EventHomeScreen.tsx`). El evento no usa las pantallas Comida/ComidaWeb.
+- **Eventos pasados**: nuevo flag `status: 'active' | 'archived'` por evento y pantalla `app/screens/EventosPasadosScreen.tsx` accesible desde "Más > Eventos pasados" (item `eventos-pasados`). Jubileo pasa a `archived` y se accede desde ahí (ya no como item suelto de "Más").
+- **Refactor**: las sub-pantallas de evento y el plumbing del header se extraen a `app/screens/eventStackScreens.tsx`, compartido por el tab "Más" y la tab de evento (alta de futuras actividades-tab = un archivo fino + 1 entrada en `events.ts`).
+- **Perfiles** (`firebase-seed/profileConfig.json`): monitor y miembro reciben la tab y el botón Home de Visita Papa; todos los perfiles cambian el item `jubileo` por `eventos-pasados`. Recuerda replicar en `/profileConfig` de Firebase para el gating en runtime.
+- Catálogos: `tabsCatalog.ts`, `colors.ts`, `profileCatalog.ts`, `MasHomeScreen.tsx`.
+- **Pendiente** (`PROMPT_MCMPANEL_VISITAPAPA.md`): gestionar el evento activo/archivado desde mcmpanel (nodo `activities/` en Firebase) en vez de en código.
+
+---
+
 ## 2026-05-28 — Calendario: detalles de evento + parser ICS enriquecido
 
 - **Detalles de evento al hacer tap**: cada tarjeta de evento ahora abre un `EventDetailsBottomSheet` (nuevo componente) con fecha y hora, ubicación con botón "Abrir en Mapas/Maps", videollamada destacada (Meet/Zoom/Teams/Webex/Jitsi), descripción con saltos de línea y URLs tappables, y enlace "Abrir en Google Calendar" si el evento trae `URL`.

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -31,6 +31,7 @@ import { router } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
 import colors, { Colors } from '@/constants/colors';
+import { getEvent, ACTIVE_EVENT_ID } from '@/constants/events';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import { radii, shadows } from '@/constants/uiStyles';
@@ -191,6 +192,13 @@ export default function Home() {
   // Primary color readable on both light and dark backgrounds
   const accentColor = scheme === 'dark' ? colors.info : colors.primary;
 
+  // Banner "modo evento": destaca el evento activo en la Home. Solo se muestra
+  // a los perfiles que tienen acceso al evento (tab o botón Home).
+  const activeEvent = getEvent(ACTIVE_EVENT_ID);
+  const showEventBanner =
+    resolved.tabs.includes('visitapapa') ||
+    resolved.homeButtons.includes('visitapapa');
+
   // OTA update badge (show in header after user dismisses the modal)
   const {
     isReady: otaReady,
@@ -305,6 +313,14 @@ export default function Home() {
         iconBg: scheme === 'dark' ? '#1A1A3A' : '#E8E0FF',
         iconColor: '#6366F1',
         href: '/cancionero',
+      },
+      visitapapa: {
+        key: 'visitapapa',
+        label: 'Visita Papa',
+        icon: 'church',
+        iconBg: scheme === 'dark' ? '#332B00' : '#FFF8D6',
+        iconColor: '#C9A800',
+        href: '/visitapapa',
       },
       fotos: {
         key: 'fotos',
@@ -624,6 +640,55 @@ export default function Home() {
 
             {/* ── Banner de permisos de notificaciones (denied / undetermined) ── */}
             <NotificationPermissionBanner placement="home" />
+
+            {/* ── Banner del evento activo (modo evento) ── */}
+            {showEventBanner && (
+              <TouchableOpacity
+                style={[
+                  styles.eventBanner,
+                  {
+                    backgroundColor: hexAlpha(activeEvent.tintColor, '20'),
+                    borderColor: hexAlpha(activeEvent.tintColor, '50'),
+                  },
+                ]}
+                onPress={() => {
+                  h.tap();
+                  router.push('/visitapapa');
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={activeEvent.title}
+              >
+                <View
+                  style={[
+                    styles.eventBannerIcon,
+                    { backgroundColor: hexAlpha(activeEvent.tintColor, '35') },
+                  ]}
+                >
+                  <MaterialIcons name="church" size={22} color="#8A6D00" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text
+                    style={[styles.eventBannerTitle, { color: theme.text }]}
+                    numberOfLines={1}
+                  >
+                    {activeEvent.title}
+                  </Text>
+                  {activeEvent.bannerText && (
+                    <Text
+                      style={[styles.eventBannerBody, { color: theme.icon }]}
+                      numberOfLines={2}
+                    >
+                      {activeEvent.bannerText}
+                    </Text>
+                  )}
+                </View>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={22}
+                  color={theme.icon}
+                />
+              </TouchableOpacity>
+            )}
 
             {/* ── Novedades ── */}
             <View style={styles.section}>
@@ -1344,6 +1409,35 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   } as TextStyle,
   onboardingBannerBody: {
+    fontSize: 11,
+    marginTop: 2,
+    lineHeight: 15,
+    opacity: 0.8,
+  } as TextStyle,
+
+  // ── Banner del evento activo (modo evento) ──
+  eventBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    padding: spacing.sm + 4,
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    marginBottom: spacing.md,
+  } as ViewStyle,
+  eventBannerIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
+  } as ViewStyle,
+  eventBannerTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+  } as TextStyle,
+  eventBannerBody: {
     fontSize: 11,
     marginTop: 2,
     lineHeight: 15,

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -31,7 +31,7 @@ import { router } from 'expo-router';
 import { useNavigation } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
 import colors, { Colors } from '@/constants/colors';
-import { getEvent, ACTIVE_EVENT_ID } from '@/constants/events';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
 import { radii, shadows } from '@/constants/uiStyles';
@@ -194,10 +194,14 @@ export default function Home() {
 
   // Banner "modo evento": destaca el evento activo en la Home. Solo se muestra
   // a los perfiles que tienen acceso al evento (tab o botón Home).
-  const activeEvent = getEvent(ACTIVE_EVENT_ID);
+  // El evento activo se lee de Firebase (`activities/_meta`) con fallback al
+  // valor hardcoded en `constants/events.ts`.
+  const { activeEvent } = useActiveMeta();
+  const activeTabId = activeEvent.tabId ?? '';
   const showEventBanner =
-    resolved.tabs.includes('visitapapa') ||
-    resolved.homeButtons.includes('visitapapa');
+    activeTabId !== '' &&
+    (resolved.tabs.includes(activeTabId) ||
+      resolved.homeButtons.includes(activeTabId));
 
   // OTA update badge (show in header after user dismisses the modal)
   const {

--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -1,144 +1,35 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { View, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { useNavigation } from 'expo-router';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { MaterialIcons } from '@expo/vector-icons';
-import { PressableFeedback } from 'heroui-native';
-import GlassHeader from '@/components/ui/GlassHeader.ios';
-
 import MasHomeScreen from '../screens/MasHomeScreen';
 import ComunicaScreen from '../screens/ComunicaScreen';
 import ComunicaGestionScreen from '../screens/ComunicaGestionScreen';
-import EventHomeScreen from '../screens/EventHomeScreen';
-import HorarioScreen from '../screens/HorarioScreen';
-import MaterialesScreen from '../screens/MaterialesScreen';
-import MaterialPagesScreen from '../screens/MaterialPagesScreen';
-import VisitasScreen from '../screens/VisitasScreen';
-import ProfundizaScreen from '../screens/ProfundizaScreen';
-import GruposScreen from '../screens/GruposScreen';
-import ContactosScreen from '../screens/ContactosScreen';
-import ReflexionesScreen from '../screens/ReflexionesScreen';
-import AppsScreen from '../screens/AppsScreen';
 import AlbumListScreen from '../screens/AlbumListScreen';
-import WordleScreen from '../screens/WordleScreen';
-import ComidaScreen from '../screens/ComidaScreen';
-import ComidaWebScreen from '../screens/ComidaWebScreen';
+import EventosPasadosScreen from '../screens/EventosPasadosScreen';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
-import { getEvent } from '@/constants/events';
+import {
+  EventStackParamList,
+  eventStackScreenOptions,
+  renderEventScreens,
+} from '../screens/eventStackScreens';
 
 /**
- * Route params comunes a todas las pantallas de un evento (Jubileo u otros
- * eventos futuros). El `eventId` se resuelve en `constants/events.ts` para
- * saber de qué path de Firebase leer y qué colores usar en el header.
- * Si no se pasa, se usa el evento por defecto.
+ * Stack del tab "Más". Incluye las pantallas propias de Más más todas las
+ * sub-pantallas de evento (compartidas con las tabs de evento vía
+ * `app/screens/eventStackScreens.tsx`).
  */
-type EventRouteParams = { eventId?: string };
-
-export type MasStackParamList = {
+export type MasStackParamList = EventStackParamList & {
   MasHome: { directTo?: string } | undefined;
   Fotos: undefined;
   Comunica: undefined;
   ComunicaGestion: undefined;
-  JubileoHome: EventRouteParams | undefined;
-  Horario: EventRouteParams | undefined;
-  Materiales: (EventRouteParams & { initialDayIndex?: number }) | undefined;
-  MaterialPages: EventRouteParams & { actividad: any; fecha: string };
-  Visitas: EventRouteParams | undefined;
-  Comida: EventRouteParams | undefined;
-  ComidaWeb: EventRouteParams & { url: string; title: string };
-  Profundiza: EventRouteParams | undefined;
-  Grupos: EventRouteParams | undefined;
-  Contactos: EventRouteParams | undefined;
-  Apps: EventRouteParams | undefined;
-  Wordle: EventRouteParams | undefined;
-  Reflexiones: EventRouteParams | undefined;
+  EventosPasados: undefined;
 };
 
 const Stack = createNativeStackNavigator<MasStackParamList>();
-
-// Helper para obtener estilos del header según la plataforma.
-// Web sigue el mismo patrón ligero que el cantoral: fondo tintado + hairline,
-// sin sombra pesada — así los headers se sienten coherentes en toda la app.
-const getHeaderStyle = (tintColor: string) => {
-  if (Platform.OS === 'ios') {
-    return { backgroundColor: 'transparent' };
-  } else if (Platform.OS === 'web') {
-    return {
-      backgroundColor: tintColor,
-      borderBottomWidth: 1,
-      borderBottomColor: 'rgba(0, 0, 0, 0.08)',
-      elevation: 0,
-      shadowOpacity: 0,
-    };
-  } else {
-    return { backgroundColor: tintColor };
-  }
-};
-
-// Helper para obtener el color del texto según el color de fondo
-const getTextColor = (tintColor: string) => {
-  // Determinar si el color es claro u oscuro
-  const hex = tintColor.replace('#', '');
-  const r = parseInt(
-    hex.length === 6 ? hex.substring(0, 2) : hex[0] + hex[0],
-    16,
-  );
-  const g = parseInt(
-    hex.length === 6 ? hex.substring(2, 4) : hex[1] + hex[1],
-    16,
-  );
-  const b = parseInt(
-    hex.length === 6 ? hex.substring(4, 6) : hex[2] + hex[2],
-    16,
-  );
-  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-
-  if (Platform.OS === 'ios') {
-    return '#1a1a1a'; // iOS siempre usa texto oscuro con GlassHeader
-  } else if (Platform.OS === 'web') {
-    return brightness > 180 ? '#1a1a1a' : '#fff'; // Texto oscuro para colores claros, blanco para oscuros
-  } else {
-    return '#fff'; // Android usa texto blanco por defecto
-  }
-};
-
-/**
- * Opciones de header para una pantalla de evento. El color se deriva del
- * `eventId` del route param — cae a Jubileo si falta. Esto permite reusar
- * todas las sub-pantallas para eventos nuevos sin duplicar registros.
- */
-type EventScreenRoute = { params?: { eventId?: string } };
-
-const eventScreenOptions =
-  (title: string) =>
-  ({ route }: { route: EventScreenRoute }) => {
-    const event = getEvent(route.params?.eventId);
-    const tint = event.tintColor;
-    const textColor = getTextColor(tint);
-    return {
-      title,
-      headerStyle: getHeaderStyle(tint),
-      headerTintColor: textColor,
-      headerTitleStyle: {
-        fontWeight: '700' as const,
-        fontSize: 18,
-        color: textColor,
-      },
-      headerBackground: () =>
-        Platform.OS === 'ios' ? <GlassHeader tintColor={tint} /> : undefined,
-    };
-  };
-
-/** Igual que eventScreenOptions pero usa `event.title` y oculta headerRight. */
-const eventHubScreenOptions = ({ route }: { route: EventScreenRoute }) => {
-  const event = getEvent(route.params?.eventId);
-  return {
-    ...eventScreenOptions(event.title)({ route }),
-    headerRight: undefined,
-  };
-};
 
 export default function MasTab() {
   const [settingsVisible, setSettingsVisible] = useState(false);
@@ -197,98 +88,13 @@ export default function MasTab() {
       />
       <Stack.Navigator
         initialRouteName="MasHome"
-        screenOptions={({ navigation, route }) => {
-          // Always capture the active screen's nav ref so canGoBack() and
-          // popToTop() reflect the real stack depth (not just the root screen).
-          stackNavRef.current = navigation;
-          return {
-            // Congela pantallas que no están visibles al cambiar de tab:
-            // libera CPU/memoria de las que tienen contenido pesado.
-            freezeOnBlur: true,
-            headerBackTitle: 'Atrás',
-            headerStyle:
-              Platform.OS === 'ios'
-                ? { backgroundColor: 'transparent' }
-                : Platform.OS === 'web'
-                  ? {
-                      backgroundColor: '#78909C',
-                      borderBottomWidth: 1,
-                      borderBottomColor: 'rgba(0, 0, 0, 0.08)',
-                      elevation: 0,
-                      shadowOpacity: 0,
-                    }
-                  : { backgroundColor: '#78909C' },
-            headerTintColor:
-              Platform.OS === 'ios'
-                ? '#1a1a1a'
-                : Platform.OS === 'web'
-                  ? '#fff'
-                  : '#fff',
-            headerTitleStyle: {
-              fontWeight: '700',
-              fontSize: 18,
-              color:
-                Platform.OS === 'ios'
-                  ? '#1a1a1a'
-                  : Platform.OS === 'web'
-                    ? '#fff'
-                    : '#fff',
-            },
-            headerTitleAlign: 'center',
-            headerStatusBarHeight: webStatusBarHeight,
-            headerTransparent: false,
-            headerBackground: () =>
-              Platform.OS === 'ios' ? (
-                <GlassHeader tintColor="#78909C" />
-              ) : undefined,
-            headerRight: () => {
-              // Solo mostrar los botones en las pantallas de un evento
-              const isEventScreen =
-                route.name !== 'MasHome' &&
-                route.name !== 'JubileoHome' &&
-                route.name !== 'Fotos';
-              if (!isEventScreen) return null;
-
-              // Color del icono según el evento activo (cae a Jubileo)
-              const eventId = (route.params as { eventId?: string } | undefined)
-                ?.eventId;
-              const iconColor = getTextColor(getEvent(eventId).tintColor);
-
-              return (
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    marginRight: 8,
-                  }}
-                >
-                  <PressableFeedback
-                    onPress={() => setSettingsVisible(true)}
-                    style={{ padding: 10 }}
-                  >
-                    <PressableFeedback.Highlight />
-                    <MaterialIcons
-                      name="settings"
-                      size={26}
-                      color={iconColor}
-                    />
-                  </PressableFeedback>
-                  {route.name !== 'Reflexiones' && (
-                    <PressableFeedback
-                      onPress={() =>
-                        navigation.navigate('Reflexiones', { eventId })
-                      }
-                      style={{ padding: 10 }}
-                    >
-                      <PressableFeedback.Highlight />
-                      <MaterialIcons name="forum" size={26} color={iconColor} />
-                    </PressableFeedback>
-                  )}
-                </View>
-              );
-            },
-          };
-        }}
+        screenOptions={eventStackScreenOptions({
+          onSettings: () => setSettingsVisible(true),
+          webStatusBarHeight,
+          onNavReady: (nav) => {
+            stackNavRef.current = nav;
+          },
+        })}
       >
         <Stack.Screen
           name="MasHome"
@@ -326,70 +132,15 @@ export default function MasTab() {
           }}
         />
         <Stack.Screen
-          name="JubileoHome"
-          component={EventHomeScreen}
-          options={eventHubScreenOptions}
+          name="EventosPasados"
+          component={EventosPasadosScreen}
+          options={{
+            title: 'Eventos pasados',
+            // No es una pantalla de evento: sin botones settings/reflexiones.
+            headerRight: () => null,
+          }}
         />
-        <Stack.Screen
-          name="Horario"
-          component={HorarioScreen}
-          options={eventScreenOptions('Horario')}
-        />
-        <Stack.Screen
-          name="Materiales"
-          component={MaterialesScreen}
-          options={eventScreenOptions('Materiales')}
-        />
-        <Stack.Screen
-          name="MaterialPages"
-          component={MaterialPagesScreen}
-          options={eventScreenOptions('Material')}
-        />
-        <Stack.Screen
-          name="Comida"
-          component={ComidaScreen}
-          options={eventScreenOptions('Comida')}
-        />
-        <Stack.Screen
-          name="ComidaWeb"
-          component={ComidaWebScreen}
-          options={eventScreenOptions('Comida')}
-        />
-        <Stack.Screen
-          name="Visitas"
-          component={VisitasScreen}
-          options={eventScreenOptions('Visitas')}
-        />
-        <Stack.Screen
-          name="Profundiza"
-          component={ProfundizaScreen}
-          options={eventScreenOptions('Profundiza')}
-        />
-        <Stack.Screen
-          name="Grupos"
-          component={GruposScreen}
-          options={eventScreenOptions('Grupos')}
-        />
-        <Stack.Screen
-          name="Contactos"
-          component={ContactosScreen}
-          options={eventScreenOptions('Contactos')}
-        />
-        <Stack.Screen
-          name="Apps"
-          component={AppsScreen}
-          options={eventScreenOptions('Apps')}
-        />
-        <Stack.Screen
-          name="Wordle"
-          component={WordleScreen}
-          options={eventScreenOptions('Wordle Jubileo')}
-        />
-        <Stack.Screen
-          name="Reflexiones"
-          component={ReflexionesScreen}
-          options={eventScreenOptions('Compartiendo')}
-        />
+        {renderEventScreens(Stack as never, { includeExtras: true })}
       </Stack.Navigator>
     </>
   );

--- a/mcm-app/app/(tabs)/visitapapa.tsx
+++ b/mcm-app/app/(tabs)/visitapapa.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Platform } from 'react-native';
+import { useNavigation } from 'expo-router';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import EventHomeScreen from '../screens/EventHomeScreen';
+import SettingsBottomSheet from '@/components/SettingsBottomSheet';
+import {
+  EventStackParamList,
+  eventHubScreenOptions,
+  eventStackScreenOptions,
+  renderEventScreens,
+} from '../screens/eventStackScreens';
+
+/**
+ * Tab del evento activo "Visita Papa León XIV 2026" (modo evento).
+ *
+ * Reusa el mismo stack genérico de evento que el tab "Más" (Jubileo) pero con
+ * su propio header y `eventId` fijo (`visitapapa26`) inyectado vía
+ * `initialParams`. Para crear otra actividad-tab basta con duplicar este
+ * archivo cambiando el `eventId` + registrar el tab en los catálogos.
+ */
+const Stack = createNativeStackNavigator<EventStackParamList>();
+
+export default function VisitaPapaTab() {
+  const [settingsVisible, setSettingsVisible] = useState(false);
+  const stackNavRef = useRef<any>(null);
+  const wasBlurredRef = useRef(false);
+  const insets = useSafeAreaInsets();
+  const webStatusBarHeight = Platform.OS === 'web' ? insets.top : undefined;
+
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const unsubscribeBlur = navigation.addListener('blur' as any, () => {
+      wasBlurredRef.current = true;
+    });
+
+    // Cross-tab return (blur → focus): pop to root from JS.
+    const unsubscribeFocus = navigation.addListener('focus' as any, () => {
+      if (!wasBlurredRef.current) return;
+      wasBlurredRef.current = false;
+      setTimeout(() => {
+        if (stackNavRef.current?.canGoBack()) {
+          stackNavRef.current.popToTop();
+        }
+      }, 0);
+    });
+
+    // Same-tab re-tap: pop a la raíz desde JS (ver nota en mas.tsx).
+    const unsubscribeTabPress = navigation
+      .getParent()
+      ?.addListener('tabPress' as any, () => {
+        if (!(navigation as any).isFocused?.()) return;
+        if (stackNavRef.current?.canGoBack()) {
+          stackNavRef.current.popToTop();
+        }
+      });
+
+    return () => {
+      unsubscribeBlur();
+      unsubscribeFocus();
+      unsubscribeTabPress?.();
+    };
+  }, [navigation]);
+
+  return (
+    <>
+      <SettingsBottomSheet
+        visible={settingsVisible}
+        onClose={() => setSettingsVisible(false)}
+      />
+      <Stack.Navigator
+        initialRouteName="JubileoHome"
+        screenOptions={eventStackScreenOptions({
+          onSettings: () => setSettingsVisible(true),
+          webStatusBarHeight,
+          onNavReady: (nav) => {
+            stackNavRef.current = nav;
+          },
+        })}
+      >
+        <Stack.Screen
+          name="JubileoHome"
+          component={EventHomeScreen}
+          initialParams={{ eventId: 'visitapapa26' }}
+          options={eventHubScreenOptions}
+        />
+        {renderEventScreens(Stack, { skipHub: true, includeExtras: false })}
+      </Stack.Navigator>
+    </>
+  );
+}

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -50,6 +50,7 @@ import { PreviewChannelProvider } from '@/contexts/PreviewChannelContext';
 import { PreviewChannelModal } from '@/components/PreviewChannelModal';
 import { CarismochitoProvider } from '@/contexts/CarismochitoContext';
 import CarismochitoOverlay from '@/components/CarismochitoOverlay';
+import { ActiveEventProvider } from '@/contexts/ActiveEventContext';
 // Importar iconos para asegurar que se incluyan en el build
 import '@/constants/iconAssets';
 
@@ -74,7 +75,9 @@ export default function RootLayout() {
                               <PreviewChannelProvider>
                                 <OTAProvider>
                                   <CarismochitoProvider>
-                                    <InnerLayout />
+                                    <ActiveEventProvider>
+                                      <InnerLayout />
+                                    </ActiveEventProvider>
                                   </CarismochitoProvider>
                                 </OTAProvider>
                               </PreviewChannelProvider>

--- a/mcm-app/app/screens/EventHomeScreen.tsx
+++ b/mcm-app/app/screens/EventHomeScreen.tsx
@@ -8,6 +8,7 @@ import {
   useWindowDimensions,
   ScrollView,
   Platform,
+  Linking,
 } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -19,7 +20,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { hexAlpha } from '@/utils/colorUtils';
 import { radii } from '@/constants/uiStyles';
 import spacing from '@/constants/spacing';
-import { MasStackParamList } from '../(tabs)/mas';
+import { EventStackParamList } from './eventStackScreens';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import useNetworkStatus from '@/hooks/useNetworkStatus';
 import OfflineBanner from '@/components/OfflineBanner';
@@ -44,7 +45,7 @@ const WIDE_BREAKPOINT = 700;
  */
 export default function EventHomeScreen() {
   const navigation =
-    useNavigation<NativeStackNavigationProp<MasStackParamList>>();
+    useNavigation<NativeStackNavigationProp<EventStackParamList>>();
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const event = useCurrentEvent();
@@ -86,16 +87,23 @@ export default function EventHomeScreen() {
         <View style={[styles.gridContainer, { gap }]}>
           {visibleSections.map((section) => (
             <SectionCard
-              key={section.target + section.label}
+              key={section.firebaseKey ?? section.url ?? section.label}
               section={section}
               event={event}
               width={itemWidth}
               isDark={isDark}
-              onPress={() =>
-                (navigation as any).navigate(section.target, {
-                  eventId: event.id,
-                })
-              }
+              onPress={() => {
+                // Sección-enlace: abre la URL externa (ej. Google Maps).
+                if (section.url) {
+                  Linking.openURL(section.url).catch(() => {});
+                  return;
+                }
+                if (section.target) {
+                  (navigation as any).navigate(section.target, {
+                    eventId: event.id,
+                  });
+                }
+              }}
             />
           ))}
         </View>
@@ -123,13 +131,14 @@ function SectionCard({
   onPress: () => void;
 }) {
   const styles = React.useMemo(() => createStyles(isDark), [isDark]);
+  const sectionSlug = section.firebaseKey ?? section.target ?? section.label;
   const { hidden: firebaseHidden } = useFirebaseData(
     section.firebaseKey
       ? getEventFirebasePath(event, section.firebaseKey)
-      : `__noop__/${section.target}`,
+      : `__noop__/${sectionSlug}`,
     section.firebaseKey
       ? getEventCacheKey(event, section.firebaseKey)
-      : `__noop__${event.id}_${section.target}`,
+      : `__noop__${event.id}_${sectionSlug}`,
   );
 
   if (firebaseHidden) return null;

--- a/mcm-app/app/screens/EventosPasadosScreen.tsx
+++ b/mcm-app/app/screens/EventosPasadosScreen.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import {
+  View,
+  StyleSheet,
+  Text,
+  ScrollView,
+  Platform,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { PressableFeedback } from 'heroui-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { MaterialIcons } from '@expo/vector-icons';
+
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { hexAlpha } from '@/utils/colorUtils';
+import spacing from '@/constants/spacing';
+import { radii } from '@/constants/uiStyles';
+import { getArchivedEvents } from '@/constants/events';
+import { MasStackParamList } from '../(tabs)/mas';
+
+/**
+ * "Eventos pasados": lista los eventos archivados (`status: 'archived'` en
+ * `constants/events.ts`) como tarjetas que abren su hub. Hoy muestra Jubileo;
+ * cuando un evento activo se archive aparecerá aquí automáticamente.
+ */
+export default function EventosPasadosScreen() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MasStackParamList>>();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = React.useMemo(() => createStyles(isDark), [isDark]);
+
+  const events = React.useMemo(() => getArchivedEvents(), []);
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={
+          Platform.OS === 'ios'
+            ? { paddingBottom: 140, padding: spacing.md }
+            : { paddingBottom: spacing.xl, padding: spacing.md }
+        }
+        showsVerticalScrollIndicator={false}
+      >
+        {events.length === 0 ? (
+          <Text style={styles.empty}>Todavía no hay eventos pasados.</Text>
+        ) : (
+          events.map((event) => (
+            <PressableFeedback
+              key={event.id}
+              style={[
+                styles.card,
+                { backgroundColor: isDark ? '#2C2C2E' : '#fff' },
+                Platform.OS !== 'web'
+                  ? {
+                      shadowColor: event.tintColor,
+                      shadowOffset: { width: 0, height: 4 },
+                      shadowOpacity: isDark ? 0.3 : 0.15,
+                      shadowRadius: 12,
+                      elevation: 4,
+                    }
+                  : ({
+                      boxShadow: `0 4px 12px ${hexAlpha(event.tintColor, '30')}`,
+                    } as ViewStyle),
+              ]}
+              onPress={() =>
+                navigation.navigate('JubileoHome', { eventId: event.id })
+              }
+              accessibilityRole="button"
+              accessibilityLabel={event.title}
+            >
+              <PressableFeedback.Highlight />
+              <View
+                style={[styles.accentBar, { backgroundColor: event.tintColor }]}
+              />
+              <View style={styles.cardBody}>
+                <View
+                  style={[
+                    styles.iconCircle,
+                    { backgroundColor: hexAlpha(event.tintColor, '18') },
+                  ]}
+                >
+                  <MaterialIcons
+                    name="history"
+                    size={26}
+                    color={event.tintColor}
+                  />
+                </View>
+                <Text
+                  style={[
+                    styles.cardTitle,
+                    { color: isDark ? '#fff' : '#1C1C1E' },
+                  ]}
+                  numberOfLines={2}
+                >
+                  {event.title}
+                </Text>
+                <View
+                  style={[
+                    styles.arrowCircle,
+                    { backgroundColor: hexAlpha(event.tintColor, '15') },
+                  ]}
+                >
+                  <MaterialIcons
+                    name="arrow-forward"
+                    size={18}
+                    color={event.tintColor}
+                  />
+                </View>
+              </View>
+            </PressableFeedback>
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+interface Styles {
+  safeArea: ViewStyle;
+  container: ViewStyle;
+  empty: TextStyle;
+  card: ViewStyle;
+  accentBar: ViewStyle;
+  cardBody: ViewStyle;
+  iconCircle: ViewStyle;
+  cardTitle: TextStyle;
+  arrowCircle: ViewStyle;
+}
+
+const createStyles = (isDark: boolean) =>
+  StyleSheet.create<Styles>({
+    safeArea: {
+      flex: 1,
+      backgroundColor: isDark ? '#1C1C1E' : '#F2F2F7',
+    },
+    container: {
+      flex: 1,
+    },
+    empty: {
+      textAlign: 'center',
+      marginTop: spacing.xl,
+      color: isDark ? '#8E8E93' : '#6B7280',
+      fontSize: 15,
+    },
+    card: {
+      borderRadius: radii.xl,
+      marginBottom: spacing.md,
+      overflow: 'hidden',
+    },
+    accentBar: {
+      height: 4,
+      width: '100%',
+    },
+    cardBody: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.md,
+      gap: spacing.md,
+    },
+    iconCircle: {
+      width: 56,
+      height: 56,
+      borderRadius: radii.md,
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexShrink: 0,
+    },
+    cardTitle: {
+      flex: 1,
+      fontSize: 18,
+      fontWeight: '700',
+      letterSpacing: -0.3,
+    },
+    arrowCircle: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexShrink: 0,
+    },
+  });

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -67,7 +67,16 @@ const MAS_ITEM_CATALOG: Record<string, NavigationItem> = {
     emoji: '🎉',
     materialIcon: 'celebration',
     target: 'JubileoHome',
+    eventId: 'jubileo',
     tintColor: '#A3BD31',
+  },
+  'eventos-pasados': {
+    label: 'Eventos pasados',
+    subtitle: 'Jubileo y otros encuentros',
+    emoji: '🗂️',
+    materialIcon: 'history',
+    target: 'EventosPasados',
+    tintColor: '#9FA8DA',
   },
   // ── Añadir eventos futuros aquí ──
   // Ejemplo:

--- a/mcm-app/app/screens/eventStackScreens.tsx
+++ b/mcm-app/app/screens/eventStackScreens.tsx
@@ -80,30 +80,15 @@ export const getHeaderStyle = (tintColor: string) => {
   }
 };
 
-// Helper para obtener el color del texto según el color de fondo
-export const getTextColor = (tintColor: string) => {
-  const hex = tintColor.replace('#', '');
-  const r = parseInt(
-    hex.length === 6 ? hex.substring(0, 2) : hex[0] + hex[0],
-    16,
-  );
-  const g = parseInt(
-    hex.length === 6 ? hex.substring(2, 4) : hex[1] + hex[1],
-    16,
-  );
-  const b = parseInt(
-    hex.length === 6 ? hex.substring(4, 6) : hex[2] + hex[2],
-    16,
-  );
-  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-
-  if (Platform.OS === 'ios') {
-    return '#1a1a1a'; // iOS siempre usa texto oscuro con GlassHeader
-  } else if (Platform.OS === 'web') {
-    return brightness > 180 ? '#1a1a1a' : '#fff';
-  } else {
-    return '#fff'; // Android usa texto blanco por defecto
-  }
+// Helper para obtener el color del texto del header.
+// iOS y web usan siempre texto oscuro (coherente con el resto de tabs, p.ej.
+// el cantoral, que pinta texto oscuro sobre su franja de color). Antes web
+// volteaba a blanco para tints medios/oscuros (el verde de Jubileo), lo que
+// rompía la coherencia visual con el resto de la app. Android sigue la
+// convención Material de texto blanco sobre la barra de color.
+// (El parámetro se mantiene por compatibilidad de firma.)
+export const getTextColor = (_tintColor?: string) => {
+  return Platform.OS === 'android' ? '#fff' : '#1a1a1a';
 };
 
 /**
@@ -121,6 +106,10 @@ export const eventScreenOptions =
       title,
       headerStyle: getHeaderStyle(tint),
       headerTintColor: textColor,
+      // Quita la sombra pesada bajo la barra de color (coherente con el
+      // cantoral). En web/android `shadowOpacity`/`elevation` del headerStyle
+      // no bastan: la sombra se controla con esta prop.
+      headerShadowVisible: false,
       headerTitleStyle: {
         fontWeight: '700' as const,
         fontSize: 18,
@@ -222,6 +211,7 @@ export function eventStackScreenOptions({
               }
             : { backgroundColor: '#78909C' },
       headerTintColor: Platform.OS === 'ios' ? '#1a1a1a' : '#fff',
+      headerShadowVisible: false,
       headerTitleStyle: {
         fontWeight: '700' as const,
         fontSize: 18,

--- a/mcm-app/app/screens/eventStackScreens.tsx
+++ b/mcm-app/app/screens/eventStackScreens.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+import { View, Platform } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { MaterialIcons } from '@expo/vector-icons';
+import { PressableFeedback } from 'heroui-native';
+
+import GlassHeader from '@/components/ui/GlassHeader.ios';
+import { getEvent } from '@/constants/events';
+
+import EventHomeScreen from './EventHomeScreen';
+import HorarioScreen from './HorarioScreen';
+import MaterialesScreen from './MaterialesScreen';
+import MaterialPagesScreen from './MaterialPagesScreen';
+import VisitasScreen from './VisitasScreen';
+import ProfundizaScreen from './ProfundizaScreen';
+import GruposScreen from './GruposScreen';
+import ContactosScreen from './ContactosScreen';
+import AppsScreen from './AppsScreen';
+import ReflexionesScreen from './ReflexionesScreen';
+import ComidaScreen from './ComidaScreen';
+import ComidaWebScreen from './ComidaWebScreen';
+import WordleScreen from './WordleScreen';
+
+/**
+ * Plumbing compartido del stack de un evento (Jubileo, Visita Papa, etc.).
+ *
+ * Las sub-pantallas de evento son las mismas en todos los eventos; este módulo
+ * las registra una sola vez para que las consuman tanto el tab "Más"
+ * (`app/(tabs)/mas.tsx`) como las tabs de evento propias (ej.
+ * `app/(tabs)/visitapapa.tsx`). Añadir una actividad-tab nueva = un archivo
+ * fino + 1 entrada en `constants/events.ts`.
+ */
+
+/**
+ * Route params comunes a todas las pantallas de un evento. El `eventId` se
+ * resuelve en `constants/events.ts` para saber de qué path de Firebase leer y
+ * qué colores usar en el header. Si no se pasa, se usa el evento por defecto.
+ */
+export type EventRouteParams = { eventId?: string };
+
+/** Pantallas comunes a cualquier evento. */
+export type EventStackParamList = {
+  JubileoHome: EventRouteParams | undefined;
+  Horario: EventRouteParams | undefined;
+  Materiales: (EventRouteParams & { initialDayIndex?: number }) | undefined;
+  MaterialPages: EventRouteParams & { actividad: any; fecha: string };
+  Visitas: EventRouteParams | undefined;
+  Comida: EventRouteParams | undefined;
+  ComidaWeb: EventRouteParams & { url: string; title: string };
+  Profundiza: EventRouteParams | undefined;
+  Grupos: EventRouteParams | undefined;
+  Contactos: EventRouteParams | undefined;
+  Apps: EventRouteParams | undefined;
+  Wordle: EventRouteParams | undefined;
+  Reflexiones: EventRouteParams | undefined;
+};
+
+type EventStackNavigator = ReturnType<
+  typeof createNativeStackNavigator<EventStackParamList>
+>;
+
+type EventScreenRoute = { params?: { eventId?: string } };
+
+// Helper para obtener estilos del header según la plataforma.
+// Web sigue el mismo patrón ligero que el cantoral: fondo tintado + hairline,
+// sin sombra pesada — así los headers se sienten coherentes en toda la app.
+export const getHeaderStyle = (tintColor: string) => {
+  if (Platform.OS === 'ios') {
+    return { backgroundColor: 'transparent' };
+  } else if (Platform.OS === 'web') {
+    return {
+      backgroundColor: tintColor,
+      borderBottomWidth: 1,
+      borderBottomColor: 'rgba(0, 0, 0, 0.08)',
+      elevation: 0,
+      shadowOpacity: 0,
+    };
+  } else {
+    return { backgroundColor: tintColor };
+  }
+};
+
+// Helper para obtener el color del texto según el color de fondo
+export const getTextColor = (tintColor: string) => {
+  const hex = tintColor.replace('#', '');
+  const r = parseInt(
+    hex.length === 6 ? hex.substring(0, 2) : hex[0] + hex[0],
+    16,
+  );
+  const g = parseInt(
+    hex.length === 6 ? hex.substring(2, 4) : hex[1] + hex[1],
+    16,
+  );
+  const b = parseInt(
+    hex.length === 6 ? hex.substring(4, 6) : hex[2] + hex[2],
+    16,
+  );
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+
+  if (Platform.OS === 'ios') {
+    return '#1a1a1a'; // iOS siempre usa texto oscuro con GlassHeader
+  } else if (Platform.OS === 'web') {
+    return brightness > 180 ? '#1a1a1a' : '#fff';
+  } else {
+    return '#fff'; // Android usa texto blanco por defecto
+  }
+};
+
+/**
+ * Opciones de header para una pantalla de evento. El color se deriva del
+ * `eventId` del route param — cae al evento por defecto si falta. Esto permite
+ * reusar todas las sub-pantallas para eventos nuevos sin duplicar registros.
+ */
+export const eventScreenOptions =
+  (title: string) =>
+  ({ route }: { route: EventScreenRoute }) => {
+    const event = getEvent(route.params?.eventId);
+    const tint = event.tintColor;
+    const textColor = getTextColor(tint);
+    return {
+      title,
+      headerStyle: getHeaderStyle(tint),
+      headerTintColor: textColor,
+      headerTitleStyle: {
+        fontWeight: '700' as const,
+        fontSize: 18,
+        color: textColor,
+      },
+      headerBackground: () =>
+        Platform.OS === 'ios' ? <GlassHeader tintColor={tint} /> : undefined,
+    };
+  };
+
+/** Igual que eventScreenOptions pero usa `event.title` y oculta headerRight. */
+export const eventHubScreenOptions = ({
+  route,
+}: {
+  route: EventScreenRoute;
+}) => {
+  const event = getEvent(route.params?.eventId);
+  return {
+    ...eventScreenOptions(event.title)({ route }),
+    headerRight: undefined,
+  };
+};
+
+/**
+ * Botones del header derecho en las sub-pantallas de evento (ajustes +
+ * reflexiones). No se muestran en el hub ni en pantallas no-evento.
+ */
+export function eventHeaderRight({
+  navigation,
+  route,
+  onSettings,
+}: {
+  navigation: any;
+  route: { name: string; params?: { eventId?: string } };
+  onSettings: () => void;
+}) {
+  const isEventScreen =
+    route.name !== 'MasHome' &&
+    route.name !== 'JubileoHome' &&
+    route.name !== 'Fotos';
+  if (!isEventScreen) return null;
+
+  const eventId = route.params?.eventId;
+  const iconColor = getTextColor(getEvent(eventId).tintColor);
+
+  return (
+    <View
+      style={{ flexDirection: 'row', alignItems: 'center', marginRight: 8 }}
+    >
+      <PressableFeedback onPress={onSettings} style={{ padding: 10 }}>
+        <PressableFeedback.Highlight />
+        <MaterialIcons name="settings" size={26} color={iconColor} />
+      </PressableFeedback>
+      {route.name !== 'Reflexiones' && (
+        <PressableFeedback
+          onPress={() => navigation.navigate('Reflexiones', { eventId })}
+          style={{ padding: 10 }}
+        >
+          <PressableFeedback.Highlight />
+          <MaterialIcons name="forum" size={26} color={iconColor} />
+        </PressableFeedback>
+      )}
+    </View>
+  );
+}
+
+/**
+ * Builder del `screenOptions` del Stack.Navigator de un evento. Replica el
+ * header gris por defecto (que cada pantalla sobreescribe con su tint vía
+ * `eventScreenOptions`) y los botones settings/reflexiones.
+ *
+ * @param onSettings   abre el bottom sheet de ajustes del tab.
+ * @param onNavReady   recibe el `navigation` del stack activo (para popToTop).
+ */
+export function eventStackScreenOptions({
+  onSettings,
+  webStatusBarHeight,
+  onNavReady,
+}: {
+  onSettings: () => void;
+  webStatusBarHeight?: number;
+  onNavReady?: (navigation: any) => void;
+}) {
+  return ({ navigation, route }: { navigation: any; route: any }) => {
+    onNavReady?.(navigation);
+    return {
+      freezeOnBlur: true,
+      headerBackTitle: 'Atrás',
+      headerStyle:
+        Platform.OS === 'ios'
+          ? { backgroundColor: 'transparent' }
+          : Platform.OS === 'web'
+            ? {
+                backgroundColor: '#78909C',
+                borderBottomWidth: 1,
+                borderBottomColor: 'rgba(0, 0, 0, 0.08)',
+                elevation: 0,
+                shadowOpacity: 0,
+              }
+            : { backgroundColor: '#78909C' },
+      headerTintColor: Platform.OS === 'ios' ? '#1a1a1a' : '#fff',
+      headerTitleStyle: {
+        fontWeight: '700' as const,
+        fontSize: 18,
+        color: Platform.OS === 'ios' ? '#1a1a1a' : '#fff',
+      },
+      headerTitleAlign: 'center' as const,
+      headerStatusBarHeight: webStatusBarHeight,
+      headerTransparent: false,
+      headerBackground: () =>
+        Platform.OS === 'ios' ? <GlassHeader tintColor="#78909C" /> : undefined,
+      headerRight: () => eventHeaderRight({ navigation, route, onSettings }),
+    };
+  };
+}
+
+/**
+ * Registra las sub-pantallas de un evento dentro de un Stack.Navigator.
+ *
+ * @param opts.skipHub        no registra `JubileoHome` (lo registra el tab con
+ *                            sus `initialParams`).
+ * @param opts.includeExtras  registra Comida/ComidaWeb/Wordle (solo Jubileo;
+ *                            Visita Papa usa una sección-enlace para la comida).
+ */
+export function renderEventScreens(
+  Stack: EventStackNavigator,
+  opts?: { skipHub?: boolean; includeExtras?: boolean },
+) {
+  const { skipHub = false, includeExtras = false } = opts ?? {};
+  return (
+    <>
+      {!skipHub && (
+        <Stack.Screen
+          name="JubileoHome"
+          component={EventHomeScreen}
+          options={eventHubScreenOptions}
+        />
+      )}
+      <Stack.Screen
+        name="Horario"
+        component={HorarioScreen}
+        options={eventScreenOptions('Horario')}
+      />
+      <Stack.Screen
+        name="Materiales"
+        component={MaterialesScreen}
+        options={eventScreenOptions('Materiales')}
+      />
+      <Stack.Screen
+        name="MaterialPages"
+        component={MaterialPagesScreen}
+        options={eventScreenOptions('Material')}
+      />
+      <Stack.Screen
+        name="Visitas"
+        component={VisitasScreen}
+        options={eventScreenOptions('Visitas')}
+      />
+      <Stack.Screen
+        name="Profundiza"
+        component={ProfundizaScreen}
+        options={eventScreenOptions('Profundiza')}
+      />
+      <Stack.Screen
+        name="Grupos"
+        component={GruposScreen}
+        options={eventScreenOptions('Grupos')}
+      />
+      <Stack.Screen
+        name="Contactos"
+        component={ContactosScreen}
+        options={eventScreenOptions('Contactos')}
+      />
+      <Stack.Screen
+        name="Apps"
+        component={AppsScreen}
+        options={eventScreenOptions('Apps')}
+      />
+      <Stack.Screen
+        name="Reflexiones"
+        component={ReflexionesScreen}
+        options={eventScreenOptions('Compartiendo')}
+      />
+      {includeExtras && (
+        <>
+          <Stack.Screen
+            name="Comida"
+            component={ComidaScreen}
+            options={eventScreenOptions('Comida')}
+          />
+          <Stack.Screen
+            name="ComidaWeb"
+            component={ComidaWebScreen}
+            options={eventScreenOptions('Comida')}
+          />
+          <Stack.Screen
+            name="Wordle"
+            component={WordleScreen}
+            options={eventScreenOptions('Wordle Jubileo')}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/mcm-app/constants/colors.ts
+++ b/mcm-app/constants/colors.ts
@@ -62,6 +62,7 @@ export const UIColors = {
 // Colores de tabs (cabecera)
 export const TabHeaderColors = {
   cancionero: '#f4c11e', // Amarillo Cantoral
+  visitapapa: '#FCD200', // Amarillo Vaticano — Visita Papa
   calendario: '#31AADF', // Celeste
   fotos: '#E15C62', // Rojo MIC
   comunica: 'rgba(157, 30, 116, 0.87)', // Morado LC con transparencia

--- a/mcm-app/constants/events.ts
+++ b/mcm-app/constants/events.ts
@@ -207,7 +207,7 @@ export const VISITAPAPA: EventConfig = {
       emoji: '🍽️',
       materialIcon: 'restaurant',
       tintColor: '#F06292',
-      url: 'https://maps.app.goo.gl/teJTgd1etjTYhANZA',
+      url: 'https://maps.app.goo.gl/7DEtUhW1tfrnY9Sk7',
     },
     {
       label: 'Visitas',

--- a/mcm-app/constants/events.ts
+++ b/mcm-app/constants/events.ts
@@ -79,6 +79,13 @@ export interface EventConfig {
   status?: 'active' | 'archived';
   /** Subtítulo del banner destacado de la Home (modo evento). */
   bannerText?: string;
+  /**
+   * Nombre del tab de expo-router que representa este evento (ej.
+   * `'visitapapa'`). Lo usa el banner de la Home para el gating de visibilidad
+   * (solo se muestra si el perfil tiene acceso al tab o al botón Home).
+   * Vacío/ausente = sin tab propio (evento solo accesible desde "Más").
+   */
+  tabId?: string;
   sections: EventSection[];
 }
 
@@ -173,6 +180,7 @@ export const VISITAPAPA: EventConfig = {
   firebasePrefix: 'activities/visitapapa26',
   status: 'active',
   bannerText: 'Horarios, materiales y todo para vivir la visita del Papa',
+  tabId: 'visitapapa',
   sections: [
     {
       label: 'Horario',

--- a/mcm-app/constants/events.ts
+++ b/mcm-app/constants/events.ts
@@ -29,8 +29,17 @@ export interface EventSection {
   subtitle?: string;
   emoji: string;
   materialIcon?: ComponentProps<typeof MaterialIcons>['name'];
-  /** Nombre de la pantalla a la que navegar en MasStackParamList. */
-  target: string;
+  /**
+   * Nombre de la pantalla a la que navegar en MasStackParamList. Opcional:
+   * las secciones-enlace (`url`) no navegan a ninguna pantalla.
+   */
+  target?: string;
+  /**
+   * Enlace externo. Si está presente, la tarjeta abre la URL con
+   * `Linking.openURL` en vez de navegar a `target` (ej. una lista de Google
+   * Maps). Reutilizable para cualquier sección que sea solo un enlace.
+   */
+  url?: string;
   tintColor: string;
   /**
    * Slug de Firebase relativo al `firebasePrefix` del evento.
@@ -60,6 +69,16 @@ export interface EventConfig {
    *   `activities/evento2027`).
    */
   firebasePrefix: string;
+  /**
+   * Estado del evento:
+   * · `active`   → evento destacado (modo evento): tab propia + botón Home +
+   *   banner en la Home. Es el `ACTIVE_EVENT_ID`.
+   * · `archived` → evento pasado: accesible en "Más > Eventos pasados".
+   * Si falta, se trata como activo de cara al catálogo.
+   */
+  status?: 'active' | 'archived';
+  /** Subtítulo del banner destacado de la Home (modo evento). */
+  bannerText?: string;
   sections: EventSection[];
 }
 
@@ -70,6 +89,7 @@ export const JUBILEO: EventConfig = {
   title: 'Jubileo',
   tintColor: '#A3BD31',
   firebasePrefix: 'jubileo',
+  status: 'archived',
   sections: [
     {
       label: 'Horario',
@@ -146,18 +166,116 @@ export const JUBILEO: EventConfig = {
   ],
 };
 
+export const VISITAPAPA: EventConfig = {
+  id: 'visitapapa26',
+  title: 'Visita Papa León XIV 2026',
+  tintColor: '#FCD200',
+  firebasePrefix: 'activities/visitapapa26',
+  status: 'active',
+  bannerText: 'Horarios, materiales y todo para vivir la visita del Papa',
+  sections: [
+    {
+      label: 'Horario',
+      subtitle: 'Programa del encuentro',
+      emoji: '⏰',
+      materialIcon: 'schedule',
+      target: 'Horario',
+      tintColor: '#FF8A65',
+      firebaseKey: 'horario',
+    },
+    {
+      label: 'Materiales',
+      subtitle: 'Recursos y dinámicas',
+      emoji: '📦',
+      materialIcon: 'inventory-2',
+      target: 'Materiales',
+      tintColor: '#4FC3F7',
+      firebaseKey: 'materiales',
+    },
+    {
+      // Sección-enlace: abre una lista de Google Maps en vez de navegar.
+      label: 'Comida de Domingo',
+      subtitle: 'Dónde comer el domingo',
+      emoji: '🍽️',
+      materialIcon: 'restaurant',
+      tintColor: '#F06292',
+      url: 'https://maps.app.goo.gl/teJTgd1etjTYhANZA',
+    },
+    {
+      label: 'Visitas',
+      subtitle: 'Salidas y traslados',
+      emoji: '🚌',
+      materialIcon: 'directions-bus',
+      target: 'Visitas',
+      tintColor: '#81C784',
+      firebaseKey: 'visitas',
+    },
+    {
+      label: 'Profundiza',
+      subtitle: 'Reflexión y textos',
+      emoji: '📖',
+      materialIcon: 'menu-book',
+      target: 'Profundiza',
+      tintColor: '#BA68C8',
+      firebaseKey: 'profundiza',
+    },
+    {
+      label: 'Grupos',
+      subtitle: 'Equipos de trabajo',
+      emoji: '👥',
+      materialIcon: 'groups',
+      target: 'Grupos',
+      tintColor: '#FFD54F',
+      firebaseKey: 'grupos',
+    },
+    {
+      label: 'Contactos',
+      subtitle: 'Teléfonos útiles',
+      emoji: '☎️',
+      materialIcon: 'contact-phone',
+      target: 'Contactos',
+      tintColor: '#9FA8DA',
+      firebaseKey: 'contactos',
+    },
+    {
+      label: 'Apps',
+      subtitle: 'Herramientas MCM',
+      emoji: '📲',
+      materialIcon: 'apps',
+      target: 'Apps',
+      tintColor: '#FFB74D',
+      firebaseKey: 'apps',
+    },
+  ],
+};
+
 // ─── Registry ────────────────────────────────────────────────────────
 
 export const EVENTS: Record<string, EventConfig> = {
   [JUBILEO.id]: JUBILEO,
+  [VISITAPAPA.id]: VISITAPAPA,
 };
 
-export const DEFAULT_EVENT_ID = JUBILEO.id;
+/**
+ * Evento activo / destacado ("modo evento"): la app lo resalta con tab propia,
+ * botón en la Home y banner. También es el evento por defecto.
+ *
+ * TODO (mcmpanel/Firebase): mover esta decisión al nodo `activities/` para
+ * poder activar/archivar eventos sin desplegar. Ver PROMPT_MCMPANEL_VISITAPAPA.md.
+ */
+export const ACTIVE_EVENT_ID = VISITAPAPA.id;
 
-/** Devuelve la config del evento. Cae a Jubileo si el id es inválido o nulo. */
+export const DEFAULT_EVENT_ID = ACTIVE_EVENT_ID;
+
+/** Devuelve la config del evento. Cae al evento activo si el id es inválido. */
 export function getEvent(id?: string | null): EventConfig {
   if (!id) return EVENTS[DEFAULT_EVENT_ID];
   return EVENTS[id] ?? EVENTS[DEFAULT_EVENT_ID];
+}
+
+/** Eventos archivados (pasados), para "Más > Eventos pasados". */
+export function getArchivedEvents(): EventConfig[] {
+  return Object.values(EVENTS).filter((e) => e.status === 'archived');
 }
 
 /** Path de Firebase de una sección: `<firebasePrefix>/<key>`. */

--- a/mcm-app/constants/profileCatalog.ts
+++ b/mcm-app/constants/profileCatalog.ts
@@ -9,6 +9,7 @@ export const KNOWN_TABS = [
   'index',
   'cancionero',
   'contigo',
+  'visitapapa',
   'calendario',
   'fotos',
   'comunica',
@@ -21,6 +22,7 @@ export const KNOWN_HOME_BUTTONS = [
   'cancionero',
   'fotos',
   'evangelio',
+  'visitapapa',
   'mas',
 ] as const;
 
@@ -29,6 +31,7 @@ export const KNOWN_MAS_ITEMS = [
   'comunica',
   'comunica-gestion',
   'jubileo',
+  'eventos-pasados',
 ] as const;
 
 /**

--- a/mcm-app/constants/tabsCatalog.ts
+++ b/mcm-app/constants/tabsCatalog.ts
@@ -65,6 +65,17 @@ export const TABS_CONFIG: TabConfig[] = [
     headerShown: false,
   },
   {
+    name: 'visitapapa',
+    label: 'Visita Papa',
+    subtitle: 'Visita del Papa León XIV 2026',
+    emoji: '🕊️',
+    iosIcon: { default: 'cross.circle', selected: 'cross.circle.fill' },
+    androidIcon: 'church',
+    tintColor: TabHeaderColors.visitapapa,
+    headerColor: TabHeaderColors.visitapapa,
+    headerShown: false, // Tab con su propio StackNavigator header
+  },
+  {
     name: 'calendario',
     label: 'Calendario',
     subtitle: 'Eventos y celebraciones',

--- a/mcm-app/contexts/ActiveEventContext.tsx
+++ b/mcm-app/contexts/ActiveEventContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext } from 'react';
+import { useFirebaseData } from '@/hooks/useFirebaseData';
+import { ACTIVE_EVENT_ID, getEvent, EventConfig } from '@/constants/events';
+
+interface ActiveMetaData {
+  activeEventId: string;
+}
+
+interface ActiveEventContextValue {
+  activeEventId: string;
+  activeEvent: EventConfig;
+}
+
+const defaultActiveEvent = getEvent(ACTIVE_EVENT_ID);
+
+const ActiveEventContext = createContext<ActiveEventContextValue>({
+  activeEventId: ACTIVE_EVENT_ID,
+  activeEvent: defaultActiveEvent,
+});
+
+/**
+ * Lee `activities/_meta` de Firebase una sola vez y propaga el evento activo
+ * a toda la app. Mientras no llega el valor remoto (o sin conexión) usa el
+ * `ACTIVE_EVENT_ID` hardcoded como fallback offline.
+ *
+ * El nodo Firebase esperado:
+ *   activities/_meta/updatedAt  → timestamp
+ *   activities/_meta/data       → { activeEventId: 'visitapapa26' }
+ *
+ * Permite al panel MCM cambiar el evento activo sin desplegar la app.
+ */
+export function ActiveEventProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { data } = useFirebaseData<ActiveMetaData>(
+    'activities/_meta',
+    'activities_meta',
+  );
+  const activeEventId = data?.activeEventId ?? ACTIVE_EVENT_ID;
+  const activeEvent = getEvent(activeEventId);
+  return (
+    <ActiveEventContext.Provider value={{ activeEventId, activeEvent }}>
+      {children}
+    </ActiveEventContext.Provider>
+  );
+}
+
+/** Devuelve el evento activo actual, leyéndolo de Firebase si está disponible. */
+export function useActiveMeta(): ActiveEventContextValue {
+  return useContext(ActiveEventContext);
+}

--- a/mcm-app/firebase-seed/profileConfig.json
+++ b/mcm-app/firebase-seed/profileConfig.json
@@ -14,7 +14,7 @@
       "description": "de miembros del MIC y COM",
       "tabs": ["index", "contigo", "calendario", "fotos"],
       "homeButtons": ["fotos", "evangelio"],
-      "masItems": ["jubileo"],
+      "masItems": ["eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "familias"]
@@ -22,9 +22,9 @@
     "monitor": {
       "label": "Monitor/a",
       "description": "de grupos del MIC y COM",
-      "tabs": ["index", "contigo", "calendario", "fotos"],
-      "homeButtons": ["fotos", "evangelio"],
-      "masItems": ["jubileo"],
+      "tabs": ["index", "contigo", "visitapapa", "calendario", "fotos"],
+      "homeButtons": ["fotos", "evangelio", "visitapapa"],
+      "masItems": ["eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "monitores"]
@@ -32,9 +32,9 @@
     "miembro": {
       "label": "Miembro MCM",
       "description": "de cualquier etapa",
-      "tabs": ["index", "contigo", "calendario", "fotos"],
-      "homeButtons": ["fotos", "evangelio"],
-      "masItems": ["jubileo"],
+      "tabs": ["index", "contigo", "visitapapa", "calendario", "fotos"],
+      "homeButtons": ["fotos", "evangelio", "visitapapa"],
+      "masItems": ["eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "miembros"]

--- a/mcm-app/hooks/useCurrentEvent.ts
+++ b/mcm-app/hooks/useCurrentEvent.ts
@@ -3,7 +3,7 @@ import { getEvent, EventConfig } from '@/constants/events';
 
 /**
  * Lee `eventId` del route param actual y devuelve la config del evento.
- * Si no hay eventId o es inválido, cae al evento por defecto (Jubileo).
+ * Si no hay eventId o es inválido, cae al evento por defecto (`DEFAULT_EVENT_ID`).
  *
  * Uso desde cualquier sub-pantalla montada en el MasStack:
  *

--- a/mcm-app/hooks/useCurrentEvent.ts
+++ b/mcm-app/hooks/useCurrentEvent.ts
@@ -1,9 +1,12 @@
 import { useRoute } from '@react-navigation/native';
 import { getEvent, EventConfig } from '@/constants/events';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
 
 /**
  * Lee `eventId` del route param actual y devuelve la config del evento.
- * Si no hay eventId o es inválido, cae al evento por defecto (`DEFAULT_EVENT_ID`).
+ * Si no hay eventId o es inválido, cae al evento activo según Firebase
+ * (`activities/_meta.activeEventId`) o, sin conexión, al `ACTIVE_EVENT_ID`
+ * hardcoded en `constants/events.ts`.
  *
  * Uso desde cualquier sub-pantalla montada en el MasStack:
  *
@@ -16,5 +19,6 @@ import { getEvent, EventConfig } from '@/constants/events';
 export function useCurrentEvent(): EventConfig {
   const route = useRoute();
   const params = (route.params ?? {}) as { eventId?: string };
-  return getEvent(params.eventId);
+  const { activeEventId } = useActiveMeta();
+  return getEvent(params.eventId ?? activeEventId);
 }

--- a/mcm-app/hooks/useFirebaseData.ts
+++ b/mcm-app/hooks/useFirebaseData.ts
@@ -33,7 +33,7 @@ export function useFirebaseData<T>(
             AsyncStorage.getItem(`${storageKey}_hidden`),
           ]);
 
-        if (localDataStr) {
+        if (localDataStr && localDataStr !== 'undefined') {
           const parsed = JSON.parse(localDataStr);
           const transformed = transform ? transform(parsed) : (parsed as T);
           if (isMounted) setData(transformed);
@@ -47,7 +47,9 @@ export function useFirebaseData<T>(
         // sólo el metadato (pocos bytes) y descargo `data` únicamente si
         // ha cambiado. Esto evita bajar megas de `songs`/`albums` en cada
         // arranque cuando el contenido remoto no se ha tocado.
-        if (localDataStr && localUpdatedAt) {
+        const hasLocalCache = !!localDataStr && localDataStr !== 'undefined';
+
+        if (hasLocalCache && localUpdatedAt) {
           const [metaSnap, hiddenSnap] = await Promise.all([
             get(ref(db, `${path}/updatedAt`)),
             get(ref(db, `${path}/hidden`)),
@@ -71,14 +73,18 @@ export function useFirebaseData<T>(
           if (!dataSnap.exists()) return;
           const rawData = dataSnap.val();
           const remoteData = transform ? transform(rawData) : (rawData as T);
-          await AsyncStorage.setItem(
-            `${storageKey}_data`,
-            JSON.stringify(remoteData),
-          );
-          await AsyncStorage.setItem(
-            `${storageKey}_updatedAt`,
-            remoteUpdatedAt,
-          );
+          // No persistir `undefined`: en web AsyncStorage lo guarda como el
+          // string "undefined" y luego JSON.parse revienta.
+          if (remoteData !== undefined) {
+            await AsyncStorage.setItem(
+              `${storageKey}_data`,
+              JSON.stringify(remoteData),
+            );
+            await AsyncStorage.setItem(
+              `${storageKey}_updatedAt`,
+              remoteUpdatedAt,
+            );
+          }
           if (isMounted) setData(remoteData);
           return;
         }
@@ -95,14 +101,18 @@ export function useFirebaseData<T>(
             remoteHidden ? 'true' : 'false',
           );
           const remoteData = transform ? transform(val.data) : (val.data as T);
-          await AsyncStorage.setItem(
-            `${storageKey}_data`,
-            JSON.stringify(remoteData),
-          );
-          await AsyncStorage.setItem(
-            `${storageKey}_updatedAt`,
-            remoteUpdatedAt,
-          );
+          // No persistir `undefined` (nodo sin `data`): evita guardar el
+          // string "undefined" que rompería el JSON.parse del próximo arranque.
+          if (remoteData !== undefined) {
+            await AsyncStorage.setItem(
+              `${storageKey}_data`,
+              JSON.stringify(remoteData),
+            );
+            await AsyncStorage.setItem(
+              `${storageKey}_updatedAt`,
+              remoteUpdatedAt,
+            );
+          }
           if (isMounted) setData(remoteData);
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Introduces **Visita Papa León XIV 2026** as the active event (replacing Jubileo) with its own dedicated tab, and implements a system for managing active vs. archived events. Jubileo is now archived and accessible via "Más > Eventos pasados".

## Key Changes

- **New event infrastructure** (`app/screens/eventStackScreens.tsx`):
  - Extracted shared event stack plumbing into a reusable module with `renderEventScreens()`, `eventStackScreenOptions()`, and `eventHubScreenOptions()` helpers
  - Supports dynamic event coloring and header styling based on `eventId` route param
  - Enables multiple events to share the same sub-screens (Horario, Materiales, Visitas, etc.) without duplication

- **Visita Papa 2026 event** (`constants/events.ts`):
  - Added `VISITAPAPA` config with `id: 'visitapapa26'`, Firebase prefix `activities/visitapapa26`, tint color `#FCD200`
  - Marked as `status: 'active'` (highlighted in Home, has dedicated tab, used as default event)
  - Includes 8 sections: Horario, Materiales, Comida (external link to Google Maps), Visitas, Profundiza, Grupos, Contactos, Apps
  - Jubileo marked as `status: 'archived'`

- **New "Visita Papa" tab** (`app/(tabs)/visitapapa.tsx`):
  - Dedicated tab positioned before Calendario
  - Reuses generic event stack with `eventId: 'visitapapa26'` injected via `initialParams`
  - Same navigation patterns as "Más" tab (blur/focus handling, settings sheet, reflexiones button)

- **"Eventos pasados" screen** (`app/screens/EventosPasadosScreen.tsx`):
  - New screen in "Más" tab listing archived events as cards
  - Taps navigate to event hub with event-specific colors
  - Currently shows Jubileo; auto-populates as events are archived

- **Event banner in Home** (`app/(tabs)/index.tsx`):
  - Displays active event with tint color, title, and optional subtitle (`bannerText`)
  - Only shown to profiles with access to the event (tab or home button)
  - Taps navigate to event tab

- **EventSection model enhancement** (`constants/events.ts`):
  - Added optional `url` field for external link sections (e.g., "Comida de Domingo" → Google Maps)
  - Made `target` optional (sections with `url` don't navigate to screens)

- **Profile catalog updates**:
  - Added `visitapapa` to `KNOWN_TABS` and `KNOWN_HOME_BUTTONS`
  - Replaced `jubileo` with `eventos-pasados` in `KNOWN_MAS_ITEMS` (Jubileo still recognized for backward compatibility)
  - Updated seed profile config to reflect new structure

- **Tab catalog** (`constants/tabsCatalog.ts`):
  - Registered "Visita Papa" tab with emoji 🕊️, iOS icon `cross.circle`, Android icon `church`

- **Documentation**:
  - Added `PROMPT_MCMPANEL_VISITAPAPA.md` with implementation guide for mcmpanel (profile management, section editing, future Firebase-driven active event selection)
  - Updated `CHANGELOG.md` with event launch details

## Implementation Details

- **Event routing**: All event sub-screens accept optional `eventId` param; falls back to `ACTIVE_EVENT_ID` if missing. Enables reuse across events without code duplication.
- **Header styling**: Platform-aware (iOS uses `GlassHeader`, web uses hairline border, Android uses solid color). Text color auto-calculated from tint brightness.
- **External links**: Sections with `url` field open via `Linking.openURL` instead of navigation (no screen registration needed).
- **Active event management**: Currently hardcoded in `constants/events.ts` (`ACTIVE_EVENT_ID`). Future: move

https://claude.ai/code/session_01N9cLEb46xZ4S9sxPpox8XH