### PR TITLE
Modo Carismochito: tema verde, anillo de cuenta atrás, haptics y mascota que baila

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -45,6 +45,28 @@
   cita y dos diseños alternos (fondo tintado / tarjeta limpia con barra de
   color) para dar variedad. Estado vacío amable cuando no hay reflexiones.
 
+## 2026-06-03 — Modo Carismochito: tema verde, cuenta atrás con anillo, haptics y mascota que baila
+
+- **Tema verde "de verdad" al activar** (`utils/heroUIRuntimeTheme.ts` →
+  `setCarismochitoTheme`, `contexts/CarismochitoContext.tsx`): al entrar en el
+  modo se tiñe la capa de componentes heroui-native con varios verdes distintos
+  (accent/success/danger/warning/focus/link) reutilizando el mismo mecanismo de
+  variables CSS que el modo claro/oscuro (toggle reactivo, sin tocar los ~60
+  archivos que usan `colors` estático). Se restaura el tema base al salir o al
+  desmontar. La capa propia (StyleSheet) se cubre con el lavado verde envolvente.
+- **Cuenta atrás rediseñada** (`components/CarismochitoOverlay.tsx`): pasa a 3 s
+  con un **anillo de progreso** SVG que se vacía alrededor de la mascota que
+  baila, con el número dentro. Sustituye al número gigante anterior.
+- **Respuesta háptica** (`utils/haptics.ts`: `shake`, `carismoOn`, `carismoOff`):
+  golpe al agitar el móvil, secuencia festiva al activarse y doble golpe al
+  desactivarse/cancelar.
+- **Mascota carismochito que baila** (`components/CarismochitoMascot.tsx`): nuevo
+  componente con baile (balanceo + salto + escala). Usa un carismochito vectorial
+  de respaldo y admite un **PNG** dejándolo en `assets/images/carismochito.png` y
+  descomentando una línea `require` (interruptor documentado en el archivo).
+- Dependencias ya presentes: `expo-haptics`, `expo-sensors`, `expo-image`,
+  `react-native-svg` (sin paquetes nativos nuevos → no requiere build de tienda).
+
 ## 2026-06-02 — Eventos (Visita Papa): rediseño de headers, hero, estados vacíos y FABs
 
 - **Sub-pantallas sin header (transparente) en todas las plataformas**

--- a/mcm-app/components/CarismochitoMascot.tsx
+++ b/mcm-app/components/CarismochitoMascot.tsx
@@ -1,0 +1,237 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Easing, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
+import Svg, { Circle, Ellipse, Path } from 'react-native-svg';
+
+/* -------------------------------------------------------------------------- */
+/* PNG opcional                                                               */
+/* -------------------------------------------------------------------------- */
+/*
+ * Para usar el carismochito "de verdad" (PNG con fondo transparente):
+ *   1. Sube tu imagen a  mcm-app/assets/images/carismochito.png
+ *   2. Descomenta la línea `require(...)` de abajo y borra el `null`.
+ * Sin hacer nada, se usa el carismochito vectorial de respaldo (también baila).
+ */
+const MASCOT_PNG: number | null = null;
+// const MASCOT_PNG: number | null = require('@/assets/images/carismochito.png');
+
+/* -------------------------------------------------------------------------- */
+/* Carismochito vectorial (respaldo)                                          */
+/* -------------------------------------------------------------------------- */
+
+const SKIN = '#4FA37A';
+const SKIN_DARK = '#2E6B4F';
+const OUTLINE = '#173A2A';
+const CAP = '#7C7C82';
+const CAP_DARK = '#5C5C62';
+const MOHAWK_RED = '#E2342B';
+const MOHAWK_YEL = '#F2D43B';
+const IRIS = '#5B86B5';
+const MOUTH = '#E2342B';
+
+function CarismochitoFace({ size = 140 }: { size?: number }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 130 140">
+      {/* Cresta (mohawk) — pinchos rojos y amarillos */}
+      <Path
+        d="M60 44 L40 6 L56 44 Z"
+        fill={MOHAWK_RED}
+        stroke={OUTLINE}
+        strokeWidth={1.5}
+      />
+      <Path
+        d="M62 44 L52 0 L70 44 Z"
+        fill={MOHAWK_YEL}
+        stroke={OUTLINE}
+        strokeWidth={1.5}
+      />
+      <Path
+        d="M66 44 L70 -2 L80 44 Z"
+        fill={MOHAWK_RED}
+        stroke={OUTLINE}
+        strokeWidth={1.5}
+      />
+      <Path
+        d="M72 46 L88 8 L82 46 Z"
+        fill={MOHAWK_YEL}
+        stroke={OUTLINE}
+        strokeWidth={1.5}
+      />
+
+      {/* Orejas puntiagudas */}
+      <Path
+        d="M24 60 L6 74 L26 88 Z"
+        fill={SKIN}
+        stroke={OUTLINE}
+        strokeWidth={2}
+      />
+      <Path
+        d="M102 60 L122 74 L100 88 Z"
+        fill={SKIN}
+        stroke={OUTLINE}
+        strokeWidth={2}
+      />
+
+      {/* Cabeza */}
+      <Path
+        d="M64 20 C34 20 22 44 22 74 C22 106 40 126 64 126 C88 126 106 106 106 74 C106 44 94 20 64 20 Z"
+        fill={SKIN}
+        stroke={OUTLINE}
+        strokeWidth={2.5}
+      />
+
+      {/* Gorra (banda gris en la frente) */}
+      <Path
+        d="M26 52 Q64 30 102 52 L102 60 Q64 42 26 60 Z"
+        fill={CAP}
+        stroke={OUTLINE}
+        strokeWidth={2}
+      />
+      <Path
+        d="M26 56 Q64 38 102 56"
+        stroke={CAP_DARK}
+        strokeWidth={2}
+        fill="none"
+      />
+
+      {/* Ojos grandes */}
+      <Ellipse
+        cx="48"
+        cy="74"
+        rx="14"
+        ry="17"
+        fill="#ffffff"
+        stroke={OUTLINE}
+        strokeWidth={2}
+      />
+      <Ellipse
+        cx="80"
+        cy="74"
+        rx="14"
+        ry="17"
+        fill="#ffffff"
+        stroke={OUTLINE}
+        strokeWidth={2}
+      />
+      <Circle cx="50" cy="78" r="6.5" fill={IRIS} />
+      <Circle cx="82" cy="78" r="6.5" fill={IRIS} />
+      <Circle cx="50" cy="78" r="3" fill={OUTLINE} />
+      <Circle cx="82" cy="78" r="3" fill={OUTLINE} />
+      <Circle cx="52" cy="75" r="1.6" fill="#fff" />
+      <Circle cx="84" cy="75" r="1.6" fill="#fff" />
+
+      {/* Sonrisa + lengua */}
+      <Path
+        d="M46 100 Q64 116 82 100"
+        stroke={OUTLINE}
+        strokeWidth={3.5}
+        strokeLinecap="round"
+        fill="none"
+      />
+      <Path d="M58 107 Q64 116 70 107 Q64 113 58 107 Z" fill={MOUTH} />
+
+      {/* Mejillas */}
+      <Circle cx="34" cy="96" r="5" fill={SKIN_DARK} opacity={0.5} />
+      <Circle cx="94" cy="96" r="5" fill={SKIN_DARK} opacity={0.5} />
+    </Svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mascota que baila                                                          */
+/* -------------------------------------------------------------------------- */
+
+export default function CarismochitoMascot({
+  size = 140,
+  /** Intensidad del baile: 1 = sutil (badge), 2 = enérgico (cuenta atrás). */
+  dance = 2,
+}: {
+  size?: number;
+  dance?: 1 | 2;
+}) {
+  const sway = useRef(new Animated.Value(0)).current; // rotación + balanceo lateral
+  const bob = useRef(new Animated.Value(0)).current; // salto vertical + escala
+
+  useEffect(() => {
+    const swayLoop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(sway, {
+          toValue: 1,
+          duration: dance === 2 ? 460 : 900,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(sway, {
+          toValue: -1,
+          duration: dance === 2 ? 460 : 900,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    const bobLoop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(bob, {
+          toValue: 1,
+          duration: dance === 2 ? 300 : 700,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bob, {
+          toValue: 0,
+          duration: dance === 2 ? 300 : 700,
+          easing: Easing.in(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    swayLoop.start();
+    bobLoop.start();
+    return () => {
+      swayLoop.stop();
+      bobLoop.stop();
+    };
+  }, [sway, bob, dance]);
+
+  const rotate = sway.interpolate({
+    inputRange: [-1, 1],
+    outputRange: dance === 2 ? ['-9deg', '9deg'] : ['-4deg', '4deg'],
+  });
+  const translateX = sway.interpolate({
+    inputRange: [-1, 1],
+    outputRange: dance === 2 ? [-6, 6] : [-2, 2],
+  });
+  const translateY = bob.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, dance === 2 ? -16 : -5],
+  });
+  const scale = bob.interpolate({
+    inputRange: [0, 1],
+    outputRange: [1, dance === 2 ? 1.08 : 1.03],
+  });
+
+  return (
+    <Animated.View
+      style={{
+        transform: [{ translateX }, { translateY }, { rotate }, { scale }],
+      }}
+    >
+      {MASCOT_PNG != null ? (
+        <Image
+          source={MASCOT_PNG}
+          style={[styles.png, { width: size, height: size }]}
+          contentFit="contain"
+          transition={150}
+        />
+      ) : (
+        <CarismochitoFace size={size} />
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  png: {
+    alignSelf: 'center',
+  },
+});

--- a/mcm-app/components/CarismochitoOverlay.tsx
+++ b/mcm-app/components/CarismochitoOverlay.tsx
@@ -10,72 +10,42 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
-import Svg, { Circle, Ellipse, Path } from 'react-native-svg';
+import Svg, { Circle } from 'react-native-svg';
 import { useCarismochito } from '@/contexts/CarismochitoContext';
 import { useShakeDetector } from '@/hooks/useShakeDetector';
-import { h } from '@/utils/haptics';
+import CarismochitoMascot from '@/components/CarismochitoMascot';
 
-// Verdes deliberadamente exagerados — guiño a la mascota MCM.
-const SLIME = '#7FFF00'; // verde lima eléctrico ("muy feo")
-const SLIME_DEEP = '#5BC700';
-const SLIME_DARK = '#0D2E00';
+/* Verdes del HUD del modo (distintos tonos). */
+const G = '#1B9E4B'; // verde principal
+const G_LIGHT = '#9DE86B'; // verde lima claro
+const G_GLOW = '#5AE08A'; // verde brillo
+const G_DARK = '#06210F'; // verde casi negro
 
-/* -------------------------------------------------------------------------- */
-/* Mascota                                                                    */
-/* -------------------------------------------------------------------------- */
-
-function CarismochitoFace({ size = 140 }: { size?: number }) {
-  return (
-    <Svg width={size} height={size} viewBox="0 0 120 120">
-      {/* Aura — anillo translúcido */}
-      <Circle cx="60" cy="62" r="58" fill={SLIME} opacity={0.18} />
-      {/* Cuerpo */}
-      <Path
-        d="M60 10 C32 10 14 36 14 64 C14 90 32 110 60 110 C88 110 106 90 106 64 C106 36 88 10 60 10 Z"
-        fill={SLIME}
-      />
-      {/* Brillo */}
-      <Ellipse cx="42" cy="32" rx="14" ry="7" fill="#E8FFB8" opacity={0.85} />
-      {/* Ojos */}
-      <Circle cx="44" cy="56" r="9" fill={SLIME_DARK} />
-      <Circle cx="76" cy="56" r="9" fill={SLIME_DARK} />
-      <Circle cx="47" cy="53" r="3" fill="#fff" />
-      <Circle cx="79" cy="53" r="3" fill="#fff" />
-      {/* Sonrisa */}
-      <Path
-        d="M40 74 Q60 92 80 74"
-        stroke={SLIME_DARK}
-        strokeWidth={4}
-        strokeLinecap="round"
-        fill="none"
-      />
-      {/* Lengua */}
-      <Path d="M52 82 Q60 90 68 82 Q60 88 52 82 Z" fill="#FF6B9D" />
-      {/* Mejillas */}
-      <Circle cx="26" cy="72" r="6" fill={SLIME_DEEP} opacity={0.55} />
-      <Circle cx="94" cy="72" r="6" fill={SLIME_DEEP} opacity={0.55} />
-    </Svg>
-  );
-}
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 /* -------------------------------------------------------------------------- */
-/* Pantalla de cuenta atrás                                                   */
+/* Cuenta atrás con anillo de progreso                                        */
 /* -------------------------------------------------------------------------- */
+
+const RING_SIZE = 230;
+const RING_STROKE = 12;
+const RING_R = (RING_SIZE - RING_STROKE) / 2;
+const RING_C = 2 * Math.PI * RING_R;
 
 function CountdownScreen({
   countdown,
+  totalSeconds,
   onCancel,
 }: {
   countdown: number;
+  totalSeconds: number;
   onCancel: () => void;
 }) {
   const insets = useSafeAreaInsets();
-  // Pop-in del modal al aparecer
   const enter = useRef(new Animated.Value(0)).current;
-  // Pulso del número en cada tick
   const numberScale = useRef(new Animated.Value(1)).current;
-  // Bobbing de la mascota
-  const bob = useRef(new Animated.Value(0)).current;
+  // Progreso del anillo: 0 (lleno) → 1 (vacío) de forma continua.
+  const progress = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     Animated.spring(enter, {
@@ -84,61 +54,46 @@ function CountdownScreen({
       friction: 10,
       useNativeDriver: true,
     }).start();
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(bob, {
-          toValue: 1,
-          duration: 900,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(bob, {
-          toValue: 0,
-          duration: 900,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [enter, bob]);
+    // El anillo se vacía suavemente durante toda la cuenta atrás.
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: totalSeconds * 1000,
+      easing: Easing.linear,
+      useNativeDriver: false,
+    }).start();
+  }, [enter, progress, totalSeconds]);
 
   useEffect(() => {
-    // Pulso en cada cambio del número
-    numberScale.setValue(0.6);
+    numberScale.setValue(0.5);
     Animated.spring(numberScale, {
       toValue: 1,
       tension: 80,
       friction: 6,
       useNativeDriver: true,
     }).start();
-    h.tap();
   }, [countdown, numberScale]);
 
-  const enterOpacity = enter;
   const enterScale = enter.interpolate({
     inputRange: [0, 1],
-    outputRange: [0.92, 1],
+    outputRange: [0.9, 1],
   });
-  const bobY = bob.interpolate({
+  const dashoffset = progress.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, -10],
+    outputRange: [0, RING_C],
   });
 
   return (
     <Animated.View
-      style={[styles.countdownRoot, { opacity: enterOpacity }]}
+      style={[styles.countdownRoot, { opacity: enter }]}
       pointerEvents="auto"
     >
-      {/* Fondo en degradado verde-oscuro */}
       <LinearGradient
-        colors={['#001A00', SLIME_DARK, '#0D4400']}
+        colors={['#011A0A', G_DARK, '#0C3D1C']}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 1 }}
         style={StyleSheet.absoluteFill}
       />
-      {/* Halo de lima */}
+      {/* Halo difuso detrás */}
       <View pointerEvents="none" style={styles.haloOuter}>
         <View style={styles.halo} />
       </View>
@@ -150,28 +105,55 @@ function CountdownScreen({
           { paddingTop: insets.top + 24, paddingBottom: insets.bottom + 24 },
         ]}
       >
-        <Animated.View style={{ transform: [{ translateY: bobY }] }}>
-          <CarismochitoFace size={150} />
-        </Animated.View>
-
         <Text style={styles.activatingLabel}>activando modo</Text>
         <Text style={styles.carismoTitle}>CARISMOCHITO</Text>
 
-        <Animated.Text
-          style={[styles.number, { transform: [{ scale: numberScale }] }]}
-        >
-          {countdown}
-        </Animated.Text>
+        {/* Anillo + mascota bailando + número dentro */}
+        <View style={styles.ringBox}>
+          <Svg
+            width={RING_SIZE}
+            height={RING_SIZE}
+            style={StyleSheet.absoluteFill}
+          >
+            <Circle
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              r={RING_R}
+              stroke="rgba(255,255,255,0.12)"
+              strokeWidth={RING_STROKE}
+              fill="none"
+            />
+            <AnimatedCircle
+              cx={RING_SIZE / 2}
+              cy={RING_SIZE / 2}
+              r={RING_R}
+              stroke={G_GLOW}
+              strokeWidth={RING_STROKE}
+              strokeLinecap="round"
+              fill="none"
+              strokeDasharray={`${RING_C} ${RING_C}`}
+              strokeDashoffset={dashoffset}
+              // Empieza arriba (12 en punto).
+              transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+            />
+          </Svg>
+
+          <View style={styles.ringInner} pointerEvents="none">
+            <CarismochitoMascot size={132} dance={2} />
+            <Animated.Text
+              style={[styles.number, { transform: [{ scale: numberScale }] }]}
+            >
+              {countdown}
+            </Animated.Text>
+          </View>
+        </View>
 
         <Text style={styles.subtle}>
           Agita otra vez o pulsa Cancelar para cortar
         </Text>
 
         <Pressable
-          onPress={() => {
-            h.remove();
-            onCancel();
-          }}
+          onPress={onCancel}
           style={({ pressed }) => [
             styles.cancelBtn,
             pressed && { opacity: 0.75, transform: [{ scale: 0.98 }] },
@@ -186,7 +168,7 @@ function CountdownScreen({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Tinte + badge flotante mientras está activo                                */
+/* Tinte verde envolvente mientras está activo                                */
 /* -------------------------------------------------------------------------- */
 
 function ActiveTint() {
@@ -195,7 +177,7 @@ function ActiveTint() {
   useEffect(() => {
     Animated.timing(fade, {
       toValue: 1,
-      duration: 700,
+      duration: 600,
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
@@ -206,26 +188,28 @@ function ActiveTint() {
       pointerEvents="none"
       style={[StyleSheet.absoluteFill, styles.tintRoot, { opacity: fade }]}
     >
-      {/* Capa verde plana — el "wash" general */}
-      <View style={[StyleSheet.absoluteFill, styles.tintFlat]} />
-      {/* Viñeta superior */}
+      {/* Lavado verde de varios tonos — deja ver el contenido por debajo. */}
       <LinearGradient
-        colors={[`${SLIME}CC`, 'transparent']}
-        style={[StyleSheet.absoluteFill, { height: '40%' }]}
-      />
-      {/* Viñeta inferior */}
-      <LinearGradient
-        colors={['transparent', `${SLIME}CC`]}
-        style={[StyleSheet.absoluteFill, { top: '60%', height: '40%' }]}
+        colors={[
+          'rgba(6, 33, 15, 0.55)',
+          'rgba(27, 158, 75, 0.26)',
+          'rgba(122, 201, 67, 0.30)',
+          'rgba(6, 60, 28, 0.55)',
+        ]}
+        locations={[0, 0.35, 0.7, 1]}
+        style={StyleSheet.absoluteFill}
       />
     </Animated.View>
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/* Badge flotante                                                             */
+/* -------------------------------------------------------------------------- */
+
 function FloatingBadge({ onDeactivate }: { onDeactivate: () => void }) {
   const insets = useSafeAreaInsets();
   const enter = useRef(new Animated.Value(0)).current;
-  const bob = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     Animated.spring(enter, {
@@ -234,36 +218,12 @@ function FloatingBadge({ onDeactivate }: { onDeactivate: () => void }) {
       friction: 9,
       useNativeDriver: true,
     }).start();
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(bob, {
-          toValue: 1,
-          duration: 1100,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(bob, {
-          toValue: 0,
-          duration: 1100,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [enter, bob]);
+  }, [enter]);
 
-  const translateY = Animated.add(
-    enter.interpolate({
-      inputRange: [0, 1],
-      outputRange: [-60, 0],
-    }),
-    bob.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, -4],
-    }),
-  );
+  const translateY = enter.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-60, 0],
+  });
 
   return (
     <Animated.View
@@ -274,17 +234,14 @@ function FloatingBadge({ onDeactivate }: { onDeactivate: () => void }) {
       ]}
     >
       <Pressable
-        onPress={() => {
-          h.toggle();
-          onDeactivate();
-        }}
+        onPress={onDeactivate}
         style={({ pressed }) => [
           styles.badge,
           pressed && { transform: [{ scale: 0.97 }], opacity: 0.92 },
         ]}
         hitSlop={6}
       >
-        <CarismochitoFace size={36} />
+        <CarismochitoMascot size={38} dance={1} />
         <View style={styles.badgeText}>
           <Text style={styles.badgeTitle}>MODO CARISMOCHITO</Text>
           <Text style={styles.badgeSubtitle}>Agita o tócame para salir</Text>
@@ -299,16 +256,17 @@ function FloatingBadge({ onDeactivate }: { onDeactivate: () => void }) {
 /* -------------------------------------------------------------------------- */
 
 export default function CarismochitoOverlay() {
-  const { state, countdown, toggleByShake, cancelCountdown, deactivate } =
-    useCarismochito();
+  const {
+    state,
+    countdown,
+    countdownSeconds,
+    toggleByShake,
+    cancelCountdown,
+    deactivate,
+  } = useCarismochito();
 
   // Listener de shake siempre activo — el contexto decide qué hacer según estado.
   useShakeDetector(toggleByShake);
-
-  // Haptic + log al entrar en activo
-  useEffect(() => {
-    if (state === 'active') h.formSuccess();
-  }, [state]);
 
   return (
     <>
@@ -316,7 +274,11 @@ export default function CarismochitoOverlay() {
       {state === 'active' ? <FloatingBadge onDeactivate={deactivate} /> : null}
       {state === 'countingDown' ? (
         <View style={styles.modalRoot} pointerEvents="auto">
-          <CountdownScreen countdown={countdown} onCancel={cancelCountdown} />
+          <CountdownScreen
+            countdown={countdown}
+            totalSeconds={countdownSeconds}
+            onCancel={cancelCountdown}
+          />
         </View>
       ) : null}
     </>
@@ -333,10 +295,6 @@ const styles = StyleSheet.create({
     zIndex: 50,
     elevation: 50,
   },
-  tintFlat: {
-    backgroundColor: SLIME,
-    opacity: 0.32,
-  },
 
   /* Badge flotante */
   badgeRoot: {
@@ -350,17 +308,17 @@ const styles = StyleSheet.create({
   badge: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: SLIME_DARK,
+    backgroundColor: G_DARK,
     borderRadius: 28,
     paddingVertical: 6,
     paddingLeft: 6,
     paddingRight: 16,
     gap: 10,
     borderWidth: 2,
-    borderColor: SLIME,
+    borderColor: G,
     ...Platform.select({
       ios: {
-        shadowColor: SLIME,
+        shadowColor: G,
         shadowOffset: { width: 0, height: 6 },
         shadowOpacity: 0.55,
         shadowRadius: 18,
@@ -370,7 +328,7 @@ const styles = StyleSheet.create({
       },
       default: {
         // @ts-ignore - web only
-        boxShadow: `0px 6px 22px ${SLIME}AA`,
+        boxShadow: `0px 6px 22px ${G}AA`,
       },
     }),
   },
@@ -378,7 +336,7 @@ const styles = StyleSheet.create({
     paddingRight: 4,
   },
   badgeTitle: {
-    color: SLIME,
+    color: G_LIGHT,
     fontWeight: '900',
     fontSize: 12,
     letterSpacing: 1.4,
@@ -412,14 +370,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   halo: {
-    width: 420,
-    height: 420,
-    borderRadius: 210,
-    backgroundColor: SLIME,
-    opacity: 0.18,
+    width: 360,
+    height: 360,
+    borderRadius: 180,
+    backgroundColor: G,
+    opacity: 0.16,
     ...Platform.select({
       ios: {
-        shadowColor: SLIME,
+        shadowColor: G_GLOW,
         shadowOpacity: 0.7,
         shadowRadius: 80,
         shadowOffset: { width: 0, height: 0 },
@@ -427,17 +385,16 @@ const styles = StyleSheet.create({
       android: { elevation: 0 },
       default: {
         // @ts-ignore - web only
-        boxShadow: `0px 0px 120px ${SLIME}`,
+        boxShadow: `0px 0px 120px ${G_GLOW}`,
       },
     }),
   },
   activatingLabel: {
-    color: SLIME,
+    color: G_LIGHT,
     fontSize: 14,
     fontWeight: '600',
     letterSpacing: 4,
     textTransform: 'uppercase',
-    marginTop: 18,
     opacity: 0.85,
   },
   carismoTitle: {
@@ -446,25 +403,37 @@ const styles = StyleSheet.create({
     fontWeight: '900',
     letterSpacing: 3,
     marginTop: 4,
-    textShadowColor: SLIME,
+    marginBottom: 18,
+    textShadowColor: G_GLOW,
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 18,
   },
+  ringBox: {
+    width: RING_SIZE,
+    height: RING_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ringInner: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   number: {
-    color: SLIME,
-    fontSize: 140,
+    position: 'absolute',
+    bottom: 6,
+    color: '#ffffff',
+    fontSize: 52,
     fontWeight: '900',
-    marginTop: 8,
-    textShadowColor: SLIME,
+    textShadowColor: G_GLOW,
     textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 24,
+    textShadowRadius: 16,
     includeFontPadding: false,
-    lineHeight: 150,
   },
   subtle: {
     color: '#A3D86E',
     fontSize: 13,
-    marginTop: 4,
+    marginTop: 22,
     marginBottom: 28,
     textAlign: 'center',
     opacity: 0.85,
@@ -475,7 +444,7 @@ const styles = StyleSheet.create({
     borderRadius: 30,
     backgroundColor: '#ffffff',
     borderWidth: 2,
-    borderColor: SLIME,
+    borderColor: G,
     ...Platform.select({
       ios: {
         shadowColor: '#000',
@@ -491,7 +460,7 @@ const styles = StyleSheet.create({
     }),
   },
   cancelText: {
-    color: SLIME_DARK,
+    color: G_DARK,
     fontWeight: '800',
     fontSize: 16,
     letterSpacing: 1.2,

--- a/mcm-app/contexts/CarismochitoContext.tsx
+++ b/mcm-app/contexts/CarismochitoContext.tsx
@@ -6,23 +6,27 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { setCarismochitoTheme } from '@/utils/heroUIRuntimeTheme';
+import { h } from '@/utils/haptics';
 
 export type CarismochitoState = 'idle' | 'countingDown' | 'active';
 
 interface CarismochitoContextValue {
   state: CarismochitoState;
-  /** Segundos restantes durante la cuenta atrás (5 → 0). */
+  /** Segundos restantes durante la cuenta atrás. */
   countdown: number;
+  /** Duración total de la cuenta atrás (para animar el anillo de progreso). */
+  countdownSeconds: number;
   isActive: boolean;
   /** Acción asociada a "agitar el móvil": activa, cancela o desactiva según estado. */
   toggleByShake: () => void;
   /** Cancela la cuenta atrás (botón "Cancelar"). */
   cancelCountdown: () => void;
-  /** Desactiva el modo (tocando el badge flotante). */
+  /** Desactiva el modo (tocando el badge flotante o agitando). */
   deactivate: () => void;
 }
 
-const COUNTDOWN_SECONDS = 5;
+const COUNTDOWN_SECONDS = 3;
 
 const Ctx = createContext<CarismochitoContextValue | null>(null);
 
@@ -44,6 +48,9 @@ export function CarismochitoProvider({
   const [state, setState] = useState<CarismochitoState>('idle');
   const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Espejo del estado para decidir en `toggleByShake` sin setState anidado.
+  const stateRef = useRef<CarismochitoState>(state);
+  stateRef.current = state;
 
   const stopTimer = useCallback(() => {
     if (intervalRef.current) {
@@ -56,15 +63,20 @@ export function CarismochitoProvider({
     stopTimer();
     setCountdown(COUNTDOWN_SECONDS);
     setState('countingDown');
+    let remaining = COUNTDOWN_SECONDS;
     intervalRef.current = setInterval(() => {
-      setCountdown((c) => {
-        if (c <= 1) {
-          stopTimer();
-          setState('active');
-          return 0;
-        }
-        return c - 1;
-      });
+      remaining -= 1;
+      if (remaining <= 0) {
+        stopTimer();
+        setCountdown(0);
+        setState('active');
+        // Recolorea la capa heroui en verde + golpe háptico de celebración.
+        setCarismochitoTheme(true);
+        h.carismoOn();
+      } else {
+        setCountdown(remaining);
+        h.tap();
+      }
     }, 1000);
   }, [stopTimer]);
 
@@ -72,37 +84,46 @@ export function CarismochitoProvider({
     stopTimer();
     setCountdown(COUNTDOWN_SECONDS);
     setState('idle');
+    h.carismoOff();
   }, [stopTimer]);
 
   const deactivate = useCallback(() => {
     stopTimer();
     setCountdown(COUNTDOWN_SECONDS);
     setState('idle');
+    setCarismochitoTheme(false);
+    h.carismoOff();
   }, [stopTimer]);
 
   const toggleByShake = useCallback(() => {
-    setState((prev) => {
-      if (prev === 'idle') {
-        startCountdown();
-        return 'countingDown';
-      }
-      if (prev === 'countingDown') {
-        cancelCountdown();
-        return 'idle';
-      }
+    // Cada agitado confirmado da respuesta háptica, decida lo que decida.
+    h.shake();
+    const prev = stateRef.current;
+    if (prev === 'idle') {
+      startCountdown();
+    } else if (prev === 'countingDown') {
+      cancelCountdown();
+    } else {
       // active → desactivar
       deactivate();
-      return 'idle';
-    });
+    }
   }, [startCountdown, cancelCountdown, deactivate]);
 
-  useEffect(() => () => stopTimer(), [stopTimer]);
+  // Limpieza: parar timer y restaurar el tema si se desmonta en activo.
+  useEffect(
+    () => () => {
+      stopTimer();
+      setCarismochitoTheme(false);
+    },
+    [stopTimer],
+  );
 
   return (
     <Ctx.Provider
       value={{
         state,
         countdown,
+        countdownSeconds: COUNTDOWN_SECONDS,
         isActive: state === 'active',
         toggleByShake,
         cancelCountdown,

--- a/mcm-app/utils/haptics.ts
+++ b/mcm-app/utils/haptics.ts
@@ -66,4 +66,39 @@ export const h = {
       250,
     );
   },
+
+  // --- Carismochito (easter egg) ---
+  /** Golpe seco al detectar el agitado del móvil. */
+  shake: () =>
+    isNative &&
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {}),
+
+  /** Secuencia festiva al ACTIVAR el modo carismochito. */
+  carismoOn: () => {
+    if (!isNative) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+    setTimeout(
+      () =>
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy).catch(() => {}),
+      90,
+    );
+    setTimeout(
+      () =>
+        Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        ).catch(() => {}),
+      220,
+    );
+  },
+
+  /** Doble golpe rígido al DESACTIVAR el modo carismochito. */
+  carismoOff: () => {
+    if (!isNative) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Rigid).catch(() => {});
+    setTimeout(
+      () =>
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {}),
+      110,
+    );
+  },
 };

--- a/mcm-app/utils/heroUIRuntimeTheme.ts
+++ b/mcm-app/utils/heroUIRuntimeTheme.ts
@@ -147,6 +147,55 @@ const darkThemeVars = {
   '--color-border-tertiary': '#7a7a80',
 } as const;
 
+/*
+ * Modo CARISMOCHITO (easter egg): tiñe la familia de colores "de marca" de
+ * heroui-native con varios verdes distintos, reutilizando el mismo mecanismo
+ * de variables CSS que usa el modo claro/oscuro. Se aplica fusionando estos
+ * overrides sobre el mapa base de cada esquema, así no se pierde ninguna
+ * variable. Al salir se restaura el mapa base.
+ */
+const carismochitoOverridesLight = {
+  '--color-accent': '#1b9e4b',
+  '--color-accent-foreground': '#ffffff',
+  '--color-accent-hover': '#16823e',
+  '--color-accent-soft': 'rgba(27, 158, 75, 0.15)',
+  '--color-accent-soft-foreground': '#15823c',
+  '--color-accent-soft-hover': 'rgba(27, 158, 75, 0.22)',
+  '--color-focus': '#1b9e4b',
+  '--color-link': '#1b9e4b',
+  '--color-success': '#7ac943',
+  '--color-success-foreground': '#11321a',
+  '--color-success-hover': '#6bb838',
+  '--color-success-soft': 'rgba(122, 201, 67, 0.2)',
+  '--color-success-soft-foreground': '#3f6110',
+  '--color-danger': '#2bb673',
+  '--color-danger-foreground': '#ffffff',
+  '--color-danger-hover': '#23a165',
+  '--color-danger-soft': 'rgba(43, 182, 115, 0.16)',
+  '--color-danger-soft-foreground': '#1c7a4d',
+  '--color-warning': '#aecf2f',
+  '--color-warning-foreground': '#11321a',
+} as const;
+
+const carismochitoOverridesDark = {
+  '--color-accent': '#27c25c',
+  '--color-accent-foreground': '#06210f',
+  '--color-accent-hover': '#33d268',
+  '--color-accent-soft': 'rgba(39, 194, 92, 0.2)',
+  '--color-accent-soft-foreground': '#8de8a8',
+  '--color-accent-soft-hover': 'rgba(39, 194, 92, 0.26)',
+  '--color-focus': '#27c25c',
+  '--color-link': '#7ee29a',
+  '--color-success': '#8edb52',
+  '--color-success-foreground': '#06210f',
+  '--color-success-hover': '#9fe863',
+  '--color-danger': '#2fd189',
+  '--color-danger-foreground': '#06210f',
+  '--color-danger-hover': '#3fe098',
+  '--color-warning': '#c4e25a',
+  '--color-warning-foreground': '#06210f',
+} as const;
+
 let runtimeThemeRegistered = false;
 
 export function registerHeroUIRuntimeTheme() {
@@ -162,4 +211,25 @@ export function registerHeroUIRuntimeTheme() {
 export function syncHeroUITheme(theme: ThemeScheme) {
   registerHeroUIRuntimeTheme();
   Uniwind.setTheme(theme);
+}
+
+/**
+ * Activa (`true`) o restaura (`false`) la paleta verde del modo carismochito
+ * sobre la capa de componentes heroui-native. Reactivo, sin recargar nada.
+ */
+export function setCarismochitoTheme(active: boolean) {
+  registerHeroUIRuntimeTheme();
+  if (active) {
+    Uniwind.updateCSSVariables('light', {
+      ...lightThemeVars,
+      ...carismochitoOverridesLight,
+    });
+    Uniwind.updateCSSVariables('dark', {
+      ...darkThemeVars,
+      ...carismochitoOverridesDark,
+    });
+  } else {
+    Uniwind.updateCSSVariables('light', lightThemeVars);
+    Uniwind.updateCSSVariables('dark', darkThemeVars);
+  }
 }


### PR DESCRIPTION
Mejora del easter egg **modo Carismochito** (se activa agitando el móvil).

## Qué cambia

- **Tema verde reactivo al activar** (`utils/heroUIRuntimeTheme.ts` → `setCarismochitoTheme`, `contexts/CarismochitoContext.tsx`): al entrar en el modo se tiñe la capa de componentes heroui-native con varios verdes distintos (accent / success / danger / warning / focus / link) reutilizando **el mismo mecanismo de variables CSS que el modo claro/oscuro** — toggle reactivo, sin refactorizar los ~60 archivos que usan `colors` estático. Se restaura el tema base al salir o al desmontar.
- **Cuenta atrás rediseñada** (`components/CarismochitoOverlay.tsx`): de número gigante a un **anillo de progreso SVG** que se vacía alrededor de la mascota que baila, con el número dentro. Bajada a 3 s.
- **Respuesta háptica** (`utils/haptics.ts`): `shake` (al agitar), `carismoOn` (al activarse) y `carismoOff` (al desactivar/cancelar).
- **Mascota que baila** (`components/CarismochitoMascot.tsx`): nuevo componente con baile (balanceo + salto + escala). Carismochito vectorial de respaldo + **interruptor de una línea** para enchufar un PNG en `assets/images/carismochito.png`.
- **Capa verde envolvente** de varios tonos sobre el resto de la app (lo que pinta con `StyleSheet` y no puede recolorearse con el swap de tema).

## Notas

- No hay paquetes nativos nuevos (`expo-haptics`, `expo-sensors`, `expo-image`, `react-native-svg` ya eran dependencias) → **no requiere build de tienda**.
- Pendiente opcional: subir el PNG real del carismochito a `assets/images/carismochito.png` y descomentar la línea `require` en `CarismochitoMascot.tsx` (documentado en el archivo). Mientras tanto se usa el carismochito vectorial, que también baila.

## Verificación

- `npm run typecheck` → 0 errores
- ESLint → 0 problemas

https://claude.ai/code/session_011NRxKKcXcSgM8EqdHZ7GJm

---
_Generated by [Claude Code](https://claude.ai/code/session_011NRxKKcXcSgM8EqdHZ7GJm)_