### PR TITLE
Update VISITAPAPA event label from "Visitas" to "Sectores Eventos"

### DIFF
--- a/mcm-app/constants/events.ts
+++ b/mcm-app/constants/events.ts
@@ -210,7 +210,7 @@ export const VISITAPAPA: EventConfig = {
       url: 'https://maps.app.goo.gl/7DEtUhW1tfrnY9Sk7',
     },
     {
-      label: 'Visitas',
+      label: 'Sectores Eventos',
       subtitle: 'Salidas y traslados',
       emoji: '🚌',
       materialIcon: 'directions-bus',


### PR DESCRIPTION
## Summary
Updated the label for the VISITAPAPA event's bus/transportation section to better reflect its purpose as event sectors rather than generic visits.

## Changes
- Changed the `label` field in the VISITAPAPA event configuration from `'Visitas'` to `'Sectores Eventos'` to more accurately describe the departures and transfers section

## Details
This is a cosmetic update to the event configuration that improves clarity for users viewing the VISITAPAPA event details. The section handles event-related transportation and sector organization, which is now more clearly communicated through the updated label.

https://claude.ai/code/session_019bHSnduqTW17HqVQhTE2c3