### PR TITLE
fix(android): onboarding login cancelado, botón saltar en zona segura y toasts visibles

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,24 @@
 
 ---
 
+## 2026-06-05 — Fixes onboarding Android: login, botón "saltar" y toasts
+
+- **Login con Google en Android ya no muestra error al cancelar**: al cerrar el
+  selector de cuenta, `@react-native-google-signin` v13+ devuelve
+  `{ type: 'cancelled' }` (o lanza `SIGN_IN_CANCELLED`). Antes se trataba como
+  un fallo real y aparecía el toast "No se pudo iniciar sesión". Ahora se
+  normaliza a `ERR_CANCELED` y se ignora como una cancelación normal.
+  Archivo: `utils/platformAuth.native.ts`.
+- **Botón "Entrar sin iniciar sesión" reubicado en zona segura**: en el paso de
+  login del onboarding el enlace inferior quedaba bajo la barra de navegación de
+  3 botones de Android y no se podía pulsar. Ahora respeta el safe-area inferior
+  (`insets.bottom`) y se presenta como botón tipo píldora, más visible y con
+  mayor área de toque. Archivo: `app/onboarding.tsx`.
+- **Toasts ya no quedan ocultos bajo la barra de 3 botones en Android**: se sube
+  el margen inferior mínimo del toast para garantizar que despeja la barra de
+  navegación aunque el inset reportado sea 0. Archivo:
+  `contexts/AppToastContext.tsx`.
+
 ## 2026-06-05 — Modo Carismochito: persistente y menos intrusivo
 
 - **Persiste al cerrar y reabrir la app**: si el modo queda activo, se recuerda

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -1464,21 +1464,36 @@ function LoginOnboardingScreen({
         )}
       </View>
 
-      {/* Cuando NO hay sesión, enlace inferior para continuar sin cuenta
-          (lleva al resumen final). */}
+      {/* Cuando NO hay sesión, botón inferior para continuar sin cuenta
+          (lleva al resumen final). Respetamos el safe-area inferior para que
+          en Android no quede bajo la barra de navegación de 3 botones y se
+          pueda pulsar sin problema. */}
       {!user && (
         <Animated.View
           entering={FadeInUp.delay(320).duration(380)}
-          style={loginOnbStyles.skipWrap}
+          style={[
+            loginOnbStyles.skipWrap,
+            { paddingBottom: Math.max(insets.bottom + 12, 20) },
+          ]}
         >
           <Pressable
             onPress={onSkip}
-            hitSlop={10}
+            hitSlop={{ top: 12, bottom: 12, left: 16, right: 16 }}
             accessibilityRole="button"
             accessibilityLabel="Continuar sin cuenta"
-            style={({ pressed }) => [pressed && { opacity: 0.65 }]}
+            style={({ pressed }) => [
+              loginOnbStyles.skipBtn,
+              pressed && { opacity: 0.6 },
+            ]}
           >
-            <Text style={loginOnbStyles.skipText}>Entrar en la app sin iniciar sesión →</Text>
+            <Text style={loginOnbStyles.skipText}>
+              Entrar sin iniciar sesión
+            </Text>
+            <MaterialIcons
+              name="arrow-forward"
+              size={16}
+              color="rgba(255,255,255,0.9)"
+            />
           </Pressable>
         </Animated.View>
       )}
@@ -1579,13 +1594,27 @@ const loginOnbStyles = StyleSheet.create({
     fontWeight: '600',
   } as TextStyle,
   skipWrap: {
-    paddingBottom: Platform.OS === 'ios' ? 32 : 24,
+    paddingTop: 8,
+    paddingHorizontal: 24,
     alignItems: 'center',
   } as ViewStyle,
+  skipBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 12,
+    paddingHorizontal: 22,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.14)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.28)',
+  } as ViewStyle,
   skipText: {
-    color: 'rgba(255,255,255,0.55)',
-    fontSize: 13,
-    fontWeight: '500',
+    color: 'rgba(255,255,255,0.9)',
+    fontSize: 14,
+    fontWeight: '600',
+    letterSpacing: -0.1,
   } as TextStyle,
 });
 

--- a/mcm-app/contexts/AppToastContext.tsx
+++ b/mcm-app/contexts/AppToastContext.tsx
@@ -187,10 +187,12 @@ function ToastItem({
   const v = VARIANT_STYLES[t.variant ?? 'default'];
   // Extra breathing room above the tab bar / home indicator — much more
   // than the previous build, which felt glued to the edge on iOS.
+  // En Android el mínimo es más alto para que el toast nunca quede oculto bajo
+  // la barra de navegación de 3 botones (≈48dp) cuando el inset reportado es 0.
   const bottomOffset =
     Platform.OS === 'ios'
       ? Math.max(insets.bottom + 18, 36)
-      : Math.max(insets.bottom + 12, 24);
+      : Math.max(insets.bottom + 16, 56);
 
   const useBlur = Platform.OS === 'ios';
 

--- a/mcm-app/utils/platformAuth.native.ts
+++ b/mcm-app/utils/platformAuth.native.ts
@@ -51,7 +51,32 @@ export async function configureGoogleSignIn(): Promise<void> {
 export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
   const GoogleSignin = await getGoogleSignin();
   await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
-  const response = await GoogleSignin.signIn();
+  let response;
+  try {
+    response = await GoogleSignin.signIn();
+  } catch (err: any) {
+    // En Android, cerrar el selector de cuenta lanza SIGN_IN_CANCELLED.
+    // Lo normalizamos a ERR_CANCELED para que la capa superior (AuthContext)
+    // lo trate como cancelación y NO muestre un toast de error.
+    if (
+      err?.code === '12501' || // statusCodes.SIGN_IN_CANCELLED (Android)
+      err?.code === 'SIGN_IN_CANCELLED' ||
+      err?.code === 'ERR_CANCELED'
+    ) {
+      const cancelled: any = new Error('Google Sign-In cancelado');
+      cancelled.code = 'ERR_CANCELED';
+      throw cancelled;
+    }
+    throw err;
+  }
+  // En @react-native-google-signin v13+ una cancelación NO lanza: devuelve
+  // `{ type: 'cancelled', data: null }`. La detectamos para no tratarla como
+  // un fallo real.
+  if (response?.type === 'cancelled') {
+    const cancelled: any = new Error('Google Sign-In cancelado');
+    cancelled.code = 'ERR_CANCELED';
+    throw cancelled;
+  }
   if (!response.data?.idToken) {
     throw new Error('Google Sign-In: no se recibió idToken');
   }


### PR DESCRIPTION
## Fixes de onboarding en Android

Tres arreglos reportados desde el onboarding en Android. Todo es **JS-only** (sin paquetes nativos nuevos), apto para OTA.

### 1. Login con Google ya no muestra error al cancelar
`@react-native-google-signin` v13+ **no lanza** al cancelar el selector de cuenta: devuelve `{ type: 'cancelled' }`. El código antiguo lo trataba como `no se recibió idToken` → fallo real → toast rojo **"No se pudo iniciar sesión"** aunque solo hubieras cerrado el diálogo. Ahora se detecta tanto `{ type: 'cancelled' }` como el código nativo `SIGN_IN_CANCELLED` y se normalizan a `ERR_CANCELED` (cancelación silenciosa, sin toast de error).
- `utils/platformAuth.native.ts`

### 2. Botón "Entrar sin iniciar sesión" reubicado en zona segura
El enlace inferior tenía un `paddingBottom` fijo de 24px que no despejaba la barra de 3 botones de Android → quedaba debajo y no se podía pulsar. Ahora respeta el safe-area inferior (`insets.bottom`), se presenta como botón tipo píldora más visible y con mayor área de toque.
- `app/onboarding.tsx`

### 3. Toasts ocultos bajo la barra de 3 botones en Android
Se sube el margen inferior mínimo del toast (`Math.max(insets.bottom + 16, 56)`) para garantizar que despeja la barra de navegación aunque el inset reportado sea 0.
- `contexts/AppToastContext.tsx`

## Verificación
- `tsc --noEmit`: 0 errores
- `npm run lint`: limpio en los archivos tocados
- Documentado en `CHANGELOG.md`

https://claude.ai/code/session_01RCbhaibATb1o3KUPFKaPk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCbhaibATb1o3KUPFKaPk7)_