### PR TITLE
Notificaciones: alinear app con el contrato del MCM Panel

### DIFF
--- a/NOTIFICACIONES.md
+++ b/NOTIFICACIONES.md
@@ -254,16 +254,32 @@ El backend debe:
 ## Rutas internas disponibles para deep linking
 
 ```
-/(tabs)/index          Inicio
-/(tabs)/cancionero     Cantoral (activar feature flag primero)
-/(tabs)/calendario     Calendario
-/(tabs)/fotos          Galería de fotos
-/(tabs)/mas            Más opciones
-/notifications         Pantalla de notificaciones
-/wordle                Juego Wordle
+/(tabs)/index               Inicio
+/(tabs)/cancionero          Cantoral (según perfil)
+/(tabs)/calendario          Calendario
+/(tabs)/fotos               Galería de fotos (NO "albums")
+/(tabs)/mas                 Más opciones (hub de eventos: Jubileo, etc.)
+/(tabs)/contigo             Contigo (según perfil)
+/(tabs)/contigo/evangelio   Evangelio del día
+/(tabs)/contigo/oracion     Oración
+/(tabs)/contigo/revision    Revisión
+/(tabs)/contigo/bookmarks   Favoritos
+/(tabs)/visitapapa          Visita del Papa (según perfil)
+/notifications              Pantalla de notificaciones (raíz, NO bajo tabs)
+/wordle                     Juego Wordle (dormido, no usar)
 ```
 
-Nota: `/(tabs)/comunica` está desactivada actualmente.
+Notas:
+
+- `jubileo`, `actividades` y `albums` **NO** son rutas propias. Jubileo y las
+  actividades viven dentro de `/(tabs)/mas` (`EventHomeScreen`); la galería es
+  `/(tabs)/fotos`. La app aplica **alias automáticos** para estos casos — ver
+  `utils/notificationRoutes.ts`.
+- La visibilidad de algunas tabs depende del **perfil** (`/profileConfig`). Para
+  destinos universales usa `index`, `calendario`, `fotos` o `mas`.
+- **Contrato completo con el MCM Panel** (campos del payload, `/pushTokens`,
+  segmentación, correcciones): ver `NOTIFICACIONES_CONTRATO.md` en la raíz del
+  monorepo.
 
 ---
 

--- a/NOTIFICACIONES_CONTRATO.md
+++ b/NOTIFICACIONES_CONTRATO.md
@@ -1,0 +1,305 @@
+# Contrato de datos MCM Panel ↔ MCM App (revisado y alineado)
+
+> Este documento es la **respuesta de la MCM App** al contrato propuesto por el
+> MCM Panel. Recoge: (1) lo que la app procesa hoy de verdad, (2) las
+> correcciones que el Panel debe aplicar (campos/valores equivocados en el
+> contrato original), y (3) los cambios que ya se han hecho en la app para
+> tolerar el formato del Panel.
+>
+> Fecha: 2026-06-02 · App v2.0.0 · Fuente de verdad: código de `mcm-app/`.
+
+---
+
+## TL;DR — qué tiene que cambiar el Panel
+
+1. **Rutas (`internalRoute`)**: varias de las configuradas NO existen. Lista real
+   más abajo. La app ahora aplica alias, pero conviene corregir el Panel.
+   - `/(tabs)/actividades` ❌ → no existe (las actividades/eventos viven en `/(tabs)/mas`)
+   - `/(tabs)/jubileo` ❌ → no existe (Jubileo es un evento dentro de `/(tabs)/mas`)
+   - `/(tabs)/albums` ❌ → la galería es **`/(tabs)/fotos`**
+   - `/(tabs)/wordle` ❌ → es **`/wordle`** (ruta raíz, y además Wordle está dormido)
+2. **`/pushTokens`**: el contrato inventa `userType` y `delegacion` con valores
+   (`joven`/`responsable`/`"Castellón"`) que **no existen**. Los campos reales son
+   `profileType`, `delegationId` y, sobre todo, **`topics[]`** (la clave de
+   segmentación). Detalle y valores válidos abajo.
+3. **Botón de acción**: el contrato manda `data.actionButtons` (array). La app usa
+   `actionButton` (objeto con `isInternal`). La app ya **acepta ambos**, pero el
+   formato canónico recomendado es el objeto singular con `isInternal`.
+4. **`categoryId`**: la app solo registra categorías iOS `general`, `eventos`,
+   `fotos`. Mandar `evento`/`actividad`/`cantoral`/`jubileo`/`urgente` como
+   `categoryId` no aporta botones (se ignora). Conviene **desacoplar** `categoryId`
+   (solo iOS action buttons) de `data.category` (etiqueta de negocio).
+5. **Imagen en iOS**: **no hay Notification Service Extension**. `richContent.image`
+   + `mutableContent` NO pintan imagen en la notificación del sistema iOS. La imagen
+   solo se ve dentro de la app (modal de detalle) vía `data.imageUrl`. En Android sí
+   se ve. Mantener `data.imageUrl` siempre.
+
+---
+
+## 1. Recepción de notificaciones
+
+Listeners en `mcm-app/notifications/usePushNotifications.ts`:
+
+- `addNotificationReceivedListener` — app en **foreground**: guarda la notificación
+  en AsyncStorage y refresca el badge. El handler global
+  (`NotificationHandler.ts`) suprime el banner del sistema en foreground para evitar
+  duplicados; solo suena + actualiza el badge del icono.
+- `addNotificationResponseReceivedListener` — **tap** del usuario: resuelve la ruta,
+  navega con Expo Router y marca como leída.
+
+`data.id` es **crítico**: se usa como ID estable para deduplicar. Si no llega, la
+app genera un hash de `título|cuerpo` (peor dedup). **Manténganlo siempre.**
+
+## 2. Navegación (`internalRoute`)
+
+Sí, se lee `data.internalRoute` y se navega con `router.navigate(...)`. La app
+**normaliza** la ruta antes de navegar (`utils/notificationRoutes.ts`), tolerando
+rutas desnudas (`cancionero`), el grupo `(tabs)` y un **mapa de alias** para las
+rutas heredadas del Panel.
+
+### (a) Lista DEFINITIVA de rutas válidas
+
+| `internalRoute`                 | Destino                  |
+| ------------------------------- | ------------------------ |
+| `/(tabs)/index`                 | Inicio (Home)            |
+| `/(tabs)/cancionero`            | Cantoral                 |
+| `/(tabs)/calendario`            | Calendario               |
+| `/(tabs)/fotos`                 | Fotos / álbumes          |
+| `/(tabs)/mas`                   | Más (hub de eventos)     |
+| `/(tabs)/contigo`               | Contigo (si el perfil lo tiene) |
+| `/(tabs)/contigo/evangelio`     | Evangelio del día        |
+| `/(tabs)/contigo/oracion`       | Oración                  |
+| `/(tabs)/contigo/revision`      | Revisión                 |
+| `/(tabs)/contigo/bookmarks`     | Favoritos                |
+| `/(tabs)/visitapapa`            | Visita del Papa (si activo) |
+| `/notifications`                | Centro de notificaciones |
+| `/wordle`                       | Wordle (dormido — no usar) |
+
+> Ojo: la visibilidad de tabs como `contigo`, `visitapapa` o `cancionero` depende
+> del **perfil** del usuario (`/profileConfig`). Si una notificación apunta a una tab
+> que ese perfil no tiene, la navegación puede no llevar a ningún sitio. Para algo
+> universal, usa `/(tabs)/index`, `/(tabs)/calendario`, `/(tabs)/fotos` o `/(tabs)/mas`.
+
+### Alias que la app traduce automáticamente (compatibilidad)
+
+| Lo que manda el Panel  | A dónde va realmente |
+| ---------------------- | -------------------- |
+| `/(tabs)/actividades`  | `/(tabs)/mas`        |
+| `/(tabs)/jubileo`      | `/(tabs)/mas`        |
+| `/(tabs)/albums`       | `/(tabs)/fotos`      |
+| `/(tabs)/wordle`       | `/wordle`            |
+| `/(tabs)/notifications`| `/notifications`     |
+
+### ¿"jubileo" sigue existiendo como ruta propia?
+
+No. Jubileo (y cualquier evento/actividad) **ya no es una tab**. Vive dentro del
+stack de **"Más"** (`app/screens/EventHomeScreen.tsx`), al que se llega navegando a
+`/(tabs)/mas` y seleccionando el evento (param `eventId`, p. ej. `jubileo`,
+`visitapapa26`). En Firebase los eventos están bajo `activities/<nombre>/` (y el
+legacy `jubileo/`).
+
+### Deep link a UNA actividad concreta
+
+**Hoy no hay** un deep link estable tipo `/(tabs)/mas/evento/<id>`. El destino
+navegable es `/(tabs)/mas`. Abrir directamente un evento por `id/slug` requeriría
+trabajo nuevo en la app (registrar una ruta con parámetro y propagar `eventId`).
+Si el Panel lo necesita, lo dejamos como mejora pendiente — ver §"Mejoras".
+
+## 3. Categorías / botones de acción
+
+### (b) Categorías iOS registradas (`setNotificationCategoryAsync`)
+
+`mcm-app/notifications/NotificationHandler.ts` (solo iOS):
+
+| `categoryId` | Botón (identifier → título) | Al pulsar navega a |
+| ------------ | --------------------------- | ------------------ |
+| `general`    | `view` → "Ver"              | `/notifications`   |
+| `eventos`    | `view_event` → "Ver Evento" | `/(tabs)/calendario` |
+| `fotos`      | `view_photos` → "Ver Fotos" | `/(tabs)/fotos`    |
+
+**Recomendación (mejora del Panel):** `categoryId` solo sirve para los **botones de
+acción del sistema iOS**. No lo igualéis a la categoría de negocio. Mandad:
+
+- `categoryId` ∈ `{ general, eventos, fotos }` **solo** cuando queráis esos botones
+  nativos. Cualquier otro id se ignora (sin error).
+- La categoría de negocio va en `data.category` (etiqueta, ver §6).
+
+> Nota: el contrato manda `evento` (singular); la categoría iOS registrada es
+> `eventos` (plural). Si queréis el botón "Ver Evento", usad `eventos`.
+
+### `actionButtons` vs `actionButton`
+
+La app trabaja con un **único** `actionButton`:
+
+```jsonc
+"data": {
+  "actionButton": {
+    "text": "Ver novedades",
+    "url": "https://mcmespana.com/x",   // o ruta interna: "/(tabs)/fotos"
+    "isInternal": false                  // true = navega dentro de la app
+  }
+}
+```
+
+La app **ya acepta también** `data.actionButtons: [{ text, url }]` (usa el primer
+elemento) e infiere `isInternal` (interno si la `url` no empieza por `http`). Aun así,
+**el formato canónico recomendado es el objeto singular con `isInternal` explícito.**
+
+`internalRoute` (sección asociada) y `actionButton` (CTA explícito) son
+complementarios — ver `NOTIFICACIONES.md` §"Arquitectura de botones y navegación".
+
+## 4. Imagen
+
+- **Android**: la imagen de `richContent.image` se muestra en la notificación del
+  sistema automáticamente. ✅
+- **iOS**: **NO** hay Notification Service Extension configurada. `mutableContent` +
+  `richContent.image` **no** adjuntan imagen a la notificación del sistema. La imagen
+  solo aparece **dentro de la app** (modal de detalle) leyendo **`data.imageUrl`**. ⚠️
+- **Acción**: enviad siempre `data.imageUrl` (es lo que usa la app). Añadir NSE en
+  iOS es una mejora futura (requiere build nativo, no OTA).
+
+## 5. Icono (`data.icon`)
+
+Se usa **solo dentro de la app**: la tarjeta del centro de notificaciones pinta
+`data.icon` como miniatura. iOS/Android no lo usan en la notificación del SO. Es
+opcional.
+
+## 6. Categoría de negocio (`data.category`)
+
+Se **guarda** en la notificación local, pero **hoy no dispara** color/icono/filtro/
+agrupación en la UI (es una etiqueta a futuro). No rechaza valores desconocidos.
+
+Vocabulario que entiende el tipo de la app (`types/notifications.ts`):
+`general`, `eventos`, `cancionero`, `fotos`, `urgente`, `mantenimiento`,
+`celebraciones`.
+
+> El contrato usaba `evento`/`actividad`/`jubileo`/`cantoral`. Para no divergir,
+> recomendamos converger al vocabulario de arriba (p. ej. `eventos` en vez de
+> `evento`, `cancionero` en vez de `cantoral`). Como es solo una etiqueta sin efecto
+> visual todavía, no es bloqueante. Colorear/iconizar por categoría queda como mejora.
+
+## 7. Registro de tokens (`/pushTokens`)
+
+### (d) Campos que la app guarda HOY por dispositivo
+
+`mcm-app/services/pushNotificationService.ts` → `buildTokenData`:
+
+```jsonc
+"/pushTokens/token_<tokenSaneado>": {
+  "token": "ExponentPushToken[...]",
+  "platform": "ios" | "android" | "web",
+  "registeredAt": "2026-06-02T10:00:00.000Z",
+  "lastActive":   "2026-06-02T10:05:00.000Z",  // heartbeat cada 5 min → activos 24h/7d
+  "appVersion": "2.0.0",
+  "deviceInfo": { "model": "...", "osVersion": "..." },
+  "profileType": "familia" | "monitor" | "miembro" | null,
+  "delegationId": "mcm-castellon" | ... | null,
+  "topics": ["general", "eventos", "familias", "mcm-castellon"]
+}
+```
+
+> La clave del nodo es el **propio token saneado** (`token_<...>`), no un deviceId
+> aleatorio. Así una reinstalación no deja tokens huérfanos.
+
+### Corrección al contrato (el Panel está equivocado aquí)
+
+| Contrato (incorrecto) | Real en la app | Notas |
+| --------------------- | -------------- | ----- |
+| `userType: "joven"\|"responsable"` | `profileType: "familia"\|"monitor"\|"miembro"\|null` | otros valores |
+| `delegacion: "Castellón"` | `delegationId: "mcm-castellon"` (slug) | es un **id**, no el nombre |
+| — | `topics: string[]` | **campo clave de segmentación** (no estaba en el contrato) |
+
+**Cómo segmentar (recomendado): usad `topics`.** Es un array **pre-computado** =
+union de los `notificationTopics` del perfil + el `notificationTopic` de la
+delegación. Segmentad con "el array `topics` contiene X". Ejemplos:
+
+- Todos → `general`
+- Solo monitores → `monitores`
+- Solo Castellón → `mcm-castellon`
+- Familias de Madrid → `familias` **y** `mcm-madrid`
+
+**Valores válidos de `profileType`:** `familia`, `monitor`, `miembro`.
+
+**Valores válidos de `delegationId`** (de `firebase-seed/profileConfig.json`):
+`mcm-espana`, `mcm-benicarlo-vinaros`, `mcm-burriana`, `mcm-caravaca`,
+`mcm-castellon`, `mcm-espinardo`, `mcm-granada`, `mcm-lalcora`, `mcm-madrid`,
+`mcm-nules`, `mcm-onda`, `mcm-quintanar`, `mcm-vila-real`, `mcm-villacanas`,
+`mcm-zaragoza`, `internacional`.
+
+**Topics conocidos** (`constants/profileCatalog.ts`): `general`, `eventos`,
+`familias`, `monitores`, `miembros`, `mcm-castellon`, `mcm-madrid` (las delegaciones
+añaden el suyo dinámicamente).
+
+> Dispositivos antiguos / sin onboarding tendrán `profileType: null`,
+> `delegationId: null`, `topics: []` (o `["general"]`). Si filtráis por topic y un
+> token no lo tiene, no le llega: para envíos masivos, segmentad por `general` o
+> tratad "sin topic" como "todos" según convenga.
+
+## 8. (c) Channels Android
+
+Solo uno, creado en runtime (`usePushNotifications.ts`):
+
+| `channelId` | Nombre              | Importancia |
+| ----------- | ------------------- | ----------- |
+| `default`   | "Notificaciones MCM" | `MAX` (heads-up) |
+
+El Panel puede (a futuro) mandar `channelId`, pero hoy solo existe `default`. Crear
+channels por prioridad/tipo (p. ej. `urgente`) es una mejora futura (ver §Mejoras).
+
+## 9. Prioridad
+
+La app **no** lee `priority` para configurar nada por notificación. En Android el
+"heads-up" lo decide la **importancia del channel** (`MAX`), así que **todas** salen
+como heads-up independientemente de `priority`. `priority` (top-level) sí lo usa Expo
+para la **velocidad de entrega** (FCM). Para diferenciar visualmente `high` vs
+`normal` haría falta channels separados (mejora futura).
+
+> Detalle menor: el tipo de la app usaba `high|normal|low`; Expo/top-level usa
+> `default|normal|high`. Mantened `default|normal|high` en el campo top-level.
+
+---
+
+## (e) Resumen: qué procesa la app y qué ignora
+
+| Campo del payload        | ¿Se procesa? | Cómo |
+| ------------------------ | ------------ | ---- |
+| `title` / `body`         | ✅ | Notificación + tarjeta |
+| `sound`                  | ✅ | Sonido (foreground y SO) |
+| `priority` (top-level)   | 🟡 | Solo entrega (FCM). Display fijo por channel MAX |
+| `categoryId`             | 🟡 | Solo iOS, ids `general`/`eventos`/`fotos`; resto ignorado |
+| `richContent.image`      | 🟡 | Android sí; **iOS no** (sin NSE) |
+| `mutableContent`         | 🟡 | iOS lo ignora en la práctica (sin NSE) |
+| `data.id`                | ✅ | **Crítico**: dedup / marca leído |
+| `data.internalRoute`     | ✅ | Navegación (con normalización + alias) |
+| `data.actionButton`      | ✅ | CTA en tarjeta + modal |
+| `data.actionButtons[]`   | ✅ | Aceptado (usa el primero) → mapeado a `actionButton` |
+| `data.imageUrl`          | ✅ | Imagen en el modal de detalle in-app |
+| `data.icon`              | ✅ | Miniatura en la tarjeta in-app |
+| `data.category`          | 🟡 | Se guarda; sin efecto visual todavía |
+| `data.priority`          | ❌ | No se usa (usad el top-level) |
+
+✅ procesa · 🟡 parcial/limitado · ❌ ignora
+
+---
+
+## Cambios ya aplicados en la app (esta entrega)
+
+- `utils/notificationRoutes.ts` (nuevo): `normalizeNotificationRoute()` con mapa de
+  **alias** para rutas heredadas del Panel, y `extractActionButton()` que acepta
+  `actionButton` (objeto) **y** `actionButtons` (array).
+- `notifications/usePushNotifications.ts`: usa ambos helpers; **fix** del action iOS
+  `view` que apuntaba a `/(tabs)/notifications` (inexistente) → `/notifications`.
+- `services/pushNotificationService.ts`: el historial de Firebase normaliza
+  `actionButtons[]` → `actionButton`.
+- `app/notifications.tsx`: la normalización de rutas (chips/navegación) usa el helper
+  compartido (alias incluidos).
+- Tests: `__tests__/notificationRoutes.test.ts`.
+
+Todo es **JS puro → compatible con OTA** (sin código nativo, sin `[skip-ota]`).
+
+## Mejoras futuras sugeridas (requieren build nativo o trabajo nuevo)
+
+1. **NSE iOS** para imagen en la notificación del sistema (`richContent.image`). Nativo → `[skip-ota]`.
+2. **Deep link a un evento concreto** (`/(tabs)/mas` + `eventId` por parámetro de ruta).
+3. **Channels Android por tipo/prioridad** (`urgente`, `eventos`) para heads-up/sonido diferenciados.
+4. **Usar `data.category`** para color/icono/agrupación en el centro de notificaciones.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,27 @@
 
 ---
 
+## 2026-06-02 — Notificaciones: alineación con el contrato del MCM Panel
+
+- **Normalización de rutas + alias** (`utils/notificationRoutes.ts` nuevo,
+  `notifications/usePushNotifications.ts`, `app/notifications.tsx`): el `internalRoute`
+  que manda el panel se normaliza antes de navegar, con un mapa de alias para rutas
+  heredadas/incorrectas (`/(tabs)/actividades`/`jubileo` → `/(tabs)/mas`,
+  `/(tabs)/albums` → `/(tabs)/fotos`, `/(tabs)/wordle` → `/wordle`). **Fix**: el botón
+  iOS `view` apuntaba a `/(tabs)/notifications` (ruta inexistente) → `/notifications`.
+- **Botón de acción tolerante a ambos formatos** (`utils/notificationRoutes.ts`,
+  `services/pushNotificationService.ts`): se acepta tanto `data.actionButton` (objeto
+  canónico) como `data.actionButtons` (array del contrato del panel, se usa el primer
+  elemento), infiriendo `isInternal` si no viene. Aplica al push y al historial de
+  Firebase.
+- **Tests** (`__tests__/notificationRoutes.test.ts`).
+- **Contrato revisado** (`NOTIFICACIONES_CONTRATO.md` en raíz del monorepo): respuesta
+  a las 9 preguntas del panel + correcciones (rutas reales, `/pushTokens` usa
+  `profileType`/`delegationId`/`topics` —no `userType`/`delegacion`—, segmentación por
+  `topics`, iOS sin NSE, channel único `default`). Sin código nativo → compatible OTA.
+
+---
+
 ## 2026-05-29 — UI fixes: onboarding, eventos (Liquid Glass), modo oscuro login
 
 - **Onboarding — paso de login como pantalla final/resumen** (`app/onboarding.tsx`): para perfiles con login (monitor/miembro), al iniciar sesión la pantalla de login pasa a ser el último paso y muestra el resumen (perfil + delegación) con el botón "Ir a la app" centrado verticalmente; ya no hay pantalla `success` extra en ese flujo. Quien continúa sin cuenta sigue viendo la pantalla de resumen `success`.

--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -24,6 +24,35 @@
 
 ---
 
+## Notificaciones push — mejoras pendientes (alineación con MCM Panel)
+
+> Contexto: ver `NOTIFICACIONES_CONTRATO.md` (raíz). La app ya tolera el formato del
+> panel (alias de rutas + `actionButtons[]`). Estas mejoras requieren build nativo o
+> trabajo nuevo y por eso quedaron fuera de la entrega OTA de 2026-06-02.
+
+- [ ] **NSE iOS para imágenes en la notificación del sistema** — hoy `richContent.image`
+  + `mutableContent` NO pintan imagen en iOS (no hay Notification Service Extension);
+  la imagen solo se ve in-app vía `data.imageUrl`. Añadir NSE (Android ya funciona).
+  ⚠️ Código nativo → requiere build de producción y commit con `[skip-ota]`.
+- [ ] **Deep link a un evento/actividad concreto** — hoy el destino navegable es
+  `/(tabs)/mas`; no hay ruta estable tipo `/(tabs)/mas/evento/<id>`. Registrar una
+  ruta con parámetro `eventId` y propagarla para que una notificación abra el evento
+  directamente (Jubileo, visitapapa26, `activities/<nombre>`).
+- [ ] **Channels Android por tipo/prioridad** — hoy solo existe el channel `default`
+  (importancia MAX), así que `priority` no diferencia el display. Crear channels
+  (`urgente`, `eventos`…) para heads-up/sonido diferenciados y permitir que el panel
+  mande `channelId`. ⚠️ Puede requerir build nativo.
+- [ ] **Usar `data.category` en el centro de notificaciones** — hoy se guarda pero no
+  dispara color/icono/agrupación/filtro. Diseñar el tratamiento visual por categoría
+  y converger el vocabulario con el panel (`eventos` vs `evento`, `cancionero` vs
+  `cantoral`).
+- [ ] **(Panel) Corregir el contrato** — que el MCM Panel use las rutas reales,
+  segmente por `topics`/`profileType`/`delegationId` (no `userType`/`delegacion`) y
+  desacople `categoryId` (solo iOS) de `data.category`. Detalle en
+  `NOTIFICACIONES_CONTRATO.md`.
+
+---
+
 ## Mantenimiento
 
 - [ ] **Ampliar cobertura de tests**: ya hay 7 ficheros en `__tests__/` (`chordNotation`, `filterSongsData`, `formatText`, `resolveProfileConfig`, `songUtils`, `useFirebaseData`, `useNetworkStatus`). Priorizar lo que falta: `useSongProcessor`, `useChoirSession`, `useResolvedProfileConfig`, y al menos una pantalla con render snapshot.

--- a/mcm-app/__tests__/notificationRoutes.test.ts
+++ b/mcm-app/__tests__/notificationRoutes.test.ts
@@ -1,0 +1,80 @@
+import {
+  normalizeNotificationRoute,
+  extractActionButton,
+} from '@/utils/notificationRoutes';
+
+describe('normalizeNotificationRoute', () => {
+  it('deja pasar URLs externas sin tocar', () => {
+    expect(normalizeNotificationRoute('https://mcmespana.com/x')).toBe(
+      'https://mcmespana.com/x',
+    );
+  });
+
+  it('prefija las tabs reales con el grupo (tabs)', () => {
+    expect(normalizeNotificationRoute('cancionero')).toBe('/(tabs)/cancionero');
+    expect(normalizeNotificationRoute('/fotos')).toBe('/(tabs)/fotos');
+    expect(normalizeNotificationRoute('/(tabs)/calendario')).toBe(
+      '/(tabs)/calendario',
+    );
+  });
+
+  it('mapea rutas heredadas/incorrectas del panel a la ruta real', () => {
+    expect(normalizeNotificationRoute('/(tabs)/actividades')).toBe(
+      '/(tabs)/mas',
+    );
+    expect(normalizeNotificationRoute('/(tabs)/jubileo')).toBe('/(tabs)/mas');
+    expect(normalizeNotificationRoute('/(tabs)/albums')).toBe('/(tabs)/fotos');
+    expect(normalizeNotificationRoute('/(tabs)/wordle')).toBe('/wordle');
+    expect(normalizeNotificationRoute('jubileo')).toBe('/(tabs)/mas');
+    expect(normalizeNotificationRoute('albums')).toBe('/(tabs)/fotos');
+  });
+
+  it('corrige el centro de notificaciones a su ruta raíz', () => {
+    expect(normalizeNotificationRoute('/(tabs)/notifications')).toBe(
+      '/notifications',
+    );
+    expect(normalizeNotificationRoute('notifications')).toBe('/notifications');
+  });
+
+  it('colapsa barras y quita la barra final', () => {
+    expect(normalizeNotificationRoute('//fotos//')).toBe('/(tabs)/fotos');
+  });
+
+  it('mantiene subrutas de contigo', () => {
+    expect(normalizeNotificationRoute('contigo/evangelio')).toBe(
+      '/(tabs)/contigo/evangelio',
+    );
+  });
+});
+
+describe('extractActionButton', () => {
+  it('devuelve undefined sin datos', () => {
+    expect(extractActionButton(undefined)).toBeUndefined();
+    expect(extractActionButton({})).toBeUndefined();
+  });
+
+  it('lee el formato canónico actionButton (objeto)', () => {
+    expect(
+      extractActionButton({
+        actionButton: { text: 'Ver', url: '/(tabs)/fotos', isInternal: true },
+      }),
+    ).toEqual({ text: 'Ver', url: '/(tabs)/fotos', isInternal: true });
+  });
+
+  it('acepta el formato del contrato actionButtons (array) usando el primero', () => {
+    expect(
+      extractActionButton({
+        actionButtons: [{ text: 'Abrir', url: 'https://x.com' }],
+      }),
+    ).toEqual({ text: 'Abrir', url: 'https://x.com', isInternal: false });
+  });
+
+  it('infiere isInternal cuando no viene: http = externo, ruta = interno', () => {
+    expect(
+      extractActionButton({ actionButtons: [{ url: '/(tabs)/mas' }] }),
+    ).toEqual({ text: 'Ver', url: '/(tabs)/mas', isInternal: true });
+    expect(
+      extractActionButton({ actionButtons: [{ url: 'http://x.com' }] }),
+    ).toEqual({ text: 'Ver', url: 'http://x.com', isInternal: false });
+  });
+});

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -34,6 +34,7 @@ import {
   isNotificationOlderThan60Days,
 } from '@/services/pushNotificationService';
 import { NotificationData, ReceivedNotification } from '@/types/notifications';
+import { normalizeNotificationRoute } from '@/utils/notificationRoutes';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import NotificationPermissionBanner from '@/components/NotificationPermissionBanner';
 
@@ -77,36 +78,9 @@ const ROUTE_LABELS: Record<string, { label: string; icon: string }> = {
   notifications: { label: 'Notificaciones', icon: 'notifications' },
 };
 
-function normalizeRoute(route: string): string {
-  if (!route) return '';
-  let clean = route.trim();
-  if (clean.startsWith('http')) return clean;
-
-  clean = clean.replace(/\/+/g, '/');
-
-  const hasSlash = clean.startsWith('/');
-  const naked = hasSlash ? clean.substring(1) : clean;
-
-  if (naked.startsWith('(tabs)/')) {
-    return '/' + naked;
-  }
-
-  const tabPaths = [
-    'cancionero',
-    'calendario',
-    'fotos',
-    'mas',
-    'index',
-    'contigo',
-  ];
-
-  const isTab = tabPaths.some((p) => naked === p || naked.startsWith(p + '/'));
-  if (isTab) {
-    return '/(tabs)/' + naked;
-  }
-
-  return '/' + naked;
-}
+// Delega en el normalizador compartido (incluye el mapa de alias para rutas
+// heredadas/incorrectas que pueda mandar el panel).
+const normalizeRoute = normalizeNotificationRoute;
 
 function getRouteLabel(route: string): { label: string; icon: string } | null {
   const norm = normalizeRoute(route);

--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -23,6 +23,10 @@ import {
   type TokenProfileMetadata,
 } from '@/services/pushNotificationService';
 import { ReceivedNotification } from '@/types/notifications';
+import {
+  normalizeNotificationRoute,
+  extractActionButton,
+} from '@/utils/notificationRoutes';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import { useUserProfile } from '@/contexts/UserProfileContext';
@@ -58,9 +62,12 @@ function getStableNotificationId(
   return `local_${Math.abs(hash).toString(36)}`;
 }
 
-// Mapeo de actionIdentifier de iOS a rutas internas
+// Mapeo de actionIdentifier de iOS a rutas internas.
+// Los valores se pasan por `normalizeNotificationRoute` antes de navegar, así
+// que basta con que apunten a una ruta real (p. ej. el centro de notificaciones
+// es `/notifications`, no `/(tabs)/notifications`).
 const ACTION_ROUTES: Record<string, string> = {
-  view: '/(tabs)/notifications',
+  view: '/notifications',
   view_event: '/(tabs)/calendario',
   view_photos: '/(tabs)/fotos',
 };
@@ -141,7 +148,7 @@ export default function usePushNotifications() {
           imageUrl: notification.request.content.data?.imageUrl as
             | string
             | undefined,
-          actionButton: notification.request.content.data?.actionButton as any,
+          actionButton: extractActionButton(notification.request.content.data),
           receivedAt: new Date().toISOString(),
           isRead: false,
           category: notification.request.content.data?.category as any,
@@ -181,8 +188,9 @@ export default function usePushNotifications() {
         }
 
         if (targetRoute) {
+          const normalized = normalizeNotificationRoute(targetRoute);
           try {
-            router.navigate(targetRoute as any);
+            router.navigate(normalized as any);
           } catch {}
         }
 
@@ -196,7 +204,7 @@ export default function usePushNotifications() {
           body: response.notification.request.content.body || '',
           icon: data?.icon as string | undefined,
           imageUrl: data?.imageUrl as string | undefined,
-          actionButton: data?.actionButton as any,
+          actionButton: extractActionButton(data),
           receivedAt: new Date().toISOString(),
           isRead: false,
           category: data?.category as any,

--- a/mcm-app/services/pushNotificationService.ts
+++ b/mcm-app/services/pushNotificationService.ts
@@ -17,6 +17,24 @@ import {
   NotificationData,
   ReceivedNotification,
 } from '@/types/notifications';
+import { extractActionButton } from '@/utils/notificationRoutes';
+
+/**
+ * Normaliza un registro de notificación de Firebase a la forma canónica que usa
+ * la app. En particular convierte `actionButtons` (array, formato del contrato
+ * del panel) al `actionButton` único que renderiza la pantalla.
+ */
+const normalizeNotificationRecord = (
+  key: string,
+  val: any,
+): NotificationData => {
+  const actionButton = extractActionButton(val);
+  return {
+    ...val,
+    id: val.id || key,
+    ...(actionButton ? { actionButton } : {}),
+  };
+};
 
 const DEVICE_ID_KEY = '@mcm_device_id';
 const PUSH_TOKEN_KEY = '@mcm_push_token';
@@ -237,10 +255,7 @@ export const getNotificationsHistory = async (): Promise<
     const notificationsData = snapshot.val();
     const notifications: NotificationData[] = Object.entries(
       notificationsData,
-    ).map(([key, val]: [string, any]) => ({
-      ...val,
-      id: val.id || key,
-    }));
+    ).map(([key, val]: [string, any]) => normalizeNotificationRecord(key, val));
 
     // Ordenar por fecha de creación (más recientes primero)
     return notifications.sort(
@@ -268,10 +283,9 @@ export const subscribeToNotifications = (
         const notificationsData = snapshot.val();
         const notifications: NotificationData[] = Object.entries(
           notificationsData,
-        ).map(([key, val]: [string, any]) => ({
-          ...val,
-          id: val.id || key,
-        }));
+        ).map(([key, val]: [string, any]) =>
+          normalizeNotificationRecord(key, val),
+        );
 
         // Ordenar por fecha
         const sorted = notifications.sort(

--- a/mcm-app/utils/notificationRoutes.ts
+++ b/mcm-app/utils/notificationRoutes.ts
@@ -1,0 +1,117 @@
+// utils/notificationRoutes.ts
+//
+// Utilidades compartidas para procesar el `internalRoute` y el botón de acción
+// que llegan en una notificación push (desde el MCM Panel) y en el historial de
+// Firebase. Centraliza dos cosas:
+//
+//   1. normalizeNotificationRoute(): convierte cualquier ruta que mande el panel
+//      a una ruta REAL del router de la app. Tolera rutas "desnudas"
+//      (`cancionero`), el grupo `(tabs)` y un mapa de ALIAS para rutas heredadas
+//      o incorrectas que el panel pueda seguir enviando (p. ej. `actividades`,
+//      `jubileo`, `albums`, `wordle`). Así un error de configuración del panel
+//      no deja al usuario en una pantalla 404.
+//
+//   2. extractActionButton(): normaliza el botón de acción. El contrato del panel
+//      define `data.actionButtons` (array) pero la app trabaja con un único
+//      `actionButton` (objeto con `isInternal`). Esta función acepta ambos
+//      formatos y devuelve siempre la forma canónica.
+
+/**
+ * Rutas que el panel puede enviar pero que NO existen como ruta propia en el
+ * router. Se mapean a la ruta real equivalente.
+ *
+ * - `actividades` / `jubileo` → viven dentro del stack de "Más" (`/(tabs)/mas`).
+ * - `albums` / `album`        → la galería es la tab "fotos".
+ * - `wordle`                  → ruta raíz, no está bajo `(tabs)`.
+ * - `(tabs)/notifications`    → el centro de notificaciones es ruta raíz
+ *                                `/notifications`, no una tab.
+ */
+const ROUTE_ALIASES: Record<string, string> = {
+  '/(tabs)/notifications': '/notifications',
+  '/(tabs)/actividades': '/(tabs)/mas',
+  '/(tabs)/jubileo': '/(tabs)/mas',
+  '/(tabs)/albums': '/(tabs)/fotos',
+  '/(tabs)/album': '/(tabs)/fotos',
+  '/(tabs)/wordle': '/wordle',
+  '/actividades': '/(tabs)/mas',
+  '/jubileo': '/(tabs)/mas',
+  '/albums': '/(tabs)/fotos',
+  '/album': '/(tabs)/fotos',
+};
+
+/** Segmentos que SÍ son tabs reales bajo `app/(tabs)/`. */
+const TAB_PATHS = [
+  'cancionero',
+  'calendario',
+  'fotos',
+  'mas',
+  'index',
+  'contigo',
+  'visitapapa',
+];
+
+/**
+ * Normaliza una ruta de notificación a una ruta real del router de Expo.
+ * Las URLs externas (http/https) se devuelven sin tocar.
+ */
+export function normalizeNotificationRoute(route: string): string {
+  if (!route) return '';
+  let clean = route.trim();
+  if (/^https?:\/\//i.test(clean)) return clean;
+
+  // Colapsar barras repetidas y quitar la barra final (salvo en la raíz).
+  clean = clean.replace(/\/+/g, '/');
+  if (clean.length > 1 && clean.endsWith('/')) clean = clean.slice(0, -1);
+
+  // Alias directo sobre el valor tal cual lo manda el panel.
+  if (ROUTE_ALIASES[clean]) return ROUTE_ALIASES[clean];
+
+  const naked = clean.startsWith('/') ? clean.slice(1) : clean;
+
+  let resolved: string;
+  if (naked.startsWith('(tabs)/')) {
+    resolved = '/' + naked;
+  } else if (TAB_PATHS.some((p) => naked === p || naked.startsWith(p + '/'))) {
+    resolved = '/(tabs)/' + naked;
+  } else {
+    resolved = '/' + naked;
+  }
+
+  // Re-aplicar alias sobre la ruta ya resuelta (cubre el caso de rutas
+  // desnudas que tras prefijarse coinciden con un alias).
+  return ROUTE_ALIASES[resolved] ?? resolved;
+}
+
+export interface NotificationActionButton {
+  text: string;
+  url: string;
+  isInternal: boolean;
+}
+
+/**
+ * Extrae el botón de acción de los datos de una notificación, aceptando tanto
+ * el formato canónico de la app (`actionButton`, objeto) como el del contrato
+ * del panel (`actionButtons`, array — se usa el primer elemento).
+ *
+ * Si `isInternal` no viene explícito, se infiere: una ruta interna NO empieza
+ * por `http(s)://`.
+ */
+export function extractActionButton(
+  data: Record<string, any> | null | undefined,
+): NotificationActionButton | undefined {
+  if (!data) return undefined;
+
+  const raw =
+    data.actionButton ??
+    (Array.isArray(data.actionButtons) ? data.actionButtons[0] : undefined);
+
+  if (!raw || typeof raw !== 'object' || !raw.url) return undefined;
+
+  const url = String(raw.url);
+  const isInternal =
+    typeof raw.isInternal === 'boolean'
+      ? raw.isInternal
+      : !/^https?:\/\//i.test(url);
+
+  return { text: String(raw.text ?? 'Ver'), url, isInternal };
+}


### PR DESCRIPTION
## Resumen

Procesa el contrato de datos del **MCM Panel ↔ MCM App** para notificaciones push: alinea la app con lo que el panel envía y **corrige los puntos en los que el contrato estaba equivocado**. Todo es JS puro → **compatible con OTA** (sin código nativo, sin `[skip-ota]`).

## Discrepancias detectadas (el panel se equivocaba)

1. **Rutas inexistentes**: `/(tabs)/actividades`, `/(tabs)/jubileo`, `/(tabs)/albums`, `/(tabs)/wordle` no existen. Reales: las actividades/Jubileo viven en `/(tabs)/mas`, la galería es `/(tabs)/fotos`, Wordle es `/wordle` (raíz, además dormido).
2. **`/pushTokens`**: el contrato inventaba `userType`/`delegacion` con valores (`joven`/`responsable`/`"Castellón"`) que no existen. Campos reales: `profileType` (`familia|monitor|miembro`), `delegationId` (slug `mcm-castellon`…) y **`topics[]`** — el array precomputado que es la clave de segmentación.
3. **`actionButtons` (array)** vs el `actionButton` (objeto con `isInternal`) canónico de la app.
4. **`categoryId`**: la app solo registra `general`/`eventos`/`fotos` en iOS; el resto se ignora.

Además, **bug latente corregido**: el action iOS `view` navegaba a `/(tabs)/notifications` (ruta inexistente) → `/notifications`.

## Cambios en la app

- **`utils/notificationRoutes.ts`** (nuevo): `normalizeNotificationRoute()` con mapa de **alias** para rutas heredadas del panel + `extractActionButton()` que acepta `actionButton` (objeto) **y** `actionButtons` (array), infiriendo `isInternal`.
- **`notifications/usePushNotifications.ts`**: usa ambos helpers; fix del action `view`.
- **`services/pushNotificationService.ts`**: el historial de Firebase normaliza `actionButtons[]` → `actionButton`.
- **`app/notifications.tsx`**: reusa el normalizador compartido (alias incluidos).
- **Tests**: `__tests__/notificationRoutes.test.ts` (10 casos).

## Documentación

- **`NOTIFICACIONES_CONTRATO.md`** (nuevo, raíz): contrato revisado con la respuesta a las 9 preguntas del panel + correcciones y la guía de segmentación por `topics`.
- **`NOTIFICACIONES.md`**: lista de rutas corregida.
- **`mcm-app/CHANGELOG.md`** y **`mcm-app/TODO.md`**: mejoras futuras anotadas (NSE iOS, deep link a evento, channels Android, uso de `data.category`).

## Verificación

- `npx tsc --noEmit` → 0 errores
- ESLint → limpio
- Jest → **95/95** tests pasan (incluye los 10 nuevos)

https://claude.ai/code/session_018fMQCkuorsAY7DuPc9zTCe

---
_Generated by [Claude Code](https://claude.ai/code/session_018fMQCkuorsAY7DuPc9zTCe)_