### PR TITLE
UI: onboarding (resumen+pasos), eventos Liquid Glass, modo oscuro login

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,15 @@
 
 ---
 
+## 2026-05-29 — UI fixes: onboarding, eventos (Liquid Glass), modo oscuro login
+
+- **Onboarding — paso de login como pantalla final/resumen** (`app/onboarding.tsx`): para perfiles con login (monitor/miembro), al iniciar sesión la pantalla de login pasa a ser el último paso y muestra el resumen (perfil + delegación) con el botón "Ir a la app" centrado verticalmente; ya no hay pantalla `success` extra en ese flujo. Quien continúa sin cuenta sigue viendo la pantalla de resumen `success`.
+- **Onboarding — indicador de pasos**: el indicador de puntos (`ProgressDots`) ahora aparece en perfil, delegación y login, con un total dinámico según el perfil elegido (otros → 1, familia → 2, monitor/miembro → 3).
+- **Eventos — Liquid Glass en sub-pantallas** (`app/screens/eventStackScreens.tsx`, `components/EventActionButtons.tsx`, `app/(tabs)/visitapapa.tsx`, `app/(tabs)/mas.tsx`): las sub-pantallas con `ScreenHero` (Horario, Materiales, Visitas, Profundiza, Grupos, Contactos, Apps) ocultan el título duplicado del header (queda solo la barra glass + volver). Las acciones de Ajustes y Compartiendo salen del header y se muestran como FAB glass flotantes (`EventActionButtons`) que el tab renderiza por encima del navigator.
+- **Modo oscuro del login** (`components/SocialLoginSection.tsx`): el botón de Google ya no usa texto oscuro fijo (era ilegible sobre tarjeta oscura); colores de texto/borde adaptados al esquema oscuro.
+
+---
+
 ## 2026-05-29 — Visita Papa León XIV 2026: evento activo + eventos pasados
 
 - **Nueva tab "Visita Papa"** (`app/(tabs)/visitapapa.tsx`): el evento `visitapapa26` (Firebase `activities/visitapapa26`) tiene su propia pestaña antes de Calendario, con su hub y sub-pantallas (Horario, Materiales, Visitas, Profundiza, Grupos, Contactos, Apps, Reflexiones). Color de marca `#FCD200`.

--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -11,7 +11,9 @@ import AlbumListScreen from '../screens/AlbumListScreen';
 import CalendarioScreen from './calendario';
 import EventosPasadosScreen from '../screens/EventosPasadosScreen';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
+import EventActionButtons from '@/components/EventActionButtons';
 import {
+  EVENT_SUB_ROUTES,
   EventStackParamList,
   eventStackScreenOptions,
   renderEventScreens,
@@ -35,6 +37,10 @@ const Stack = createNativeStackNavigator<MasStackParamList>();
 
 export default function MasTab() {
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [activeRoute, setActiveRoute] = useState<string>('MasHome');
+  const [activeEventId, setActiveEventId] = useState<string | undefined>(
+    undefined,
+  );
   const stackNavRef = useRef<any>(null);
   // Tracks whether we left this tab (blur) so focus knows to pop to root.
   // We only pop when returning FROM another tab, never on same-tab re-tap.
@@ -91,12 +97,21 @@ export default function MasTab() {
       <Stack.Navigator
         initialRouteName="MasHome"
         screenOptions={eventStackScreenOptions({
-          onSettings: () => setSettingsVisible(true),
           webStatusBarHeight,
           onNavReady: (nav) => {
             stackNavRef.current = nav;
           },
         })}
+        screenListeners={{
+          state: (e) => {
+            const navState: any = (e.data as any)?.state;
+            const route = navState?.routes?.[navState.index];
+            if (route?.name) {
+              setActiveRoute(route.name);
+              setActiveEventId(route.params?.eventId);
+            }
+          },
+        }}
       >
         <Stack.Screen
           name="MasHome"
@@ -154,6 +169,17 @@ export default function MasTab() {
         />
         {renderEventScreens(Stack as never, { includeExtras: true })}
       </Stack.Navigator>
+      {(EVENT_SUB_ROUTES as readonly string[]).includes(activeRoute) && (
+        <EventActionButtons
+          onSettings={() => setSettingsVisible(true)}
+          onCompartiendo={() =>
+            stackNavRef.current?.navigate('Reflexiones', {
+              eventId: activeEventId,
+            })
+          }
+          showCompartiendo={activeRoute !== 'Reflexiones'}
+        />
+      )}
     </>
   );
 }

--- a/mcm-app/app/(tabs)/visitapapa.tsx
+++ b/mcm-app/app/(tabs)/visitapapa.tsx
@@ -6,12 +6,16 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import EventHomeScreen from '../screens/EventHomeScreen';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
+import EventActionButtons from '@/components/EventActionButtons';
 import {
+  EVENT_SUB_ROUTES,
   EventStackParamList,
   eventHubScreenOptions,
   eventStackScreenOptions,
   renderEventScreens,
 } from '../screens/eventStackScreens';
+
+const EVENT_ID = 'visitapapa26';
 
 /**
  * Tab del evento activo "Visita Papa León XIV 2026" (modo evento).
@@ -25,6 +29,7 @@ const Stack = createNativeStackNavigator<EventStackParamList>();
 
 export default function VisitaPapaTab() {
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [activeRoute, setActiveRoute] = useState<string>('JubileoHome');
   const stackNavRef = useRef<any>(null);
   const wasBlurredRef = useRef(false);
   const insets = useSafeAreaInsets();
@@ -74,21 +79,36 @@ export default function VisitaPapaTab() {
       <Stack.Navigator
         initialRouteName="JubileoHome"
         screenOptions={eventStackScreenOptions({
-          onSettings: () => setSettingsVisible(true),
           webStatusBarHeight,
           onNavReady: (nav) => {
             stackNavRef.current = nav;
           },
         })}
+        screenListeners={{
+          state: (e) => {
+            const navState: any = (e.data as any)?.state;
+            const route = navState?.routes?.[navState.index];
+            if (route?.name) setActiveRoute(route.name);
+          },
+        }}
       >
         <Stack.Screen
           name="JubileoHome"
           component={EventHomeScreen}
-          initialParams={{ eventId: 'visitapapa26' }}
+          initialParams={{ eventId: EVENT_ID }}
           options={eventHubScreenOptions}
         />
         {renderEventScreens(Stack, { skipHub: true, includeExtras: false })}
       </Stack.Navigator>
+      {(EVENT_SUB_ROUTES as readonly string[]).includes(activeRoute) && (
+        <EventActionButtons
+          onSettings={() => setSettingsVisible(true)}
+          onCompartiendo={() =>
+            stackNavRef.current?.navigate('Reflexiones', { eventId: EVENT_ID })
+          }
+          showCompartiendo={activeRoute !== 'Reflexiones'}
+        />
+      )}
     </>
   );
 }

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -109,6 +109,15 @@ function useThemeT() {
     bg: isDark ? '#1C1C1E' : '#ffffff',
     card: isDark ? '#2C2C2E' : '#ffffff',
     border: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.07)',
+    // Accent used for on-surface interactive elements (icons, selected text,
+    // checks, links). In dark mode the deep primary blue is too low-contrast
+    // over the dark background, so we switch to the lighter secondary blue.
+    tint: isDark ? colors.secondary : colors.primary,
+    // Tinted backgrounds for icon circles / selected cards / summary pills.
+    iconBg: isDark ? 'rgba(149,210,242,0.14)' : 'rgba(37,56,131,0.09)',
+    selectedBg: isDark ? 'rgba(149,210,242,0.12)' : 'rgba(37,56,131,0.055)',
+    chipBg: isDark ? 'rgba(149,210,242,0.12)' : 'rgba(37,56,131,0.06)',
+    chipBorder: isDark ? 'rgba(149,210,242,0.22)' : 'rgba(37,56,131,0.10)',
     isDark,
   };
 }
@@ -119,12 +128,32 @@ const MAX_CONTENT_W = 520;
    Reusable bits
 ─────────────────────────────────────── */
 
-function ProgressDots({ current, total }: { current: number; total: number }) {
+function ProgressDots({
+  current,
+  total,
+  onDark,
+}: {
+  current: number;
+  total: number;
+  onDark?: boolean;
+}) {
   const TT = useThemeT();
+  const activeColor = onDark ? '#ffffff' : TT.tint;
+  const doneColor = onDark ? 'rgba(255,255,255,0.7)' : TT.tint;
+  const inactiveColor = onDark
+    ? 'rgba(255,255,255,0.28)'
+    : TT.isDark
+      ? 'rgba(255,255,255,0.22)'
+      : 'rgba(37,56,131,0.18)';
   return (
-    <View style={dotsStyles.row}>
+    <View
+      style={dotsStyles.row}
+      accessibilityRole="progressbar"
+      accessibilityValue={{ min: 1, max: total, now: current + 1 }}
+    >
       {Array.from({ length: total }, (_, i) => {
         const active = i === current;
+        const done = i < current;
         return (
           <View
             key={i}
@@ -132,7 +161,11 @@ function ProgressDots({ current, total }: { current: number; total: number }) {
               dotsStyles.dot,
               {
                 width: active ? 22 : 6,
-                backgroundColor: active ? TT.primary : 'rgba(37,56,131,0.18)',
+                backgroundColor: active
+                  ? activeColor
+                  : done
+                    ? doneColor
+                    : inactiveColor,
               },
             ]}
           />
@@ -171,8 +204,11 @@ function PrimaryButton({
   shimmer?: boolean;
   textColor?: string;
 }) {
-  const bg = disabled ? 'rgba(37,56,131,0.13)' : color || T.primary;
-  const fg = disabled ? 'rgba(37,56,131,0.35)' : textColor || '#fff';
+  const { isDark } = useThemeT();
+  const disabledBg = isDark ? 'rgba(255,255,255,0.10)' : 'rgba(37,56,131,0.13)';
+  const disabledFg = isDark ? 'rgba(255,255,255,0.32)' : 'rgba(37,56,131,0.35)';
+  const bg = disabled ? disabledBg : color || T.primary;
+  const fg = disabled ? disabledFg : textColor || '#fff';
 
   const scale = useSharedValue(1);
   const aStyle = useAnimatedStyle(() => ({
@@ -278,11 +314,19 @@ function SkipButton({ onPress }: { onPress: () => void }) {
       accessibilityLabel="Saltar configuración"
       style={({ pressed }) => [
         skipBtnStyles.pill,
+        {
+          borderColor: TT.isDark
+            ? 'rgba(149,210,242,0.30)'
+            : 'rgba(37,56,131,0.28)',
+          backgroundColor: TT.isDark
+            ? 'rgba(149,210,242,0.10)'
+            : 'rgba(37,56,131,0.06)',
+        },
         pressed && { opacity: 0.65 },
       ]}
     >
-      <Text style={[skipBtnStyles.text, { color: TT.primary }]}>Saltar</Text>
-      <MaterialIcons name="arrow-forward" size={13} color={TT.primary} />
+      <Text style={[skipBtnStyles.text, { color: TT.tint }]}>Saltar</Text>
+      <MaterialIcons name="arrow-forward" size={13} color={TT.tint} />
     </Pressable>
   );
 }
@@ -612,6 +656,7 @@ function ProfileScreen({
   onSkip,
   animDir,
   applySafeArea,
+  totalSteps,
 }: {
   profiles: { id: OnboardingProfileId; label: string; description: string }[];
   selected: OnboardingProfileId | null;
@@ -620,6 +665,7 @@ function ProfileScreen({
   onSkip: () => void;
   animDir: 'forward' | 'back';
   applySafeArea: boolean;
+  totalSteps: number;
 }) {
   const TT = useThemeT();
   const insets = useSafeAreaInsets();
@@ -640,12 +686,12 @@ function ProfileScreen({
       </View>
 
       <View style={stepStyles.dotsWrap}>
-        <ProgressDots current={0} total={2} />
+        <ProgressDots current={0} total={totalSteps} />
       </View>
 
       <Animated.View entering={FadeInUp.duration(420)} style={stepStyles.hero}>
-        <View style={stepStyles.heroIcon}>
-          <MaterialIcons name="person-search" size={28} color={TT.primary} />
+        <View style={[stepStyles.heroIcon, { backgroundColor: TT.iconBg }]}>
+          <MaterialIcons name="person-search" size={28} color={TT.tint} />
         </View>
         <Text style={[stepStyles.heroTitle, { color: TT.text }]}>
           ¿Quién eres?
@@ -675,26 +721,32 @@ function ProfileScreen({
                   cardStyles.card,
                   { backgroundColor: TT.card, borderColor: TT.border },
                   sel && cardStyles.cardSelected,
+                  sel && {
+                    borderColor: TT.tint,
+                    backgroundColor: TT.selectedBg,
+                  },
                   pressed && { transform: [{ scale: 0.97 }] },
                 ]}
               >
                 <View
                   style={[
                     cardStyles.iconCircle,
+                    { backgroundColor: TT.iconBg },
                     sel && cardStyles.iconCircleSelected,
+                    sel && { backgroundColor: TT.tint },
                   ]}
                 >
                   <MaterialIcons
                     name={PROFILE_ICONS[p.id]}
                     size={24}
-                    color={sel ? '#fff' : TT.primary}
+                    color={sel ? (TT.isDark ? '#1C1C1E' : '#fff') : TT.tint}
                   />
                 </View>
                 <View style={{ flex: 1 }}>
                   <Text
                     style={[
                       cardStyles.cardTitle,
-                      { color: sel ? TT.primary : TT.text },
+                      { color: sel ? TT.tint : TT.text },
                     ]}
                   >
                     {p.label}
@@ -710,7 +762,7 @@ function ProfileScreen({
                   <MaterialIcons
                     name="check-circle"
                     size={22}
-                    color={TT.primary}
+                    color={TT.tint}
                   />
                 )}
               </Pressable>
@@ -747,6 +799,9 @@ function DelegationScreen({
   onBack,
   onSkip,
   applySafeArea,
+  stepIndex,
+  totalSteps,
+  finishLabel,
 }: {
   delegations: { id: string; label: string; description?: string }[];
   selected: string | null;
@@ -755,6 +810,9 @@ function DelegationScreen({
   onBack: () => void;
   onSkip: () => void;
   applySafeArea: boolean;
+  stepIndex: number;
+  totalSteps: number;
+  finishLabel: string;
 }) {
   const TT = useThemeT();
   const insets = useSafeAreaInsets();
@@ -772,21 +830,19 @@ function DelegationScreen({
       <StatusBar style={TT.isDark ? 'light' : 'dark'} animated />
       <View style={[stepStyles.topBar, { paddingTop: topPad }]}>
         <Pressable onPress={onBack} hitSlop={12} style={stepStyles.backBtn}>
-          <MaterialIcons name="arrow-back-ios" size={16} color={TT.primary} />
-          <Text style={[stepStyles.backLabel, { color: TT.primary }]}>
-            Atrás
-          </Text>
+          <MaterialIcons name="arrow-back-ios" size={16} color={TT.tint} />
+          <Text style={[stepStyles.backLabel, { color: TT.tint }]}>Atrás</Text>
         </Pressable>
         <SkipButton onPress={onSkip} />
       </View>
 
       <View style={stepStyles.dotsWrap}>
-        <ProgressDots current={1} total={2} />
+        <ProgressDots current={stepIndex} total={totalSteps} />
       </View>
 
       <Animated.View entering={FadeInUp.duration(420)} style={stepStyles.hero}>
-        <View style={stepStyles.heroIcon}>
-          <MaterialIcons name="location-on" size={28} color={TT.primary} />
+        <View style={[stepStyles.heroIcon, { backgroundColor: TT.iconBg }]}>
+          <MaterialIcons name="location-on" size={28} color={TT.tint} />
         </View>
         <Text style={[stepStyles.heroTitle, { color: TT.text }]}>
           ¿De qué delegación?
@@ -816,6 +872,10 @@ function DelegationScreen({
                   delegStyles.row,
                   { borderColor: TT.border, backgroundColor: TT.card },
                   sel && delegStyles.rowSelected,
+                  sel && {
+                    borderColor: TT.tint,
+                    backgroundColor: TT.selectedBg,
+                  },
                   pressed && { transform: [{ scale: 0.98 }] },
                 ]}
               >
@@ -824,7 +884,7 @@ function DelegationScreen({
                     style={[
                       delegStyles.label,
                       {
-                        color: sel ? TT.primary : TT.text,
+                        color: sel ? TT.tint : TT.text,
                         fontWeight: sel ? '700' : '500',
                       },
                     ]}
@@ -844,7 +904,7 @@ function DelegationScreen({
                   <MaterialIcons
                     name="check-circle"
                     size={20}
-                    color={TT.primary}
+                    color={TT.tint}
                   />
                 )}
               </Pressable>
@@ -860,7 +920,7 @@ function DelegationScreen({
         ]}
       >
         <PrimaryButton
-          label="¡Empezar!"
+          label={finishLabel}
           onPress={onFinish}
           disabled={!selected}
           color={TT.accent}
@@ -961,21 +1021,31 @@ function SuccessScreen({
           style={successStyles.pills}
         >
           {profile && (
-            <View style={successStyles.pill}>
+            <View
+              style={[
+                successStyles.pill,
+                { backgroundColor: TT.chipBg, borderColor: TT.chipBorder },
+              ]}
+            >
               <MaterialIcons
                 name={PROFILE_ICONS[profile.id]}
                 size={20}
-                color={TT.primary}
+                color={TT.tint}
               />
-              <Text style={[successStyles.pillText, { color: TT.primary }]}>
+              <Text style={[successStyles.pillText, { color: TT.tint }]}>
                 {profile.label}
               </Text>
             </View>
           )}
           {delegation && (
-            <View style={successStyles.pill}>
-              <MaterialIcons name="location-on" size={20} color={TT.primary} />
-              <Text style={[successStyles.pillText, { color: TT.primary }]}>
+            <View
+              style={[
+                successStyles.pill,
+                { backgroundColor: TT.chipBg, borderColor: TT.chipBorder },
+              ]}
+            >
+              <MaterialIcons name="location-on" size={20} color={TT.tint} />
+              <Text style={[successStyles.pillText, { color: TT.tint }]}>
                 {delegation.label}
               </Text>
             </View>
@@ -1224,18 +1294,29 @@ const delegStyles = StyleSheet.create({
 ─────────────────────────────────────── */
 
 function LoginOnboardingScreen({
-  onContinue,
+  onFinish,
+  onSkip,
   onBack,
   animDir,
+  profile,
+  delegation,
+  stepIndex,
+  totalSteps,
 }: {
-  onContinue: () => void;
+  onFinish: () => void;
+  onSkip: () => void;
   onBack: () => void;
   animDir: 'forward' | 'back';
+  profile: { id: OnboardingProfileId; label: string } | null;
+  delegation: { id: string; label: string } | null;
+  stepIndex: number;
+  totalSteps: number;
 }) {
   const Entering = animDir === 'back' ? SlideInLeft : SlideInRight;
   const { width: screenW } = useWindowDimensions();
   const isWide = screenW >= 640;
   const { user } = useAuth();
+  const insets = useSafeAreaInsets();
 
   return (
     <Animated.View
@@ -1283,7 +1364,7 @@ function LoginOnboardingScreen({
       {/* Back button */}
       <Pressable
         onPress={onBack}
-        style={loginOnbStyles.backBtn}
+        style={[loginOnbStyles.backBtn, { top: insets.top + 4 }]}
         accessibilityRole="button"
         accessibilityLabel="Volver"
       >
@@ -1294,7 +1375,13 @@ function LoginOnboardingScreen({
         />
       </Pressable>
 
-      {/* Content */}
+      {/* Step indicator */}
+      <View style={[loginOnbStyles.dotsTop, { top: insets.top + 14 }]}>
+        <ProgressDots current={stepIndex} total={totalSteps} onDark />
+      </View>
+
+      {/* Content — al iniciar sesión esta pantalla pasa a ser el resumen
+          final del onboarding, con el CTA centrado verticalmente. */}
       <View
         style={[loginOnbStyles.center, isWide && { paddingHorizontal: 48 }]}
       >
@@ -1316,43 +1403,76 @@ function LoginOnboardingScreen({
           entering={FadeInUp.delay(120).duration(400)}
           style={loginOnbStyles.title}
         >
-          Guarda tu progreso
+          {user ? '¡Todo listo!' : 'Guarda tu progreso'}
         </Animated.Text>
 
         <Animated.Text
           entering={FadeInUp.delay(180).duration(400)}
           style={loginOnbStyles.body}
         >
-          Sincroniza tus hábitos de oración, evangelios guardados y reflexiones
-          entre todos tus dispositivos.
+          {user
+            ? 'Tu sesión está activa y tu progreso se sincronizará entre dispositivos. ¡A disfrutar de tu comunidad!'
+            : 'Sincroniza tus hábitos de oración, evangelios guardados y reflexiones entre todos tus dispositivos.'}
         </Animated.Text>
 
-        {/* Login buttons */}
+        {/* Login buttons / authenticated card */}
         <Animated.View
           entering={FadeInUp.delay(240).duration(400)}
           style={loginOnbStyles.buttonsWrap}
         >
           <SocialLoginSection onDarkBackground />
         </Animated.View>
+
+        {/* Resumen + CTA cuando hay sesión (centrado verticalmente) */}
+        {user && (
+          <Animated.View
+            entering={FadeInUp.delay(300).duration(400)}
+            style={loginOnbStyles.summaryWrap}
+          >
+            {(profile || delegation) && (
+              <View style={loginOnbStyles.summaryPills}>
+                {profile && (
+                  <View style={loginOnbStyles.summaryPill}>
+                    <MaterialIcons
+                      name={PROFILE_ICONS[profile.id]}
+                      size={16}
+                      color="#fff"
+                    />
+                    <Text style={loginOnbStyles.summaryPillText}>
+                      {profile.label}
+                    </Text>
+                  </View>
+                )}
+                {delegation && (
+                  <View style={loginOnbStyles.summaryPill}>
+                    <MaterialIcons name="location-on" size={16} color="#fff" />
+                    <Text style={loginOnbStyles.summaryPillText}>
+                      {delegation.label}
+                    </Text>
+                  </View>
+                )}
+              </View>
+            )}
+            <PrimaryButton
+              label="Ir a la app"
+              onPress={onFinish}
+              color="#ffffff"
+              textColor={T.primary}
+              shimmer
+            />
+          </Animated.View>
+        )}
       </View>
 
-      {/* CTA: si ya hay sesión, botón grande para continuar; si no, enlace
-          pequeño para seguir sin cuenta. */}
-      <Animated.View
-        entering={FadeInUp.delay(320).duration(380)}
-        style={user ? loginOnbStyles.continueWrap : loginOnbStyles.skipWrap}
-      >
-        {user ? (
-          <PrimaryButton
-            label="Continuar"
-            onPress={onContinue}
-            color="#ffffff"
-            textColor={T.primary}
-            shimmer
-          />
-        ) : (
+      {/* Cuando NO hay sesión, enlace inferior para continuar sin cuenta
+          (lleva al resumen final). */}
+      {!user && (
+        <Animated.View
+          entering={FadeInUp.delay(320).duration(380)}
+          style={loginOnbStyles.skipWrap}
+        >
           <Pressable
-            onPress={onContinue}
+            onPress={onSkip}
             hitSlop={10}
             accessibilityRole="button"
             accessibilityLabel="Continuar sin cuenta"
@@ -1360,8 +1480,8 @@ function LoginOnboardingScreen({
           >
             <Text style={loginOnbStyles.skipText}>Continuar sin cuenta →</Text>
           </Pressable>
-        )}
-      </Animated.View>
+        </Animated.View>
+      )}
     </Animated.View>
   );
 }
@@ -1423,13 +1543,44 @@ const loginOnbStyles = StyleSheet.create({
     width: '100%',
     maxWidth: 320,
   } as ViewStyle,
+  dotsTop: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 5,
+  } as ViewStyle,
+  summaryWrap: {
+    width: '100%',
+    maxWidth: 320,
+    marginTop: 24,
+    gap: 16,
+  } as ViewStyle,
+  summaryPills: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+  } as ViewStyle,
+  summaryPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.14)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.24)',
+  } as ViewStyle,
+  summaryPillText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '600',
+  } as TextStyle,
   skipWrap: {
     paddingBottom: Platform.OS === 'ios' ? 32 : 24,
     alignItems: 'center',
-  } as ViewStyle,
-  continueWrap: {
-    paddingHorizontal: 24,
-    paddingBottom: Platform.OS === 'ios' ? 32 : 24,
   } as ViewStyle,
   skipText: {
     color: 'rgba(255,255,255,0.55)',
@@ -1546,6 +1697,25 @@ export default function OnboardingScreen() {
     }
   };
 
+  // Al iniciar sesión, la pantalla de login pasa a ser el resumen final: el
+  // botón "Ir a la app" cierra el onboarding directamente (sin pantalla
+  // `success` extra).
+  const handleLoginFinish = () => {
+    const resolved = resolveOnboardingValues(profileType, delegationId);
+    persistAndExit({
+      profileType: resolved.profileType,
+      delegationId: resolved.delegationId,
+      onboardingCompleted: true,
+    });
+  };
+
+  // Indicador de pasos: el total depende del perfil elegido (otros → 1,
+  // familia → 2, monitor/miembro → 3). Bienvenida y resumen no cuentan.
+  const needsDelegation = profileType !== OTROS_PROFILE_ID;
+  const totalSteps =
+    1 + (needsDelegation ? 1 : 0) + (needsLoginStep(profileType) ? 1 : 0);
+  const loginStepIndex = needsDelegation ? 2 : 1;
+
   const profile = useMemo(() => {
     if (!profileType) return null;
     if (profileType === OTROS_PROFILE_ID) {
@@ -1613,6 +1783,7 @@ export default function OnboardingScreen() {
             onContinue={handleProfileContinue}
             onSkip={handleSkip}
             applySafeArea={applySafeArea}
+            totalSteps={totalSteps}
           />
         )}
         {step === 'delegation' && (
@@ -1624,13 +1795,23 @@ export default function OnboardingScreen() {
             onBack={() => go('profile', 'back')}
             onSkip={handleSkip}
             applySafeArea={applySafeArea}
+            stepIndex={1}
+            totalSteps={totalSteps}
+            finishLabel={
+              needsLoginStep(profileType) ? 'Continuar' : '¡Empezar!'
+            }
           />
         )}
         {step === 'login' && (
           <LoginOnboardingScreen
-            onContinue={() => go('success')}
+            onFinish={handleLoginFinish}
+            onSkip={() => go('success')}
             onBack={() => go('delegation', 'back')}
             animDir={animDir}
+            profile={profile}
+            delegation={delegation}
+            stepIndex={loginStepIndex}
+            totalSteps={totalSteps}
           />
         )}
         {step === 'success' && (

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -1,11 +1,18 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { View, StyleSheet, ScrollView, Platform, Text } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  Platform,
+  Text,
+  Pressable,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Card,
   Switch,
   Chip,
-  Button,
   Spinner,
   BottomSheet,
   PressableFeedback,
@@ -265,16 +272,29 @@ export default function ReflexionesScreen() {
         <BottomSheet.Portal>
           <BottomSheet.Overlay />
           <BottomSheet.Content>
-            <BottomSheet.Title className="mb-2">
-              Compartir reflexión
-            </BottomSheet.Title>
-            <ScrollView>
+            <View style={styles.sheetHeader}>
+              <View style={styles.sheetIcon}>
+                <MaterialIcons
+                  name="auto-stories"
+                  size={20}
+                  color={colors.success}
+                />
+              </View>
+              <View style={{ flex: 1 }}>
+                <BottomSheet.Title>Compartir reflexión</BottomSheet.Title>
+                <Text style={styles.sheetSubtitle}>
+                  Tu experiencia puede iluminar a otros
+                </Text>
+              </View>
+            </View>
+            <ScrollView showsVerticalScrollIndicator={false}>
               <View style={styles.inputWrapper}>
                 <Text style={styles.inputLabel}>Título (opcional)</Text>
                 <TextField>
                   <Input
                     value={titulo}
                     onChangeText={setTitulo}
+                    placeholder="Un título breve"
                     style={styles.input}
                   />
                 </TextField>
@@ -285,8 +305,12 @@ export default function ReflexionesScreen() {
                   <TextArea
                     value={contenido}
                     onChangeText={setContenido}
-                    numberOfLines={4}
-                    style={[styles.input, { minHeight: 100 }]}
+                    numberOfLines={5}
+                    placeholder="Escribe aquí tu reflexión"
+                    style={[
+                      styles.input,
+                      { minHeight: 120, textAlignVertical: 'top' },
+                    ]}
                   />
                 </TextField>
               </View>
@@ -295,21 +319,32 @@ export default function ReflexionesScreen() {
                 style={styles.dateField}
               >
                 <PressableFeedback.Highlight />
-                <Text style={styles.inputLabel}>Fecha</Text>
+                <MaterialIcons name="event" size={20} color={colors.success} />
+                <Text style={styles.dateFieldLabel}>Fecha</Text>
                 <Text style={styles.dateValue}>{formatFecha(fecha)}</Text>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={20}
+                  color={theme.icon}
+                />
               </PressableFeedback>
               <View style={styles.row}>
+                <MaterialIcons
+                  name="groups"
+                  size={20}
+                  color={grupal ? colors.success : theme.icon}
+                />
+                <Text style={styles.switchLabel}>Compartir en grupo</Text>
                 <Switch
                   isSelected={grupal}
                   onSelectedChange={(v) => setGrupal(v)}
                 />
-                <Text style={styles.switchLabel}>Compartiendo en grupo</Text>
               </View>
               {grupal ? (
                 <ScrollView
                   horizontal
                   showsHorizontalScrollIndicator={false}
-                  style={{ marginBottom: 12 }}
+                  style={{ marginBottom: spacing.md }}
                 >
                   <View
                     style={{ flexDirection: 'row', gap: 8, paddingVertical: 4 }}
@@ -338,13 +373,18 @@ export default function ReflexionesScreen() {
                   </TextField>
                 </View>
               )}
-              <Button
-                variant="primary"
+              <Pressable
                 onPress={addReflexion}
-                className="mt-4 mb-6"
+                accessibilityRole="button"
+                accessibilityLabel="Guardar reflexión"
+                style={({ pressed }) => [
+                  styles.saveBtn,
+                  pressed && { opacity: 0.85 },
+                ]}
               >
-                <Button.Label>Guardar reflexión</Button.Label>
-              </Button>
+                <MaterialIcons name="send" size={18} color="#fff" />
+                <Text style={styles.saveBtnLabel}>Compartir</Text>
+              </Pressable>
             </ScrollView>
           </BottomSheet.Content>
         </BottomSheet.Portal>
@@ -403,38 +443,87 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       justifyContent: 'center',
       alignItems: 'center',
     },
+    sheetHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
+      marginBottom: spacing.md,
+    },
+    sheetIcon: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor:
+        scheme === 'dark' ? 'rgba(163,189,49,0.18)' : 'rgba(163,189,49,0.12)',
+    },
+    sheetSubtitle: {
+      fontSize: 13,
+      color: theme.icon,
+      marginTop: 2,
+    },
     inputWrapper: { marginBottom: spacing.md },
     inputLabel: {
       fontSize: 12,
       color: colors.success,
-      fontWeight: '600',
-      marginBottom: 4,
+      fontWeight: '700',
+      letterSpacing: 0.2,
+      marginBottom: 6,
     },
     input: {
       borderWidth: 1,
-      borderColor: scheme === 'dark' ? '#555' : '#ccc',
-      borderRadius: 8,
-      paddingHorizontal: 12,
-      paddingVertical: 10,
+      borderColor: scheme === 'dark' ? '#48484A' : '#D8DCC8',
+      borderRadius: 12,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
       fontSize: 16,
       color: theme.text,
       backgroundColor: scheme === 'dark' ? '#2C2C2E' : '#fff',
     },
     dateField: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
       marginBottom: spacing.md,
       borderWidth: 1,
-      borderColor: scheme === 'dark' ? '#555' : '#ccc',
-      borderRadius: 8,
-      paddingHorizontal: 12,
-      paddingVertical: 10,
+      borderColor: scheme === 'dark' ? '#48484A' : '#D8DCC8',
+      borderRadius: 12,
+      paddingHorizontal: 14,
+      paddingVertical: 13,
     },
-    dateValue: { fontSize: 16, color: theme.text },
+    dateFieldLabel: {
+      flex: 1,
+      fontSize: 15,
+      fontWeight: '500',
+      color: theme.text,
+    },
+    dateValue: { fontSize: 15, fontWeight: '600', color: colors.success },
     row: {
       flexDirection: 'row',
       alignItems: 'center',
+      gap: spacing.sm,
       marginBottom: spacing.md,
+      paddingVertical: 4,
     },
-    switchLabel: { marginLeft: spacing.sm, color: theme.text },
+    switchLabel: { flex: 1, fontSize: 15, color: theme.text },
+    saveBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      backgroundColor: colors.success,
+      borderRadius: 14,
+      paddingVertical: 15,
+      marginTop: spacing.md,
+      marginBottom: spacing.lg,
+    },
+    saveBtnLabel: {
+      color: '#fff',
+      fontSize: 16,
+      fontWeight: '700',
+      letterSpacing: 0.2,
+    },
     savingModal: {
       backgroundColor: theme.background,
       padding: spacing.lg,

--- a/mcm-app/app/screens/eventStackScreens.tsx
+++ b/mcm-app/app/screens/eventStackScreens.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { View, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { MaterialIcons } from '@expo/vector-icons';
-import { PressableFeedback } from 'heroui-native';
 
 import GlassHeader from '@/components/ui/GlassHeader.ios';
 import { getEvent } from '@/constants/events';
@@ -37,6 +35,26 @@ import WordleScreen from './WordleScreen';
  * qué colores usar en el header. Si no se pasa, se usa el evento por defecto.
  */
 export type EventRouteParams = { eventId?: string };
+
+/**
+ * Rutas de sub-pantalla de evento (todo menos el hub `JubileoHome`). Los tabs
+ * de evento usan esta lista para decidir cuándo mostrar los FAB glass de
+ * acción (`EventActionButtons`) por encima del navigator.
+ */
+export const EVENT_SUB_ROUTES = [
+  'Horario',
+  'Materiales',
+  'MaterialPages',
+  'Visitas',
+  'Profundiza',
+  'Grupos',
+  'Contactos',
+  'Apps',
+  'Reflexiones',
+  'Comida',
+  'ComidaWeb',
+  'Wordle',
+] as const;
 
 /** Pantallas comunes a cualquier evento. */
 export type EventStackParamList = {
@@ -97,13 +115,18 @@ export const getTextColor = (_tintColor?: string) => {
  * reusar todas las sub-pantallas para eventos nuevos sin duplicar registros.
  */
 export const eventScreenOptions =
-  (title: string) =>
+  (title: string, opts?: { hideHeaderTitle?: boolean }) =>
   ({ route }: { route: EventScreenRoute }) => {
     const event = getEvent(route.params?.eventId);
     const tint = event.tintColor;
     const textColor = getTextColor(tint);
     return {
       title,
+      // Las pantallas que ya muestran un título grande dentro del contenido
+      // (ScreenHero) ocultan el del header para no duplicarlo. Queda solo la
+      // barra glass + la flecha de volver; las acciones viven en los FAB glass
+      // flotantes (ver EventActionButtons).
+      ...(opts?.hideHeaderTitle ? { headerTitle: () => null } : {}),
       headerStyle: getHeaderStyle(tint),
       headerTintColor: textColor,
       // Quita la sombra pesada bajo la barra de color (coherente con el
@@ -134,66 +157,24 @@ export const eventHubScreenOptions = ({
 };
 
 /**
- * Botones del header derecho en las sub-pantallas de evento (ajustes +
- * reflexiones). No se muestran en el hub ni en pantallas no-evento.
- */
-export function eventHeaderRight({
-  navigation,
-  route,
-  onSettings,
-}: {
-  navigation: any;
-  route: { name: string; params?: { eventId?: string } };
-  onSettings: () => void;
-}) {
-  const isEventScreen =
-    route.name !== 'MasHome' &&
-    route.name !== 'JubileoHome' &&
-    route.name !== 'Fotos';
-  if (!isEventScreen) return null;
-
-  const eventId = route.params?.eventId;
-  const iconColor = getTextColor(getEvent(eventId).tintColor);
-
-  return (
-    <View
-      style={{ flexDirection: 'row', alignItems: 'center', marginRight: 8 }}
-    >
-      <PressableFeedback onPress={onSettings} style={{ padding: 10 }}>
-        <PressableFeedback.Highlight />
-        <MaterialIcons name="settings" size={26} color={iconColor} />
-      </PressableFeedback>
-      {route.name !== 'Reflexiones' && (
-        <PressableFeedback
-          onPress={() => navigation.navigate('Reflexiones', { eventId })}
-          style={{ padding: 10 }}
-        >
-          <PressableFeedback.Highlight />
-          <MaterialIcons name="forum" size={26} color={iconColor} />
-        </PressableFeedback>
-      )}
-    </View>
-  );
-}
-
-/**
  * Builder del `screenOptions` del Stack.Navigator de un evento. Replica el
  * header gris por defecto (que cada pantalla sobreescribe con su tint vía
- * `eventScreenOptions`) y los botones settings/reflexiones.
+ * `eventScreenOptions`).
  *
- * @param onSettings   abre el bottom sheet de ajustes del tab.
+ * Las acciones de evento (ajustes + Compartiendo) ya no viven en el header:
+ * se muestran como FAB glass flotantes (`EventActionButtons`) que el tab
+ * renderiza por encima del navigator.
+ *
  * @param onNavReady   recibe el `navigation` del stack activo (para popToTop).
  */
 export function eventStackScreenOptions({
-  onSettings,
   webStatusBarHeight,
   onNavReady,
 }: {
-  onSettings: () => void;
   webStatusBarHeight?: number;
   onNavReady?: (navigation: any) => void;
 }) {
-  return ({ navigation, route }: { navigation: any; route: any }) => {
+  return ({ navigation }: { navigation: any; route: any }) => {
     onNavReady?.(navigation);
     return {
       freezeOnBlur: true,
@@ -222,7 +203,6 @@ export function eventStackScreenOptions({
       headerTransparent: false,
       headerBackground: () =>
         Platform.OS === 'ios' ? <GlassHeader tintColor="#78909C" /> : undefined,
-      headerRight: () => eventHeaderRight({ navigation, route, onSettings }),
     };
   };
 }
@@ -252,12 +232,12 @@ export function renderEventScreens(
       <Stack.Screen
         name="Horario"
         component={HorarioScreen}
-        options={eventScreenOptions('Horario')}
+        options={eventScreenOptions('Horario', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Materiales"
         component={MaterialesScreen}
-        options={eventScreenOptions('Materiales')}
+        options={eventScreenOptions('Materiales', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="MaterialPages"
@@ -267,27 +247,27 @@ export function renderEventScreens(
       <Stack.Screen
         name="Visitas"
         component={VisitasScreen}
-        options={eventScreenOptions('Visitas')}
+        options={eventScreenOptions('Visitas', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Profundiza"
         component={ProfundizaScreen}
-        options={eventScreenOptions('Profundiza')}
+        options={eventScreenOptions('Profundiza', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Grupos"
         component={GruposScreen}
-        options={eventScreenOptions('Grupos')}
+        options={eventScreenOptions('Grupos', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Contactos"
         component={ContactosScreen}
-        options={eventScreenOptions('Contactos')}
+        options={eventScreenOptions('Contactos', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Apps"
         component={AppsScreen}
-        options={eventScreenOptions('Apps')}
+        options={eventScreenOptions('Apps', { hideHeaderTitle: true })}
       />
       <Stack.Screen
         name="Reflexiones"

--- a/mcm-app/components/EventActionButtons.tsx
+++ b/mcm-app/components/EventActionButtons.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import GlassFAB from '@/components/ui/GlassFAB';
+
+interface Props {
+  /** Abre el bottom sheet de ajustes del tab. */
+  onSettings: () => void;
+  /** Navega a la sección "Compartiendo" (reflexiones). */
+  onCompartiendo: () => void;
+  /**
+   * Oculta el FAB de Compartiendo (p.ej. cuando ya estamos en esa pantalla).
+   * El de Ajustes se mantiene siempre.
+   */
+  showCompartiendo?: boolean;
+}
+
+/**
+ * Acciones de evento como FAB glass flotantes (abajo a la derecha), en lugar
+ * de botones en el header. Se renderiza por encima del Stack.Navigator del
+ * evento (ver `app/(tabs)/visitapapa.tsx` y `app/(tabs)/mas.tsx`).
+ *
+ * Layout: el FAB de Compartiendo ocupa el hueco inferior (bottom 90) y el de
+ * Ajustes el superior (bottom 158) para no solaparse entre sí ni con el FAB
+ * propio de la pantalla de Compartiendo.
+ */
+export default function EventActionButtons({
+  onSettings,
+  onCompartiendo,
+  showCompartiendo = true,
+}: Props) {
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      {showCompartiendo && (
+        <GlassFAB
+          icon="forum"
+          onPress={onCompartiendo}
+          tintColor="#A3BD31"
+          iconColor="#fff"
+          style={{ bottom: 90 }}
+        />
+      )}
+      <GlassFAB
+        icon="settings"
+        onPress={onSettings}
+        tintColor="#5B6573"
+        iconColor="#fff"
+        size={22}
+        style={{ bottom: 158 }}
+      />
+    </View>
+  );
+}

--- a/mcm-app/components/SocialLoginSection.tsx
+++ b/mcm-app/components/SocialLoginSection.tsx
@@ -276,8 +276,14 @@ export default function SocialLoginSection({
   const googleBg = onDarkBackground ? 'rgba(255,255,255,0.12)' : theme.card;
   const googleBorder = onDarkBackground
     ? 'rgba(255,255,255,0.22)'
-    : 'rgba(0,0,0,0.10)';
-  const googleText = onDarkBackground ? '#fff' : '#3C4043';
+    : scheme === 'dark'
+      ? 'rgba(255,255,255,0.16)'
+      : 'rgba(0,0,0,0.10)';
+  const googleText = onDarkBackground
+    ? '#fff'
+    : scheme === 'dark'
+      ? '#ECEDEE'
+      : '#3C4043';
 
   const brand = brandColors.primary;
   const hintBg = onDarkBackground
@@ -341,6 +347,9 @@ export default function SocialLoginSection({
           style={[
             styles.socialBtn,
             styles.appleBtn,
+            !onDarkBackground && scheme === 'dark'
+              ? { borderColor: 'rgba(255,255,255,0.18)' }
+              : null,
             ...(signingIn && signingIn !== 'apple' ? [styles.btnDisabled] : []),
           ]}
           onPress={handleAppleSignIn}


### PR DESCRIPTION
- Onboarding: el login pasa a ser la última pantalla y resumen para
  perfiles con login (botón continuar centrado), con indicador de pasos
  dinámico en perfil/delegación/login y modo oscuro corregido.
- Eventos: sub-pantallas con un solo título (oculta el del header donde
  hay ScreenHero) y acciones (ajustes/compartiendo) como FAB glass
  flotantes en vez de botones de header.
- Compartiendo: rediseño del bottom sheet de compartir reflexión.
- Login: arreglado el texto del botón de Google en modo oscuro.

https://claude.ai/code/session_01UpfoCkqMtrEarthfevTmyn