### PR TITLE
Update iOS icon for Visita Papa tab to building.columns

### DIFF
--- a/mcm-app/constants/tabsCatalog.ts
+++ b/mcm-app/constants/tabsCatalog.ts
@@ -69,7 +69,7 @@ export const TABS_CONFIG: TabConfig[] = [
     label: 'Visita Papa',
     subtitle: 'Visita del Papa León XIV 2026',
     emoji: '🕊️',
-    iosIcon: { default: 'church', selected: 'church' },
+    iosIcon: { default: 'building.columns', selected: 'building.columns.fill' },
     androidIcon: 'church',
     tintColor: TabHeaderColors.visitapapa,
     headerColor: TabHeaderColors.visitapapa,


### PR DESCRIPTION
## Summary
Updates the iOS icon configuration for the "Visita Papa" tab to use the native SF Symbol `building.columns` instead of the generic `church` icon, providing a more semantically appropriate and visually consistent representation.

## Changes
- **iOS icon**: Changed from `church` to `building.columns` (default state)
- **iOS icon selected**: Changed from `church` to `building.columns.fill` (selected state)
- Android icon remains unchanged (`church`)

## Details
This change improves the visual hierarchy and semantic accuracy of the tab icon on iOS by using Apple's native SF Symbols that better represent a papal/religious building context. The `.fill` variant is used for the selected state to provide clear visual feedback to users.

https://claude.ai/code/session_01S1TCCY5Xf2grJcBGrycQ4C