### PR TITLE
Compartiendo: barra de color de sección, "+" en la barra y tarjetas con color

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -32,6 +32,18 @@
 - **Compartiendo: se elimina "Compartir en grupo"** del formulario y se cambia
   el subtítulo del hero a "Comparte aquí una frase, pensamiento o algo que te
   llevas de estos días".
+- **Visita Papa: barra de color superior en toda la sección**
+  (`app/(tabs)/visitapapa.tsx`): franja del color de la sección (#FCD200) arriba
+  del todo, al estilo iOS de Calendario y Fotos, sobre todo el stack del evento.
+- **Compartiendo: el "+" pasa del FAB a la barra superior**
+  (`components/EventActionButtons.tsx`, `ReflexionesScreen.tsx`,
+  `app/(tabs)/visitapapa.tsx`, `app/(tabs)/mas.tsx`): se elimina el FAB flotante;
+  al estar en Compartiendo, la barra de acciones muestra un "+" (junto a
+  Ajustes) que abre el formulario vía renavegación con `openFormNonce`.
+- **Compartiendo: tarjetas rediseñadas** (`ReflexionesScreen.tsx`): cada
+  reflexión tiene un color generado de su id, avatar con iniciales, marca de
+  cita y dos diseños alternos (fondo tintado / tarjeta limpia con barra de
+  color) para dar variedad. Estado vacío amable cuando no hay reflexiones.
 
 ## 2026-06-02 — Eventos (Visita Papa): rediseño de headers, hero, estados vacíos y FABs
 

--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -178,6 +178,13 @@ export default function MasTab() {
             })
           }
           showCompartiendo={activeRoute !== 'Reflexiones'}
+          showAdd={activeRoute === 'Reflexiones'}
+          onAdd={() =>
+            stackNavRef.current?.navigate('Reflexiones', {
+              eventId: activeEventId,
+              openFormNonce: Date.now(),
+            })
+          }
         />
       )}
     </>

--- a/mcm-app/app/(tabs)/visitapapa.tsx
+++ b/mcm-app/app/(tabs)/visitapapa.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Platform } from 'react-native';
+import { Platform, View, StyleSheet } from 'react-native';
 import { useNavigation } from 'expo-router';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import EventHomeScreen from '../screens/EventHomeScreen';
 import SettingsBottomSheet from '@/components/SettingsBottomSheet';
 import EventActionButtons from '@/components/EventActionButtons';
+import { getEvent } from '@/constants/events';
 import {
   EVENT_SUB_ROUTES,
   EventStackParamList,
@@ -36,6 +37,7 @@ export default function VisitaPapaTab() {
   const webStatusBarHeight = Platform.OS === 'web' ? insets.top : undefined;
 
   const navigation = useNavigation();
+  const sectionColor = getEvent(EVENT_ID).tintColor;
 
   useEffect(() => {
     const unsubscribeBlur = navigation.addListener('blur' as any, () => {
@@ -107,8 +109,32 @@ export default function VisitaPapaTab() {
             stackNavRef.current?.navigate('Reflexiones', { eventId: EVENT_ID })
           }
           showCompartiendo={activeRoute !== 'Reflexiones'}
+          showAdd={activeRoute === 'Reflexiones'}
+          onAdd={() =>
+            stackNavRef.current?.navigate('Reflexiones', {
+              eventId: EVENT_ID,
+              openFormNonce: Date.now(),
+            })
+          }
         />
       )}
+      {/* Barra de color superior de la sección (estilo iOS de Calendario/Fotos),
+          por encima de todo el stack. */}
+      <View
+        style={[styles.topColorBar, { backgroundColor: sectionColor }]}
+        pointerEvents="none"
+      />
     </>
   );
 }
+
+const styles = StyleSheet.create({
+  topColorBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 8,
+    zIndex: 1001,
+  },
+});

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -11,13 +11,16 @@ import {
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Card, Spinner, BottomSheet } from 'heroui-native';
+import { useRoute, RouteProp } from '@react-navigation/native';
+import { Spinner, BottomSheet } from 'heroui-native';
 import DateTimePicker, {
   DateTimePickerAndroid,
 } from '@react-native-community/datetimepicker';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import colors, { Colors } from '@/constants/colors';
 import spacing from '@/constants/spacing';
+import { radii, shadows } from '@/constants/uiStyles';
+import { getBrightness } from '@/components/ui/glass';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
 import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
@@ -26,9 +29,9 @@ import { getFirebaseApp } from '@/utils/firebaseApp';
 import { h } from '@/utils/haptics';
 import { useUserProfile } from '@/contexts/UserProfileContext';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
-import GlassFAB from '@/components/ui/GlassFAB';
 import PageContainer from '@/components/ui/PageContainer';
 import ScreenHero from '@/components/ui/ScreenHero';
+import type { EventStackParamList } from './eventStackScreens';
 
 interface Grupo {
   nombre: string;
@@ -60,11 +63,53 @@ const MONTHS_ES = [
 ];
 const WEEKDAYS_ES = ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'];
 
+// Paleta para las tarjetas de Compartiendo. Colores de media saturación (el
+// blanco se lee encima y combinan bien como tinte de fondo). Se elige uno de
+// forma DETERMINISTA según el id de cada reflexión, así cada tarjeta tiene
+// "su" color estable entre renders.
+const CARD_PALETTE = [
+  '#E15C62', // rojo MIC
+  '#3478C7', // azul
+  '#7B9A1E', // verde oliva
+  '#9D1E74', // morado
+  '#E0702F', // naranja
+  '#2F8FB3', // azul petróleo
+  '#9C4FB0', // violeta
+  '#D24B7E', // rosa
+  '#4E9A51', // verde
+  '#5C6BC0', // índigo
+  '#3A9188', // turquesa
+  '#C2872B', // ámbar
+];
+
+function hashString(s: string): number {
+  let hash = 0;
+  for (let i = 0; i < s.length; i++) {
+    hash = (hash << 5) - hash + s.charCodeAt(i);
+    hash |= 0; // a int32
+  }
+  return Math.abs(hash);
+}
+
+function pickCardColor(seed: string): string {
+  return CARD_PALETTE[hashString(seed || 'x') % CARD_PALETTE.length];
+}
+
+function getInitials(name?: string): string {
+  if (!name) return '';
+  const words = name.trim().split(/\s+/).slice(0, 2);
+  return words
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase();
+}
+
 export default function ReflexionesScreen() {
   const scheme = useColorScheme();
   const insets = useSafeAreaInsets();
   const theme = Colors[scheme ?? 'light'];
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
+  const route = useRoute<RouteProp<EventStackParamList, 'Reflexiones'>>();
   const { profile } = useUserProfile();
   const resolved = useResolvedProfileConfig();
 
@@ -114,6 +159,14 @@ export default function ReflexionesScreen() {
   const [autor, setAutor] = useState(getDefaultAuthor());
   const [showDateSelector, setShowDateSelector] = useState(false);
   const [saving, setSaving] = useState(false);
+
+  // El botón "+" vive ahora en la barra superior (EventActionButtons). Al
+  // pulsarlo, el tab renavega a esta pantalla con un `openFormNonce` nuevo;
+  // ese cambio abre el formulario aquí.
+  const openFormNonce = route.params?.openFormNonce;
+  useEffect(() => {
+    if (openFormNonce) setShowForm(true);
+  }, [openFormNonce]);
 
   const showDatePicker = () => {
     if (Platform.OS === 'android') {
@@ -199,60 +252,92 @@ export default function ReflexionesScreen() {
             { paddingBottom: insets.bottom + 20 },
           ]}
         >
-          {sortedList.map((r) => (
-            <Card
-              key={r.id}
-              style={[styles.card, r.grupal && styles.cardGroup]}
-            >
-              <Card.Body style={{ paddingTop: 8 }}>
-                {r.titulo ? (
-                  <Text
-                    style={[
-                      { fontWeight: '600', fontSize: 16, marginBottom: 4 },
-                      r.grupal
-                        ? { color: scheme === 'dark' ? '#d4e8c0' : '#1a3000' }
-                        : { color: theme.text },
-                    ]}
-                  >
-                    {r.titulo}
-                  </Text>
-                ) : null}
-                <Text
-                  style={
-                    r.grupal
-                      ? { color: scheme === 'dark' ? '#c0d8a8' : '#333' }
-                      : { color: theme.text }
-                  }
-                >
-                  {r.contenido}
-                </Text>
-                <Text
+          {sortedList.length === 0 ? (
+            <View style={styles.emptyState}>
+              <MaterialIcons
+                name="auto-stories"
+                size={40}
+                color={colors.success}
+              />
+              <Text style={styles.emptyTitle}>Aún no hay reflexiones</Text>
+              <Text style={styles.emptyText}>
+                Pulsa el botón + de arriba para compartir la primera.
+              </Text>
+            </View>
+          ) : (
+            sortedList.map((r, i) => {
+              const color = pickCardColor(r.id);
+              // Alterna dos diseños para que el muro "fluya": tarjeta con
+              // fondo tintado (par) y tarjeta limpia con barra de color a la
+              // izquierda (impar). Cada una con su color generado del id.
+              const filled = i % 2 === 0;
+              const name = r.grupal ? getGrupoLabel(r.grupo) : r.autor;
+              const initials = getInitials(name);
+              const onColor = getBrightness(color) > 150 ? '#1a1a1a' : '#fff';
+              return (
+                <View
+                  key={r.id}
                   style={[
-                    { marginTop: 4, fontSize: 12 },
-                    r.grupal
-                      ? { color: scheme === 'dark' ? '#a0b888' : '#555' }
-                      : { color: theme.icon },
+                    styles.card,
+                    filled
+                      ? {
+                          backgroundColor:
+                            color + (scheme === 'dark' ? '26' : '1A'),
+                        }
+                      : styles.cardSurface,
                   ]}
                 >
-                  {formatFecha(r.fecha)}
-                  {r.grupal
-                    ? ` - ${getGrupoLabel(r.grupo)}`
-                    : r.autor
-                      ? ` - ${r.autor}`
-                      : ''}
-                </Text>
-              </Card.Body>
-            </Card>
-          ))}
+                  {!filled && (
+                    <View
+                      style={[styles.accentBar, { backgroundColor: color }]}
+                    />
+                  )}
+                  <MaterialIcons
+                    name="format-quote"
+                    size={66}
+                    color={color + (scheme === 'dark' ? '26' : '1F')}
+                    style={styles.quoteMark}
+                  />
+                  <View
+                    style={[
+                      styles.cardInner,
+                      !filled && { paddingLeft: spacing.md + 8 },
+                    ]}
+                  >
+                    <View style={styles.cardHead}>
+                      <View style={[styles.avatar, { backgroundColor: color }]}>
+                        {initials ? (
+                          <Text style={[styles.avatarText, { color: onColor }]}>
+                            {initials}
+                          </Text>
+                        ) : (
+                          <MaterialIcons
+                            name="auto-stories"
+                            size={16}
+                            color={onColor}
+                          />
+                        )}
+                      </View>
+                      <View style={{ flex: 1 }}>
+                        <Text style={styles.cardAuthor} numberOfLines={1}>
+                          {name || 'Anónimo'}
+                        </Text>
+                        <Text style={styles.cardDate}>
+                          {formatFecha(r.fecha)}
+                        </Text>
+                      </View>
+                    </View>
+                    {r.titulo ? (
+                      <Text style={styles.cardTitle}>{r.titulo}</Text>
+                    ) : null}
+                    <Text style={styles.cardContent}>{r.contenido}</Text>
+                  </View>
+                </View>
+              );
+            })
+          )}
         </ScrollView>
       </PageContainer>
-
-      <GlassFAB
-        icon="add"
-        onPress={() => setShowForm(true)}
-        tintColor="#A3BD31"
-        iconColor="#fff"
-      />
 
       {/* Form bottom sheet */}
       <BottomSheet
@@ -430,10 +515,70 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       paddingTop: spacing.sm,
       paddingBottom: spacing.xl,
     },
-    list: { padding: spacing.md },
-    card: { marginBottom: spacing.md },
-    cardGroup: {
-      backgroundColor: scheme === 'dark' ? '#2D3B20' : '#E6F4D7',
+    list: { padding: spacing.md, paddingTop: spacing.sm },
+    card: {
+      marginBottom: spacing.md,
+      borderRadius: radii.xl,
+      overflow: 'hidden',
+      ...(shadows.sm as object),
+    },
+    cardSurface: {
+      backgroundColor: scheme === 'dark' ? '#2C2C2E' : '#FFFFFF',
+    },
+    accentBar: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: 6,
+    },
+    quoteMark: {
+      position: 'absolute',
+      top: -10,
+      right: 6,
+      transform: [{ scaleX: -1 }],
+    },
+    cardInner: { padding: spacing.md },
+    cardHead: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
+      marginBottom: 10,
+    },
+    avatar: {
+      width: 38,
+      height: 38,
+      borderRadius: 19,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    avatarText: { fontSize: 14, fontWeight: '800', letterSpacing: 0.3 },
+    cardAuthor: { fontSize: 15, fontWeight: '700', color: theme.text },
+    cardDate: { fontSize: 12, color: theme.icon, marginTop: 1 },
+    cardTitle: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: theme.text,
+      marginBottom: 4,
+    },
+    cardContent: { fontSize: 15, lineHeight: 21, color: theme.text },
+    emptyState: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: spacing.xl * 2,
+      paddingHorizontal: spacing.lg,
+      gap: 8,
+    },
+    emptyTitle: {
+      fontSize: 17,
+      fontWeight: '700',
+      color: theme.text,
+      marginTop: 4,
+    },
+    emptyText: {
+      fontSize: 14,
+      color: theme.icon,
+      textAlign: 'center',
     },
     modalOverlay: {
       flex: 1,

--- a/mcm-app/app/screens/eventStackScreens.tsx
+++ b/mcm-app/app/screens/eventStackScreens.tsx
@@ -87,7 +87,7 @@ export type EventStackParamList = {
   Contactos: EventRouteParams | undefined;
   Apps: EventRouteParams | undefined;
   Wordle: EventRouteParams | undefined;
-  Reflexiones: EventRouteParams | undefined;
+  Reflexiones: (EventRouteParams & { openFormNonce?: number }) | undefined;
 };
 
 type EventStackNavigator = ReturnType<

--- a/mcm-app/components/EventActionButtons.tsx
+++ b/mcm-app/components/EventActionButtons.tsx
@@ -3,6 +3,7 @@ import { Platform, Pressable, StyleSheet, View, ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import colors from '@/constants/colors';
 import { shadows } from '@/constants/uiStyles';
 import GlassSurface from '@/components/ui/GlassSurface';
 
@@ -16,6 +17,14 @@ interface Props {
    * El de Ajustes se mantiene siempre.
    */
   showCompartiendo?: boolean;
+  /**
+   * Muestra un botón "+" (añadir reflexión) en lugar del de Compartiendo —
+   * se usa cuando YA estamos en la pantalla Compartiendo. Su acción abre el
+   * formulario (ver `onAdd`).
+   */
+  showAdd?: boolean;
+  /** Acción del botón "+" (abre el formulario de nueva reflexión). */
+  onAdd?: () => void;
 }
 
 const H = 38;
@@ -33,6 +42,8 @@ export default function EventActionButtons({
   onSettings,
   onCompartiendo,
   showCompartiendo = true,
+  showAdd = false,
+  onAdd,
 }: Props) {
   const insets = useSafeAreaInsets();
   const scheme = useColorScheme();
@@ -60,6 +71,20 @@ export default function EventActionButtons({
                   hitSlop={6}
                 >
                   <MaterialIcons name="forum" size={20} color={fg} />
+                </Pressable>
+                <View style={[styles.divider, { backgroundColor: divider }]} />
+              </>
+            )}
+            {showAdd && (
+              <>
+                <Pressable
+                  onPress={onAdd}
+                  style={styles.half}
+                  accessibilityRole="button"
+                  accessibilityLabel="Compartir reflexión"
+                  hitSlop={6}
+                >
+                  <MaterialIcons name="add" size={24} color={colors.success} />
                 </Pressable>
                 <View style={[styles.divider, { backgroundColor: divider }]} />
               </>


### PR DESCRIPTION
Continuación de #234 (que ya se mergeó con el primer lote). Este PR trae el segundo lote, que se quedó en la rama después de cerrarse #234.

## Cambios
- **Visita Papa: barra de color superior** en toda la sección (`#FCD200`), estilo iOS de Calendario/Fotos, por encima de todo el stack del evento. — `app/(tabs)/visitapapa.tsx`
- **El "+" de añadir reflexión pasa del FAB a la barra superior** (junto a Ajustes) cuando estás en Compartiendo. Abre el formulario renavegando con `openFormNonce`. Aplicado a Visita Papa y a los eventos del tab "Más". — `EventActionButtons.tsx`, `ReflexionesScreen.tsx`, `app/(tabs)/visitapapa.tsx`, `app/(tabs)/mas.tsx`
- **Tarjetas de Compartiendo rediseñadas**: color generado de forma determinista por id, avatar con iniciales, marca de cita y dos diseños alternos (fondo tintado / barra de color) para dar variedad. Estado vacío cuando no hay reflexiones. — `ReflexionesScreen.tsx`

## Notas
- `tsc --noEmit` y ESLint en verde. Prettier OK. `CHANGELOG.md` actualizado.
- Sin paquetes nativos nuevos → OTA, no requiere build de tienda.

https://claude.ai/code/session_011P7KxnfgqDQxCkA3gSnNY2

---
_Generated by [Claude Code](https://claude.ai/code/session_011P7KxnfgqDQxCkA3gSnNY2)_