### PR TITLE
Android: login "próximamente" y salta el paso de login en onboarding

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,19 @@
 
 ---
 
+## 2026-06-05 — Login deshabilitado temporalmente en Android ("próximamente")
+
+- El inicio de sesión en Android queda **temporalmente desactivado** mientras se
+  reparan los proveedores nativos. En su lugar se muestra un aviso
+  **"Inicio de sesión próximamente"**.
+- **Onboarding**: el paso de login se **salta por completo** en Android. Los
+  perfiles `monitor`/`miembro` van directos al resumen final (en iOS/web sigue
+  igual). El indicador de pasos se ajusta automáticamente.
+- **Menú "Más" / hoja de cuenta**: `SocialLoginSection` muestra el aviso de
+  "próximamente" en lugar de los botones de Google/Apple en Android. Los usuarios
+  que ya tuvieran sesión iniciada siguen viendo su cuenta (y pueden cerrar sesión).
+- Archivos: `app/onboarding.tsx` (`needsLoginStep`), `components/SocialLoginSection.tsx`.
+
 ## 2026-06-05 — Fix: cancelar el login de Google ya no muestra error (Android)
 
 - En `@react-native-google-signin` v13+ cuando el usuario **cancela** el selector

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,17 @@
 
 ---
 
+## 2026-06-05 — Fix: cancelar el login de Google ya no muestra error (Android)
+
+- En `@react-native-google-signin` v13+ cuando el usuario **cancela** el selector
+  de cuentas, `signIn()` NO lanza excepción: resuelve con
+  `{ type: 'cancelled', data: null }`. El código antiguo lo interpretaba como
+  "no se recibió idToken" y lanzaba un error genérico → la UI mostraba un toast
+  rojo "No se pudo iniciar sesión" tanto en el menú "Más" como en el onboarding.
+- Ahora se detecta `response.type === 'cancelled'` y se traduce a un error con
+  `code: 'ERR_CANCELED'`, que `AuthContext` ya trata como cancelación silenciosa.
+- Archivos: `utils/platformAuth.native.ts`.
+
 ## 2026-06-05 — Modo Carismochito: persistente y menos intrusivo
 
 - **Persiste al cerrar y reabrir la app**: si el modo queda activo, se recuerda

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -1685,9 +1685,11 @@ export default function OnboardingScreen() {
     go('delegation');
   };
 
-  // Monitor y miembro van al paso de login antes del éxito
+  // Monitor y miembro van al paso de login antes del éxito.
+  // En Android el login está temporalmente deshabilitado (proveedores nativos
+  // en reparación), así que saltamos este paso por completo.
   const needsLoginStep = (p: OnboardingProfileId | null) =>
-    p === 'monitor' || p === 'miembro';
+    Platform.OS !== 'android' && (p === 'monitor' || p === 'miembro');
 
   const handleFinishToSuccess = () => {
     if (needsLoginStep(profileType)) {

--- a/mcm-app/components/SocialLoginSection.tsx
+++ b/mcm-app/components/SocialLoginSection.tsx
@@ -372,6 +372,34 @@ export default function SocialLoginSection({
     );
   }
 
+  // ── Android: inicio de sesión "próximamente" ──────────────────────
+  // El login con proveedores nativos está temporalmente deshabilitado en
+  // Android mientras se repara. Mostramos un aviso en lugar de los botones.
+  if (Platform.OS === 'android') {
+    const csBg = onDarkBackground
+      ? 'rgba(255,255,255,0.10)'
+      : scheme === 'dark'
+        ? 'rgba(255,255,255,0.06)'
+        : hexAlpha(brandColors.primary, '10');
+    const csIcon = onDarkBackground ? 'rgba(255,255,255,0.85)' : brandColors.primary;
+    const csTitle = onDarkBackground ? '#fff' : theme.text;
+    const csBody = onDarkBackground ? 'rgba(255,255,255,0.75)' : theme.icon;
+    return (
+      <View style={styles.container}>
+        <View style={[styles.comingSoonCard, { backgroundColor: csBg }]}>
+          <MaterialIcons name="schedule" size={26} color={csIcon} />
+          <Text style={[styles.comingSoonTitle, { color: csTitle }]}>
+            Inicio de sesión próximamente
+          </Text>
+          <Text style={[styles.comingSoonBody, { color: csBody }]}>
+            Estamos preparando el acceso con cuenta en Android. Mientras tanto
+            puedes seguir usando la app con normalidad. ¡Muy pronto!
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   // ── Estado: no autenticado ─────────────────────────────────────────
   const googleBg = onDarkBackground ? 'rgba(255,255,255,0.12)' : theme.card;
   const googleBorder = onDarkBackground
@@ -505,6 +533,24 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     alignItems: 'center',
   } as ViewStyle,
+  comingSoonCard: {
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 18,
+    borderRadius: radii.md,
+  } as ViewStyle,
+  comingSoonTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    textAlign: 'center',
+  } as TextStyle,
+  comingSoonBody: {
+    fontSize: 13,
+    lineHeight: 18,
+    fontWeight: '500',
+    textAlign: 'center',
+  } as TextStyle,
   hintCard: {
     flexDirection: 'row',
     alignItems: 'flex-start',

--- a/mcm-app/utils/platformAuth.native.ts
+++ b/mcm-app/utils/platformAuth.native.ts
@@ -52,6 +52,17 @@ export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
   const GoogleSignin = await getGoogleSignin();
   await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
   const response = await GoogleSignin.signIn();
+  // En @react-native-google-signin v13+ el usuario que cancela NO produce una
+  // excepción: signIn() resuelve con { type: 'cancelled', data: null }. Lo
+  // traducimos a un error con code 'ERR_CANCELED' para que AuthContext lo trate
+  // como cancelación (sin toast de error) en lugar de "no se recibió idToken".
+  if (response.type === 'cancelled') {
+    const cancelErr = new Error('Google Sign-In cancelado por el usuario') as Error & {
+      code?: string;
+    };
+    cancelErr.code = 'ERR_CANCELED';
+    throw cancelErr;
+  }
   if (!response.data?.idToken) {
     throw new Error('Google Sign-In: no se recibió idToken');
   }


### PR DESCRIPTION
## Qué hace

El login en Android queda **temporalmente deshabilitado** mientras se reparan los proveedores nativos. En su lugar se muestra un aviso "próximamente".

- **Onboarding** (`app/onboarding.tsx`): el paso de login se **salta por completo** en Android. Los perfiles `monitor`/`miembro` van directos al resumen final; el indicador de pasos se ajusta solo. iOS/web sin cambios.
- **Menú "Más" / hoja de cuenta** (`components/SocialLoginSection.tsx`): en Android se muestra una tarjeta **"Inicio de sesión próximamente"** en lugar de los botones de Google/Apple. Respeta tema claro/oscuro y fondo oscuro. Quien ya tuviera sesión iniciada sigue viendo su cuenta y puede cerrar sesión.

## Notas

- Cambio **solo JS, sin paquetes nativos** → apto para OTA.
- Para reactivar el login en Android basta con revertir las dos condiciones `Platform.OS` añadidas.

https://claude.ai/code/session_01EtDum54bmk7kNg36tMGLx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtDum54bmk7kNg36tMGLx8)_