### PR TITLE
Arreglar botones de calendario en iOS + mejoras de notificaciones (Home y deep-link)

### DIFF
--- a/NOTIFICACIONES.md
+++ b/NOTIFICACIONES.md
@@ -145,6 +145,28 @@ Una notificación puede tener los dos:
 
 Si no hay `internalRoute` ni `actionButton`, la notificación solo muestra título, cuerpo y fecha. El modal sigue siendo accesible tocando la tarjeta.
 
+Al tocar la push desde la bandeja del sistema, la app abre el centro de
+notificaciones y **despliega automáticamente esa notificación en grande**
+(deep-link interno `/notifications?openId=<id>`). Para que el `openId` haga
+match con la notificación correcta, el panel **debe** enviar `data.id` con el
+mismo ID que la notificación tiene en Firebase (ver "Abrir la notificación en
+grande" más abajo).
+
+### Abrir la notificación en grande (deep-link al detalle)
+
+Para que al pulsar una push se abra directamente esa notificación en su vista
+de detalle dentro de la app:
+
+1. **Envía siempre `data.id`** con el ID de la notificación en Firebase
+   (`notifications/<id>`). La app lo usa como identificador estable y como
+   `openId` del deep-link.
+2. **No pongas `internalRoute`** (o ponlo a `/notifications`) si lo que quieres
+   es que la notificación se abra "en grande" en el centro de notificaciones.
+   Si pones otra `internalRoute`, la app navegará a esa sección en su lugar.
+
+Con esto, tocar la notificación abre `/notifications?openId=<id>` y la app
+despliega el detalle de esa notificación automáticamente.
+
 ---
 
 ### Flujo completo de interacción
@@ -152,8 +174,10 @@ Si no hay `internalRoute` ni `actionButton`, la notificación solo muestra títu
 ```
 Usuario recibe push notification
 └── Toca desde bandeja del sistema
-    ├── Tiene internalRoute → navega directamente a esa sección
-    └── Sin internalRoute → abre la app en la pantalla de notificaciones
+    ├── Tiene internalRoute (≠ /notifications) → navega directamente a esa sección
+    └── Sin internalRoute (o internalRoute = /notifications)
+        → abre el centro de notificaciones Y despliega esa notificación
+          concreta en grande (deep-link /notifications?openId=<id>)
 
 Usuario abre pantalla de notificaciones
 └── Ve lista de tarjetas

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,31 @@
 
 ---
 
+## 2026-06-05 — Fixes de calendario y notificaciones (Home + deep-link)
+
+- **Botones de calendario de la Home arreglados en iOS**: las tarjetas de
+  "Próximos eventos", el botón "Ver calendario" y el CTA de "Ir al calendario"
+  no hacían nada en iOS. Causa: en iOS `calendario` (y `fotos`) son tabs
+  _overflow_ sin trigger nativo (solo caben 5 en la barra), así que
+  `router.push('/calendario')` no navegaba. Ahora la Home los alcanza vía el
+  stack de "Más" (igual que el acceso de Fotos); en Android/Web siguen yendo al
+  tab directo. El salto a fecha concreta también funciona en iOS.
+- **La tarjeta de Novedades abre la última notificación "en grande"**: al tocar
+  la tarjeta de la Home se abre directamente el detalle de la última
+  notificación, en vez de la lista completa. La campana del header sigue
+  abriendo la lista.
+- **Sin título duplicado en el detalle**: el bottom sheet de notificaciones ya
+  no repite el título de la notificación en su cabecera cuando se ve el detalle
+  (solo queda la flecha de volver).
+- **Deep-link de push → detalle de la notificación**: al tocar una notificación
+  desde la bandeja del sistema, la app abre el centro de notificaciones y
+  despliega esa notificación concreta (`/notifications?openId=<id>`). Si la
+  notificación trae `internalRoute`, se respeta ese destino.
+- Archivos: `app/(tabs)/index.tsx`, `app/(tabs)/calendario.tsx`,
+  `app/notifications.tsx`, `components/NotificationsBottomSheet.tsx`,
+  `notifications/usePushNotifications.ts`, `utils/masNavigation.ts`,
+  `app/screens/MasHomeScreen.tsx`.
+
 ## 2026-06-05 — Fixes onboarding Android: login, botón "saltar" y toasts
 
 - **Login con Google en Android ya no muestra error al cancelar**: al cerrar el

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -26,6 +26,7 @@ import { useCalendarConfig } from '@/contexts/CalendarConfigContext';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import OfflineBanner from '@/components/OfflineBanner';
 import { useLocalSearchParams } from 'expo-router';
+import { useRoute } from '@react-navigation/native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { hexAlpha } from '@/utils/colorUtils';
 import { h } from '@/utils/haptics';
@@ -80,6 +81,13 @@ export default function Calendario() {
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const isDark = scheme === 'dark';
   const params = useLocalSearchParams<{ date?: string }>();
+  // En iOS, `calendario` es un tab "overflow" sin trigger nativo: se navega
+  // desde el stack de Más (React Navigation), cuyos params NO llegan a
+  // `useLocalSearchParams` (que sólo lee la URL de expo-router). Leemos también
+  // los params de React Navigation para soportar el salto a fecha desde Home.
+  const navRoute = useRoute();
+  const navParamDate = (navRoute.params as { date?: string } | undefined)?.date;
+  const dateParam = params.date ?? navParamDate;
 
   const {
     calendarConfigs,
@@ -97,10 +105,10 @@ export default function Calendario() {
   const [detailsEvent, setDetailsEvent] = useState<CalendarEvent | null>(null);
 
   useEffect(() => {
-    if (params.date && typeof params.date === 'string') {
-      setSelectedDate(params.date);
+    if (dateParam && typeof dateParam === 'string') {
+      setSelectedDate(dateParam);
     }
-  }, [params.date]);
+  }, [dateParam]);
 
   const { eventsByDate, loading: eventsLoading } =
     useCalendarEvents(calendarConfigs);

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -56,6 +56,7 @@ import {
   getLocalNotificationsHistory,
   isNotificationOlderThan60Days,
 } from '@/services/pushNotificationService';
+import { NotificationData } from '@/types/notifications';
 import { useCalendarConfig } from '@/contexts/CalendarConfigContext';
 import { useOTAContext } from '@/contexts/OTAContext';
 import { h } from '@/utils/haptics';
@@ -186,6 +187,10 @@ export default function Home() {
   const [settingsVisible, setSettingsVisibleRaw] = useState(false);
   const [feedbackVisible, setFeedbackVisible] = useState(false);
   const [notifSheetOpen, setNotifSheetOpenRaw] = useState(false);
+  // Cuando se abre desde la tarjeta de Novedades queremos mostrar el detalle de
+  // la última notificación "en grande"; desde la campana, la lista completa.
+  const [notifSheetInitial, setNotifSheetInitial] =
+    useState<NotificationData | null>(null);
 
   // Settings and notifications panels must be mutually exclusive: opening
   // one auto-closes the other. Otherwise both panels stack visually and
@@ -447,6 +452,23 @@ export default function Home() {
     }
   };
 
+  // Navega al calendario (opcionalmente saltando a una fecha concreta).
+  // En iOS `calendario` es un tab "overflow" SIN trigger nativo (solo caben 5
+  // en la barra), por lo que `router.push('/calendario')` no funciona: hay que
+  // alcanzarlo a través del stack de "Más" igual que hace el acceso de Fotos.
+  // En Android/Web `calendario` es un tab real, así que navegamos directo.
+  const navigateToCalendar = (date?: string) => {
+    h.tap();
+    if (Platform.OS === 'ios') {
+      setPendingMasScreen('Calendario', date ? { date } : undefined);
+      router.push('/mas');
+    } else if (date) {
+      router.push({ pathname: '/calendario', params: { date } } as any);
+    } else {
+      router.push('/calendario');
+    }
+  };
+
   return (
     <SafeAreaView
       style={[styles.safeArea, { backgroundColor: theme.background }]}
@@ -471,6 +493,7 @@ export default function Home() {
       <NotificationsBottomSheet
         visible={notifSheetOpen}
         onClose={() => setNotifSheetOpen(false)}
+        initialNotification={notifSheetInitial}
       />
 
       {/* ── App-bar header (ScreenHero in compact mode) ── */}
@@ -540,7 +563,10 @@ export default function Home() {
                           : 'rgba(0,0,0,0.08)',
                     },
                   ]}
-                  onPress={() => setNotifSheetOpen(true)}
+                  onPress={() => {
+                    setNotifSheetInitial(null);
+                    setNotifSheetOpen(true);
+                  }}
                   accessibilityLabel={
                     unreadCount > 0
                       ? `Notificaciones, ${unreadCount} sin leer`
@@ -640,8 +666,8 @@ export default function Home() {
                     style={[styles.onboardingBannerBody, { color: theme.icon }]}
                     numberOfLines={2}
                   >
-                    Dinos a qué localidad perteneces y te
-                    mostraremos las secciones más importantes.
+                    Dinos a qué localidad perteneces y te mostraremos las
+                    secciones más importantes.
                   </Text>
                 </View>
                 <MaterialIcons
@@ -728,7 +754,12 @@ export default function Home() {
                         : 'rgba(0,0,0,0.07)',
                   },
                 ])}
-                onPress={() => setNotifSheetOpen(true)}
+                onPress={() => {
+                  // Abre directamente el detalle de la última notificación
+                  // (vista en grande), no la lista completa.
+                  setNotifSheetInitial(latestNotification);
+                  setNotifSheetOpen(true);
+                }}
                 activeOpacity={0.78}
                 accessibilityLabel={`${notifTitle}. Toca para leer`}
                 accessibilityRole="button"
@@ -951,7 +982,7 @@ export default function Home() {
                   title="Activa algún calendario"
                   subtitle="Selecciona un calendario para ver los próximos eventos aquí."
                   actionLabel="Ir al calendario"
-                  onAction={() => router.push('/calendario')}
+                  onAction={() => navigateToCalendar()}
                   accentColor={accentColor}
                 />
               ) : eventsLoading && !hasUpcomingEvents ? (
@@ -995,12 +1026,7 @@ export default function Home() {
                               borderLeftColor: calColor,
                             },
                           ])}
-                          onPress={() =>
-                            router.push({
-                              pathname: '/calendario',
-                              params: { date: evt.startDate },
-                            } as any)
-                          }
+                          onPress={() => navigateToCalendar(evt.startDate)}
                           accessibilityRole="button"
                           accessibilityLabel={`Evento: ${evt.title}`}
                         >
@@ -1101,7 +1127,7 @@ export default function Home() {
                   styles.calendarButton,
                   { borderColor: hexAlpha(accentColor, '30') },
                 ])}
-                onPress={() => router.push('/calendario')}
+                onPress={() => navigateToCalendar()}
                 accessibilityRole="button"
               >
                 <Text

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -18,7 +18,7 @@ import { TouchableOpacity, Swipeable } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import colors, { Colors } from '@/constants/colors';
 import { hexAlpha } from '@/utils/colorUtils';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -92,6 +92,10 @@ export default function NotificationsScreen() {
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const { firebaseNotifications, refreshCount } = useNotifications();
+  // Deep-link: al tocar una notificación push (desde la bandeja del sistema) la
+  // app abre esta pantalla con `openId` para mostrar esa notificación en grande.
+  const { openId } = useLocalSearchParams<{ openId?: string }>();
+  const autoOpenedIdRef = React.useRef<string | null>(null);
 
   const [localNotifications, setLocalNotifications] = useState<
     ReceivedNotification[]
@@ -405,6 +409,19 @@ export default function NotificationsScreen() {
   }, [localNotifications, firebaseNotifications]);
 
   const hasUnread = allNotifications.some((n) => !isNotificationRead(n));
+
+  // Auto-abrir el detalle de la notificación indicada por `openId` (deep-link
+  // desde una push). Esperamos a que la lista esté cargada para que la
+  // notificación recién recibida ya esté disponible y haga match por id.
+  useEffect(() => {
+    if (!openId || loading) return;
+    if (autoOpenedIdRef.current === openId) return;
+    const match = allNotifications.find((n) => n.id === openId);
+    if (match) {
+      autoOpenedIdRef.current = openId;
+      handleNotificationPress(match);
+    }
+  }, [openId, loading, allNotifications, handleNotificationPress]);
 
   return (
     <SafeAreaView

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -143,11 +143,11 @@ export default function MasHomeScreen() {
   // Deep-link desde la Home: si hay una pantalla pendiente, navegar a ella
   useFocusEffect(
     useCallback(() => {
-      const screen = takePendingMasScreen();
-      if (screen) {
-        // navigate() overloads don't accept union types — as never is the
-        // idiomatic TypeScript escape hatch for this overload resolution issue
-        navigation.navigate(screen as never);
+      const pending = takePendingMasScreen();
+      if (pending) {
+        // navigate() overloads no aceptan tipos unión ni un screen con params
+        // `undefined` + params — usamos `as any` como escape hatch idiomático.
+        (navigation.navigate as any)(pending.screen, pending.params);
       }
     }, [navigation]),
   );

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -109,9 +109,19 @@ function formatDate(date: Date): string {
 interface Props {
   visible: boolean;
   onClose: () => void;
+  /**
+   * Si se pasa, al abrir el sheet se muestra directamente el detalle de esta
+   * notificación (vista "en grande") en lugar de la lista. Lo usa la tarjeta de
+   * Novedades de la Home para abrir la última notificación concreta.
+   */
+  initialNotification?: (NotificationData | ReceivedNotification) | null;
 }
 
-export default function NotificationsBottomSheet({ visible, onClose }: Props) {
+export default function NotificationsBottomSheet({
+  visible,
+  onClose,
+  initialNotification = null,
+}: Props) {
   const scheme = useColorScheme() ?? 'light';
   const isDark = scheme === 'dark';
   const theme = Colors[scheme];
@@ -128,10 +138,23 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
     (NotificationData | ReceivedNotification) | null
   >(null);
 
-  // Reset detail view when sheet closes
+  // Al abrir: si viene una notificación inicial, mostramos su detalle en grande
+  // (y la marcamos como leída). Al cerrar: reseteamos la vista de detalle.
   useEffect(() => {
-    if (!visible) setSelectedNotification(null);
-  }, [visible]);
+    if (visible) {
+      setSelectedNotification(initialNotification ?? null);
+      if (initialNotification) {
+        markNotificationAsRead(initialNotification.id)
+          .then(() => {
+            loadLocalData();
+            refreshCount();
+          })
+          .catch(() => {});
+      }
+    } else {
+      setSelectedNotification(null);
+    }
+  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (visible) {
@@ -444,9 +467,10 @@ export default function NotificationsBottomSheet({ visible, onClose }: Props) {
       </TouchableOpacity>
     ) : undefined;
 
-  const sheetTitle = selectedNotification
-    ? selectedNotification.title
-    : 'Notificaciones';
+  // En el detalle NO repetimos el título en el header del sheet: la vista de
+  // detalle ya muestra el título en grande, así que duplicarlo arriba sobra
+  // (solo dejamos la flecha de volver). En la lista mostramos "Notificaciones".
+  const sheetTitle = selectedNotification ? undefined : 'Notificaciones';
 
   return (
     <BottomSheet

--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -172,6 +172,12 @@ export default function usePushNotifications() {
         const data = response.notification.request.content.data;
         const actionIdentifier = response.actionIdentifier;
 
+        // ID estable de la notificación (lo necesitamos también para el
+        // deep-link al centro de notificaciones).
+        const notificationId = getStableNotificationId(
+          response.notification.request.content,
+        );
+
         // Determinar ruta de navegación
         let targetRoute: string | undefined;
 
@@ -187,17 +193,27 @@ export default function usePushNotifications() {
           targetRoute = data.internalRoute as string;
         }
 
-        if (targetRoute) {
-          const normalized = normalizeNotificationRoute(targetRoute);
-          try {
-            router.navigate(normalized as any);
-          } catch {}
+        // 3. Por defecto (sin ruta específica): abrir el centro de
+        //    notificaciones mostrando esta notificación en grande.
+        if (!targetRoute) {
+          targetRoute = '/notifications';
         }
 
+        const normalized = normalizeNotificationRoute(targetRoute);
+        try {
+          // Si vamos al centro de notificaciones, hacemos deep-link a ESTA
+          // notificación concreta para abrir su detalle (vista "en grande").
+          if (normalized === '/notifications') {
+            router.navigate({
+              pathname: '/notifications',
+              params: { openId: notificationId },
+            } as any);
+          } else {
+            router.navigate(normalized as any);
+          }
+        } catch {}
+
         // Guardar y marcar como leída
-        const notificationId = getStableNotificationId(
-          response.notification.request.content,
-        );
         const receivedNotification: ReceivedNotification = {
           id: notificationId,
           title: response.notification.request.content.title || 'Notificación',

--- a/mcm-app/utils/masNavigation.ts
+++ b/mcm-app/utils/masNavigation.ts
@@ -1,9 +1,12 @@
 // utils/masNavigation.ts
 // Simple pending-navigation store for deep-linking into the Más stack from
-// outside (e.g. the Home screen quick-grid button).
+// outside (e.g. the Home screen quick-grid button, or a Home calendar card on
+// iOS where `calendario`/`fotos` are overflow tabs reachable only via the Más
+// stack — they have no native tab trigger).
 //
 // Usage:
-//   1. Caller sets a pending screen name and then navigates to the Más tab.
+//   1. Caller sets a pending screen name (+ optional params) and then navigates
+//      to the Más tab (`router.push('/mas')`).
 //   2. MasHomeScreen reads and clears the pending screen on focus,
 //      then programmatically navigates to it within the native stack.
 
@@ -11,19 +14,27 @@ import type { MasStackParamList } from '@/app/(tabs)/mas';
 
 type PendingScreen = keyof MasStackParamList;
 
-let pendingScreen: PendingScreen | null = null;
+interface PendingNavigation {
+  screen: PendingScreen;
+  params?: Record<string, unknown>;
+}
 
-/** Store the screen to navigate to inside the Más stack. */
-export const setPendingMasScreen = (screen: PendingScreen): void => {
-  pendingScreen = screen;
+let pending: PendingNavigation | null = null;
+
+/** Store the screen (and optional params) to navigate to inside the Más stack. */
+export const setPendingMasScreen = (
+  screen: PendingScreen,
+  params?: Record<string, unknown>,
+): void => {
+  pending = { screen, params };
 };
 
 /**
- * Read and clear the pending screen (one-shot).
+ * Read and clear the pending navigation (one-shot).
  * Returns null if nothing is pending.
  */
-export const takePendingMasScreen = (): PendingScreen | null => {
-  const screen = pendingScreen;
-  pendingScreen = null;
-  return screen;
+export const takePendingMasScreen = (): PendingNavigation | null => {
+  const current = pending;
+  pending = null;
+  return current;
 };


### PR DESCRIPTION
## Qué arregla

Cuatro problemas reportados desde la Home y las notificaciones:

### 1. Botones de calendario de la Home no funcionaban (iOS)
Las tarjetas de "Próximos eventos", el botón **"Ver calendario"** y el CTA **"Ir al calendario"** no hacían nada en iOS.

**Causa:** en iOS solo caben 5 tabs en la barra nativa, así que `calendario` (y `fotos`) son tabs _overflow_ **sin trigger nativo**; `router.push('/calendario')` no navega a ellos. Solo son alcanzables a través del stack de "Más".

**Fix:** nuevo helper `navigateToCalendar(date?)` en la Home. En iOS navega vía el stack de "Más" (igual que ya hacía el acceso de Fotos), incluido el salto a una fecha concreta; en Android/Web sigue yendo al tab directo. `calendario.tsx` ahora lee la fecha también desde los params de React Navigation (el path de iOS no pasa por la URL de expo-router).

### 2. La tarjeta de Novedades abre la última notificación "en grande"
Al tocar la tarjeta de la Home se abre directamente el **detalle de la última notificación**, no la lista completa. La campana del header sigue abriendo la lista.

### 3. Sin título duplicado en el detalle
El bottom sheet de notificaciones ya no repite el título en su cabecera cuando se ve el detalle (solo queda la flecha de volver).

### 4. Deep-link de push → detalle de la notificación
Al tocar una notificación desde la bandeja del sistema, la app abre el centro de notificaciones y **despliega esa notificación concreta en grande** (`/notifications?openId=<id>`). Si la notificación trae `internalRoute` a otra sección, se respeta ese destino.

> **MCM Panel:** para que el deep-link abra la notificación correcta, el panel debe enviar `data.id` con el mismo ID que la notificación tiene en Firebase. Ver `NOTIFICACIONES.md` → "Abrir la notificación en grande".

## Archivos
- `app/(tabs)/index.tsx`, `app/(tabs)/calendario.tsx`
- `app/notifications.tsx`, `components/NotificationsBottomSheet.tsx`
- `notifications/usePushNotifications.ts`
- `utils/masNavigation.ts`, `app/screens/MasHomeScreen.tsx`
- Docs: `CHANGELOG.md`, `NOTIFICACIONES.md`

## Verificación
- `npx tsc --noEmit` ✅
- `eslint` sobre los archivos tocados ✅

Solo cambios JS (sin paquetes nativos) → OTA seguro.

https://claude.ai/code/session_01PFUvpMYVYfozjfLRDRXeo3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFUvpMYVYfozjfLRDRXeo3)_