### PR TITLE
Refactor ProfundizaScreen to support multiple sections

### DIFF
--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -22,6 +22,89 @@ interface Pagina {
   color?: string;
 }
 
+interface Seccion {
+  titulo?: string;
+  introduccion?: string;
+  paginas?: Pagina[];
+}
+
+// Firebase puede devolver un objeto único o un array de secciones
+type ProfundizaData = Seccion | Seccion[];
+
+function normalizeSecciones(raw: ProfundizaData | null): Seccion[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  return [raw];
+}
+
+function AccordionSection({
+  seccion,
+  styles,
+  fontScale,
+  globalOpenIdx,
+  baseIdx,
+  onToggle,
+}: {
+  seccion: Seccion;
+  styles: ReturnType<typeof createStyles>;
+  fontScale: number;
+  globalOpenIdx: number | null;
+  baseIdx: number;
+  onToggle: (idx: number) => void;
+}) {
+  const paginas = Array.isArray(seccion.paginas) ? seccion.paginas : [];
+  return (
+    <View style={{ marginBottom: 24 }}>
+      {seccion.titulo ? (
+        <Text style={styles.seccionTitulo}>{seccion.titulo}</Text>
+      ) : null}
+      {seccion.introduccion ? (
+        <View style={{ marginBottom: 12 }}>
+          <FormattedContent text={seccion.introduccion} scale={fontScale} />
+        </View>
+      ) : null}
+      {paginas.map((p, i) => {
+        const idx = baseIdx + i;
+        const open = globalOpenIdx === idx;
+        return (
+          <View key={idx} style={styles.accordionWrapper}>
+            <PressableFeedback
+              onPress={() => {
+                h.toggle();
+                onToggle(idx);
+              }}
+              style={[
+                styles.accordion,
+                { backgroundColor: p.color || colors.primary },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={p.titulo}
+            >
+              <PressableFeedback.Highlight />
+              <Text style={styles.accordionTitle}>{p.titulo}</Text>
+              <MaterialIcons
+                name={open ? 'expand-less' : 'expand-more'}
+                size={24}
+                color={colors.white}
+              />
+            </PressableFeedback>
+            {open && (
+              <View style={styles.accordionContent}>
+                {p.subtitulo && (
+                  <Text style={styles.subtitulo}>{p.subtitulo}</Text>
+                )}
+                {p.texto && (
+                  <FormattedContent text={p.texto} scale={fontScale} />
+                )}
+              </View>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
 export default function ProfundizaScreen() {
   const scheme = useColorScheme();
   const fontScale = useFontScale(1.2);
@@ -30,26 +113,22 @@ export default function ProfundizaScreen() {
     [scheme, fontScale],
   );
   const event = useCurrentEvent();
-  const { data: profundizaData, loading } = useFirebaseData<any>(
+  const { data: profundizaData, loading } = useFirebaseData<ProfundizaData>(
     getEventFirebasePath(event, 'profundiza'),
     getEventCacheKey(event, 'profundiza'),
   );
-  const data = profundizaData as {
-    titulo?: string;
-    introduccion?: string;
-    paginas?: Pagina[];
-  } | null;
 
   const [openIdx, setOpenIdx] = useState<number | null>(null);
 
-  // Defensa frente a datos ausentes o mal formados (antes `data.paginas.map`
-  // reventaba si Firebase venía vacío o sin `paginas`).
-  const paginas = Array.isArray(data?.paginas) ? data!.paginas! : [];
-  const hasContent = !!(data && (data.introduccion || paginas.length > 0));
+  const secciones = normalizeSecciones(profundizaData ?? null);
+  const hasContent = secciones.some(
+    (s) =>
+      s.introduccion ||
+      (Array.isArray(s.paginas) && s.paginas.length > 0),
+  );
 
   if (!hasContent) {
-    // Aún cargando (sin caché) → esqueleto. Cargado pero vacío → "Próximamente".
-    if (loading && !data) {
+    if (loading && !profundizaData) {
       return (
         <PageContainer>
           <ScrollView
@@ -87,53 +166,39 @@ export default function ProfundizaScreen() {
     );
   }
 
+  // Calcular el índice base de cada sección para que el acordeón global funcione
+  const baseIdxes: number[] = [];
+  let acc = 0;
+  for (const s of secciones) {
+    baseIdxes.push(acc);
+    acc += Array.isArray(s.paginas) ? s.paginas.length : 0;
+  }
+
+  // Título del hero: primera sección con título, o genérico
+  const heroTitle =
+    secciones.length === 1 && secciones[0].titulo
+      ? secciones[0].titulo
+      : 'Profundiza';
+
   return (
     <PageContainer>
       <ScrollView
         style={styles.container}
         contentContainerStyle={styles.content}
       >
-        <ScreenHero title={data!.titulo || 'Profundiza'} hideOnWeb />
+        <ScreenHero title={heroTitle} hideOnWeb />
         <View style={styles.body}>
-          {data!.introduccion ? (
-            <FormattedContent text={data!.introduccion} scale={fontScale} />
-          ) : null}
-          <View style={{ marginTop: 16 }}>
-            {paginas.map((p, idx) => (
-              <View key={idx} style={styles.accordionWrapper}>
-                <PressableFeedback
-                  onPress={() => {
-                    h.toggle();
-                    setOpenIdx(openIdx === idx ? null : idx);
-                  }}
-                  style={[
-                    styles.accordion,
-                    { backgroundColor: p.color || colors.primary },
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel={p.titulo}
-                >
-                  <PressableFeedback.Highlight />
-                  <Text style={styles.accordionTitle}>{p.titulo}</Text>
-                  <MaterialIcons
-                    name={openIdx === idx ? 'expand-less' : 'expand-more'}
-                    size={24}
-                    color={colors.white}
-                  />
-                </PressableFeedback>
-                {openIdx === idx && (
-                  <View style={styles.accordionContent}>
-                    {p.subtitulo && (
-                      <Text style={styles.subtitulo}>{p.subtitulo}</Text>
-                    )}
-                    {p.texto && (
-                      <FormattedContent text={p.texto} scale={fontScale} />
-                    )}
-                  </View>
-                )}
-              </View>
-            ))}
-          </View>
+          {secciones.map((s, si) => (
+            <AccordionSection
+              key={si}
+              seccion={s}
+              styles={styles}
+              fontScale={fontScale}
+              globalOpenIdx={openIdx}
+              baseIdx={baseIdxes[si]}
+              onToggle={(idx) => setOpenIdx(openIdx === idx ? null : idx)}
+            />
+          ))}
         </View>
       </ScrollView>
     </PageContainer>
@@ -149,6 +214,12 @@ const createStyles = (scheme: 'light' | 'dark' | null, scale: number) => {
       paddingBottom: Platform.OS === 'ios' ? 100 : 16,
     },
     body: { paddingHorizontal: 20, paddingTop: 8 },
+    seccionTitulo: {
+      fontWeight: 'bold',
+      fontSize: 18 * scale,
+      color: theme.text,
+      marginBottom: 8,
+    },
     accordionWrapper: { marginBottom: 12 },
     accordion: {
       flexDirection: 'row',


### PR DESCRIPTION
## Summary
Refactored the ProfundizaScreen to support multiple accordion sections instead of a single flat list of pages. This enables more flexible content organization while maintaining backward compatibility with existing single-section data structures.

## Key Changes
- **New `Seccion` interface**: Introduced a section structure with `titulo`, `introduccion`, and `paginas` fields
- **Data normalization**: Added `normalizeSecciones()` utility to handle Firebase returning either a single section object or an array of sections
- **Component extraction**: Created `AccordionSection` component to encapsulate section rendering logic, reducing duplication and improving maintainability
- **Global accordion state**: Modified accordion index tracking to work across multiple sections using base indices, ensuring only one accordion item is open at a time across all sections
- **Hero title logic**: Updated to use the first section's title when there's a single section, or default to "Profundiza" for multiple sections
- **Type safety**: Improved TypeScript typing with explicit `ProfundizaData` type instead of `any`
- **Styling**: Added `seccionTitulo` style for section headers

## Implementation Details
- The accordion state now uses a global index calculated as `baseIdx + itemIndex` per section, allowing proper state management across multiple sections
- Defensive checks ensure graceful handling of missing or malformed data (e.g., missing `paginas` array)
- The refactoring maintains all existing functionality while enabling future multi-section content structures

https://claude.ai/code/session_01LqL9zyabgz8wz1cdpRHdYF