### PR TITLE
fix(auth): cancelar login de Google no muestra error en Android

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-06-05 — Fix: cancelar el login de Google ya no muestra error (Android)
+
+- En `@react-native-google-signin` v13+ cuando el usuario **cancela** el selector
+  de cuentas, `signIn()` NO lanza excepción: resuelve con
+  `{ type: 'cancelled', data: null }`. El código antiguo lo interpretaba como
+  "no se recibió idToken" y lanzaba un error genérico → la UI mostraba un toast
+  rojo "No se pudo iniciar sesión" tanto en el menú "Más" como en el onboarding.
+- Ahora se detecta `response.type === 'cancelled'` y se traduce a un error con
+  `code: 'ERR_CANCELED'`, que `AuthContext` ya trata como cancelación silenciosa.
+- Archivos: `utils/platformAuth.native.ts`.
+
 ## 2026-06-05 — Modo Carismochito: persistente y menos intrusivo
 
 - **Persiste al cerrar y reabrir la app**: si el modo queda activo, se recuerda

--- a/mcm-app/utils/platformAuth.native.ts
+++ b/mcm-app/utils/platformAuth.native.ts
@@ -52,6 +52,17 @@ export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
   const GoogleSignin = await getGoogleSignin();
   await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
   const response = await GoogleSignin.signIn();
+  // En @react-native-google-signin v13+ el usuario que cancela NO produce una
+  // excepción: signIn() resuelve con { type: 'cancelled', data: null }. Lo
+  // traducimos a un error con code 'ERR_CANCELED' para que AuthContext lo trate
+  // como cancelación (sin toast de error) en lugar de "no se recibió idToken".
+  if (response.type === 'cancelled') {
+    const cancelErr = new Error('Google Sign-In cancelado por el usuario') as Error & {
+      code?: string;
+    };
+    cancelErr.code = 'ERR_CANCELED';
+    throw cancelErr;
+  }
   if (!response.data?.idToken) {
     throw new Error('Google Sign-In: no se recibió idToken');
   }


### PR DESCRIPTION
En @react-native-google-signin v13+ la cancelación del usuario resuelve
signIn() con { type: 'cancelled' } en vez de lanzar excepción. Se detecta
ese caso y se traduce a code 'ERR_CANCELED' para que AuthContext lo trate
como cancelación silenciosa en lugar de mostrar un toast de error.

https://claude.ai/code/session_01AeRc7i3efi8sdzbc1rAUfL