### PR TITLE
Eventos: header transparente real, botón Atrás limpio y formulario Compartiendo

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 2026-06-03 — Eventos: fix header transparente, botón Atrás y formulario Compartiendo
+
+- **Header de sub-pantallas realmente transparente**
+  (`app/screens/eventStackScreens.tsx`): la barra flotante se pinta ahora con el
+  color de fondo de la pantalla (capa opaca) en vez de dejar un `View`
+  transparente que dejaba ver el material gris translúcido nativo por detrás. La
+  barra se funde con el contenido y desaparece el "doble cristal" que se veía
+  bajo el botón Atrás.
+- **Botón Atrás (y demás cristales) bien redondeados**
+  (`components/ui/GlassSurface.ios.tsx`): el radio del contenedor se aplica
+  también a la capa nativa `GlassView`/`BlurView`, evitando el borde rectangular
+  que se percibía como una segunda capa.
+- **Compartiendo: selector de fecha en modal centrado**
+  (`app/screens/ReflexionesScreen.tsx`): se sustituye el `Dialog` de heroui
+  (cuyo spinner nativo se escapaba a la esquina superior al anidarse con el
+  bottom sheet) por un `Modal` nativo centrado con botón "Listo".
+- **Compartiendo: se elimina "Compartir en grupo"** del formulario y se cambia
+  el subtítulo del hero a "Comparte aquí una frase, pensamiento o algo que te
+  llevas de estos días".
+
 ## 2026-06-02 — Eventos (Visita Papa): rediseño de headers, hero, estados vacíos y FABs
 
 - **Sub-pantallas sin header (transparente) en todas las plataformas**

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -7,17 +7,11 @@ import {
   Text,
   Pressable,
   TextInput,
+  Modal,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  Card,
-  Switch,
-  Chip,
-  Spinner,
-  BottomSheet,
-  Dialog,
-} from 'heroui-native';
+import { Card, Spinner, BottomSheet } from 'heroui-native';
 import DateTimePicker, {
   DateTimePickerAndroid,
 } from '@react-native-community/datetimepicker';
@@ -117,8 +111,6 @@ export default function ReflexionesScreen() {
   const [titulo, setTitulo] = useState('');
   const [contenido, setContenido] = useState('');
   const [fecha, setFecha] = useState(new Date());
-  const [grupal, setGrupal] = useState(false);
-  const [grupo, setGrupo] = useState<string | undefined>(undefined);
   const [autor, setAutor] = useState(getDefaultAuthor());
   const [showDateSelector, setShowDateSelector] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -152,8 +144,8 @@ export default function ReflexionesScreen() {
       titulo: titulo.trim(),
       contenido,
       fecha: fecha.toISOString().slice(0, 10),
-      grupal,
-      ...(grupal ? (grupo ? { grupo } : {}) : { autor }),
+      grupal: false,
+      autor,
     };
     try {
       const db = getDatabase(getFirebaseApp());
@@ -172,8 +164,6 @@ export default function ReflexionesScreen() {
     setTitulo('');
     setContenido('');
     setFecha(new Date());
-    setGrupal(false);
-    setGrupo(undefined);
     setAutor(getDefaultAuthor());
     setSaving(false);
   }
@@ -200,7 +190,7 @@ export default function ReflexionesScreen() {
     <View style={styles.container}>
       <ScreenHero
         title="Compartiendo"
-        subtitle="Reflexiones que iluminan a la comunidad"
+        subtitle="Comparte aquí una frase, pensamiento o algo que te llevas de estos días"
       />
       <PageContainer>
         <ScrollView
@@ -342,49 +332,16 @@ export default function ReflexionesScreen() {
                 />
               </Pressable>
 
-              <View style={styles.switchRow}>
-                <MaterialIcons
-                  name="groups"
-                  size={20}
-                  color={grupal ? colors.success : theme.icon}
-                />
-                <Text style={styles.switchLabel}>Compartir en grupo</Text>
-                <Switch
-                  isSelected={grupal}
-                  onSelectedChange={(v) => setGrupal(v)}
+              <View style={styles.field}>
+                <Text style={styles.inputLabel}>Tu nombre (opcional)</Text>
+                <TextInput
+                  value={autor}
+                  onChangeText={setAutor}
+                  placeholder="Cómo quieres firmar"
+                  placeholderTextColor={theme.icon}
+                  style={styles.input}
                 />
               </View>
-
-              {grupal ? (
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.chipRow}
-                  style={styles.chipScroll}
-                >
-                  {grupos.map((g) => (
-                    <Chip
-                      key={g.nombre}
-                      variant={grupo === g.nombre ? 'primary' : 'soft'}
-                      color="success"
-                      onPress={() => setGrupo(g.nombre)}
-                    >
-                      <Chip.Label>{getGrupoLabel(g.nombre)}</Chip.Label>
-                    </Chip>
-                  ))}
-                </ScrollView>
-              ) : (
-                <View style={styles.field}>
-                  <Text style={styles.inputLabel}>Tu nombre (opcional)</Text>
-                  <TextInput
-                    value={autor}
-                    onChangeText={setAutor}
-                    placeholder="Cómo quieres firmar"
-                    placeholderTextColor={theme.icon}
-                    style={styles.input}
-                  />
-                </View>
-              )}
 
               <Pressable
                 onPress={addReflexion}
@@ -403,30 +360,50 @@ export default function ReflexionesScreen() {
         </BottomSheet.Portal>
       </BottomSheet>
 
-      {/* Date selector modal */}
-      <Dialog
-        isOpen={showDateSelector}
-        onOpenChange={(open) => {
-          if (!open) setShowDateSelector(false);
-        }}
+      {/* Date selector — modal centrado que aparece por encima de todo
+          (incluido el bottom sheet). Antes se usaba el Dialog de heroui, que
+          al anidarse con el portal del BottomSheet dejaba escapar el spinner
+          nativo a la esquina superior. Un Modal nativo de RN se presenta de
+          forma fiable centrado sobre el resto de la UI. */}
+      <Modal
+        visible={showDateSelector}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowDateSelector(false)}
       >
-        <Dialog.Portal>
-          <Dialog.Overlay />
-          <Dialog.Content>
-            <Dialog.Close />
+        <Pressable
+          style={styles.dateModalOverlay}
+          onPress={() => setShowDateSelector(false)}
+        >
+          {/* Pressable interior que “traga” el toque para no cerrar al
+              interactuar con el selector. */}
+          <Pressable style={styles.dateModalCard} onPress={() => {}}>
+            <Text style={styles.dateModalTitle}>Elige la fecha</Text>
             <DateTimePicker
               value={fecha}
               mode="date"
-              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              display="spinner"
               locale="es-ES"
+              themeVariant={scheme === 'dark' ? 'dark' : 'light'}
               onChange={(_, selected) => {
-                setShowDateSelector(false);
                 if (selected) setFecha(selected);
               }}
+              style={styles.datePicker}
             />
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog>
+            <Pressable
+              onPress={() => setShowDateSelector(false)}
+              accessibilityRole="button"
+              accessibilityLabel="Confirmar fecha"
+              style={({ pressed }) => [
+                styles.dateDoneBtn,
+                pressed && { opacity: 0.85 },
+              ]}
+            >
+              <Text style={styles.dateDoneLabel}>Listo</Text>
+            </Pressable>
+          </Pressable>
+        </Pressable>
+      </Modal>
 
       {/* Saving overlay */}
       {saving && (
@@ -523,16 +500,44 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       color: theme.text,
     },
     dateValue: { fontSize: 15, fontWeight: '600', color: colors.success },
-    switchRow: {
-      flexDirection: 'row',
+    dateModalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.45)',
+      justifyContent: 'center',
       alignItems: 'center',
-      gap: spacing.sm,
-      marginBottom: spacing.md,
-      paddingVertical: 4,
+      padding: spacing.lg,
     },
-    switchLabel: { flex: 1, fontSize: 15, color: theme.text },
-    chipScroll: { marginBottom: spacing.md },
-    chipRow: { flexDirection: 'row', gap: 8, paddingVertical: 4 },
+    dateModalCard: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.background,
+      borderRadius: 20,
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.md,
+      alignItems: 'center',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 8 },
+      shadowOpacity: 0.2,
+      shadowRadius: 20,
+      elevation: 8,
+    },
+    dateModalTitle: {
+      fontSize: 17,
+      fontWeight: '700',
+      color: theme.text,
+      marginBottom: spacing.sm,
+    },
+    datePicker: { alignSelf: 'stretch' },
+    dateDoneBtn: {
+      alignSelf: 'stretch',
+      backgroundColor: colors.success,
+      borderRadius: 14,
+      paddingVertical: 13,
+      alignItems: 'center',
+      marginTop: spacing.sm,
+    },
+    dateDoneLabel: { color: '#fff', fontSize: 16, fontWeight: '700' },
     saveBtn: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/mcm-app/app/screens/eventStackScreens.tsx
+++ b/mcm-app/app/screens/eventStackScreens.tsx
@@ -4,6 +4,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import GlassHeader from '@/components/ui/GlassHeader.ios';
 import GlassBackButton from '@/components/ui/GlassBackButton';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
 import { getEvent } from '@/constants/events';
 
 import EventHomeScreen from './EventHomeScreen';
@@ -37,9 +39,19 @@ import WordleScreen from './WordleScreen';
  */
 export type EventRouteParams = { eventId?: string };
 
-const styles = StyleSheet.create({
-  transparentHeader: { backgroundColor: 'transparent' },
-});
+/**
+ * Fondo del header flotante: una capa OPACA pintada con el color de fondo de la
+ * pantalla (reactivo al tema claro/oscuro). Sustituye al material translúcido
+ * nativo, que dejaba ver un gris por detrás de la barra y creaba el efecto de
+ * "doble cristal" con el botón Atrás. Al fundirse con el contenido, la barra
+ * resulta visualmente inexistente y el botón "Atrás" glass flota sobre un fondo
+ * plano y limpio.
+ */
+function FloatingHeaderBackground() {
+  const scheme = useColorScheme();
+  const bg = Colors[scheme ?? 'light'].background;
+  return <View style={[StyleSheet.absoluteFill, { backgroundColor: bg }]} />;
+}
 
 /**
  * Rutas de sub-pantalla de evento (todo menos el hub `JubileoHome`). Los tabs
@@ -126,11 +138,12 @@ export const eventScreenOptions =
     const tint = event.tintColor;
     const textColor = getTextColor(tint);
     const isIOS = Platform.OS === 'ios';
-    // "Flotante" = sin header visible: barra TOTALMENTE transparente, sin
-    // título (lo pone el ScreenHero del contenido) + botón "Atrás" glass
-    // flotante a la izquierda. Las acciones glass van arriba a la derecha vía
-    // `EventActionButtons`. Se aplica a todas las sub-pantallas con título
-    // grande propio (`hideHeaderTitle`) en TODAS las plataformas.
+    // "Flotante" = sin header visible: la barra se pinta con el color de fondo
+    // de la pantalla (se funde con el contenido, no es el material gris
+    // translúcido nativo), sin título (lo pone el ScreenHero del contenido) +
+    // botón "Atrás" glass flotante a la izquierda. Las acciones glass van arriba
+    // a la derecha vía `EventActionButtons`. Se aplica a todas las sub-pantallas
+    // con título grande propio (`hideHeaderTitle`) en TODAS las plataformas.
     const useFloating = !!opts?.hideHeaderTitle;
     if (useFloating) {
       return {
@@ -140,9 +153,7 @@ export const eventScreenOptions =
         headerTitle: () => <View />,
         headerStyle: { backgroundColor: 'transparent' },
         headerShadowVisible: false,
-        headerBackground: () => (
-          <View style={[StyleSheet.absoluteFill, styles.transparentHeader]} />
-        ),
+        headerBackground: () => <FloatingHeaderBackground />,
         headerLeft: () => <GlassBackButton />,
       };
     }

--- a/mcm-app/components/ui/GlassSurface.ios.tsx
+++ b/mcm-app/components/ui/GlassSurface.ios.tsx
@@ -48,7 +48,8 @@ export default function GlassSurface({
   // isGlassEffectAPIAvailable() guards against crashes on some iOS 26 beta
   // builds where isLiquidGlassAvailable() returns true but the native API
   // isn't actually safe to use. See: https://github.com/expo/expo/issues/40911
-  const liquidAvailable = isLiquidGlassAvailable() && isGlassEffectAPIAvailable();
+  const liquidAvailable =
+    isLiquidGlassAvailable() && isGlassEffectAPIAvailable();
   const {
     backgroundColor,
     blurTint: autoTint,
@@ -63,21 +64,37 @@ export default function GlassSurface({
   const glassEffectStyle: 'clear' | 'regular' =
     variant === 'clear' ? 'clear' : 'regular';
 
+  // El radio del contenedor debe aplicarse también a la capa nativa de cristal:
+  // sin esto, el `GlassView`/`BlurView` dibuja su propio borde/halo rectangular
+  // que el contenedor recorta a destiempo y se percibe como un segundo cristal
+  // (el efecto "doble capa" del botón Atrás). Igualando el radio, la pieza de
+  // cristal queda perfectamente redondeada en una sola capa.
+  const flat = StyleSheet.flatten(style) as ViewStyle | undefined;
+  const radius =
+    typeof flat?.borderRadius === 'number' ? flat.borderRadius : undefined;
+  const radiusStyle = radius != null ? { borderRadius: radius } : null;
+
   const baseLayer = liquidAvailable ? (
     <>
       {tintColor ? (
-        <View style={[StyleSheet.absoluteFill, { backgroundColor }]} />
+        <View
+          style={[StyleSheet.absoluteFill, { backgroundColor }, radiusStyle]}
+        />
       ) : null}
       <GlassView
         glassEffectStyle={glassEffectStyle}
-        style={StyleSheet.absoluteFill}
+        style={[StyleSheet.absoluteFill, radiusStyle]}
       />
     </>
   ) : (
     <BlurView
       tint={blurTint}
       intensity={blurIntensity}
-      style={[StyleSheet.absoluteFill, tintColor ? { backgroundColor } : null]}
+      style={[
+        StyleSheet.absoluteFill,
+        tintColor ? { backgroundColor } : null,
+        radiusStyle,
+      ]}
     />
   );
 


### PR DESCRIPTION
Arregla los fallos de diseño que quedaban en la sección de actividades (sobre la rama `production`, que es lo que corre la app).

## Imagen 1 — header de actividades
- El header "transparente" en realidad era un `View` transparente sobre el **material gris translúcido nativo**, así que se veía la banda gris y el botón Atrás quedaba cristal-sobre-cristal (el "dos capas"). Ahora la barra se pinta con el color de fondo de la propia pantalla (`FloatingHeaderBackground`, reactivo a claro/oscuro): se funde con el contenido y desaparece el gris. El layout (título debajo de los botones) no cambia. — `eventStackScreens.tsx`
- El radio del contenedor se aplica también a la capa nativa `GlassView`/`BlurView`, que dibujaba un borde rectangular desajustado — eso era el "no está bien redondeado / dos capas" del botón Atrás. De paso mejora el grupo de acciones de la derecha y los FABs. — `GlassSurface.ios.tsx`

## Imagen 3 — Compartiendo
- El selector de fecha usaba el `Dialog` de heroui anidado en el portal del bottom sheet, lo que dejaba escapar el spinner nativo a la esquina superior. Sustituido por un `Modal` nativo centrado (overlay atenuado, tarjeta con título, botón "Listo", cerrar al tocar fuera). — `ReflexionesScreen.tsx`
- Subtítulo del hero → **"Comparte aquí una frase, pensamiento o algo que te llevas de estos días"**.
- Eliminado **"Compartir en grupo"** (toggle + chips); el formulario muestra siempre "Tu nombre (opcional)". Se conserva la visualización de entradas de grupo ya existentes.

## Notas
- `tsc --noEmit` y ESLint en verde. Documentado en `CHANGELOG.md`.
- Sin paquetes nativos nuevos → se cubre con OTA, no requiere build de tienda.
- Salvedad menor sin dispositivo: el header usa `Colors[scheme].background` (`#fff`/`#2C2C2E`), que coincide exacto con las sub-pantallas de contenido; el **hub** del evento usa el fondo agrupado de iOS (`#F2F2F7`/`#1C1C1E`), por lo que su franja superior puede variar un tono apenas perceptible.

https://claude.ai/code/session_011P7KxnfgqDQxCkA3gSnNY2

---
_Generated by [Claude Code](https://claude.ai/code/session_011P7KxnfgqDQxCkA3gSnNY2)_