### PR TITLE
fix(auth): cancelar login de Google no muestra error en Android

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-06-05 — Fix: cancelar el login de Google ya no muestra error (Android)
+
+- En `@react-native-google-signin` v13+ cuando el usuario **cancela** el selector
+  de cuentas, `signIn()` NO lanza excepción: resuelve con
+  `{ type: 'cancelled', data: null }`. El código antiguo lo interpretaba como
+  "no se recibió idToken" y lanzaba un error genérico → la UI mostraba un toast
+  rojo "No se pudo iniciar sesión" tanto en el menú "Más" como en el onboarding.
+- Ahora se detecta `response.type === 'cancelled'` y se traduce a un error con
+  `code: 'ERR_CANCELED'`, que `AuthContext` ya trata como cancelación silenciosa.
+- Archivos: `utils/platformAuth.native.ts`.
+
 ## 2026-06-05 — Modo Carismochito: persistente y menos intrusivo
 
 - **Persiste al cerrar y reabrir la app**: si el modo queda activo, se recuerda

--- a/mcm-app/utils/platformAuth.native.ts
+++ b/mcm-app/utils/platformAuth.native.ts
@@ -52,6 +52,17 @@ export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
   const GoogleSignin = await getGoogleSignin();
   await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
   const response = await GoogleSignin.signIn();
+  // En @react-native-google-signin v13+ el usuario que cancela NO produce una
+  // excepción: signIn() resuelve con { type: 'cancelled', data: null }. Lo
+  // traducimos a un error con code 'ERR_CANCELED' para que AuthContext lo trate
+  // como cancelación (sin toast de error) en lugar de "no se recibió idToken".
+  if (response.type === 'cancelled') {
+    const cancelErr = new Error('Google Sign-In cancelado por el usuario') as Error & {
+      code?: string;
+    };
+    cancelErr.code = 'ERR_CANCELED';
+    throw cancelErr;
+  }
   if (!response.data?.idToken) {
     throw new Error('Google Sign-In: no se recibió idToken');
   }


### PR DESCRIPTION
## Qué cambia

Corrige un falso error al **cancelar** el login de Google en Android, tanto en el menú "Más" como en el paso de login del onboarding (ambos comparten `SocialLoginSection` → `AuthContext` → `platformAuth.native.ts`).

## Por qué

En `@react-native-google-signin` v13+ (el proyecto usa v16.1.2), cuando el usuario cierra el selector de cuentas `signIn()` **ya no lanza excepción**: resuelve con `{ type: 'cancelled', data: null }`. El código antiguo lo interpretaba como "no se recibió idToken" y lanzaba un error genérico sin `code`, que `AuthContext` no reconocía como cancelación → se mostraba un toast rojo **"No se pudo iniciar sesión"** cada vez que alguien abría y cerraba el diálogo de Google.

## Cómo

Se detecta `response.type === 'cancelled'` y se traduce a un error con `code: 'ERR_CANCELED'`, que `AuthContext.signInWithGoogle` ya trata como cancelación silenciosa (sin toast).

## Archivos
- `utils/platformAuth.native.ts` — manejo de cancelación.
- `CHANGELOG.md` — entrada del fix.

## Notas
- Cambio puramente JS (sin paquetes nativos nuevos) → apto para OTA, no lleva `[skip-ota]`.
- No he podido correr `tsc`/`lint` en este entorno (sin `node_modules`); el cambio es type-safe sobre la unión discriminada de la librería.

## ⚠️ Aparte de este fix
Si el login **falla de verdad** en Android (no que se cancele), la causa #1 suele ser `DEVELOPER_ERROR` (status 10) por **SHA-1/SHA-256 no registradas** en Firebase para el keystore de EAS y/o la clave de App Signing de Google Play. Eso es configuración (no código) y no se puede verificar desde el repo: requiere comprobar `eas credentials` + consola de Firebase + regenerar `google-services.json`.

https://claude.ai/code/session_01AeRc7i3efi8sdzbc1rAUfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeRc7i3efi8sdzbc1rAUfL)_