### PR TITLE
Notificaciones: soportar hasta 3 botones de acción

### DIFF
--- a/NOTIFICACIONES.md
+++ b/NOTIFICACIONES.md
@@ -95,25 +95,52 @@ El campo `internalRoute` representa **la sección de la app a la que va asociada
 
 ---
 
-### `actionButton` — Botón de acción explícito
+### `actionButtons` — Botones de acción explícitos (hasta 3)
 
-El campo `actionButton` es un **call-to-action explícito** con texto personalizado que puede llevar a:
+El campo `actionButtons` es un **array de call-to-actions explícitos** (de 1 a 3),
+cada uno con texto personalizado que puede llevar a:
 - Una URL externa (se abre en el navegador)
 - Una ruta interna de la app
 
 ```json
-"actionButton": {
-  "text": "Ver artículo",
-  "url": "https://ejemplo.com/articulo",
-  "isInternal": false
-}
+"actionButtons": [
+  { "text": "Apuntarme", "url": "https://mcmespana.com/inscripcion", "isInternal": false },
+  { "text": "Ver fechas", "url": "/(tabs)/calendario", "isInternal": true }
+]
 ```
 
 **Comportamiento:**
-- **En la tarjeta de la lista**: se muestra como un chip azul pequeño (tappable). Al pulsarlo navega directamente a la URL/ruta sin abrir el modal.
-- **En el modal de detalle**: se muestra como un botón CTA grande en la parte inferior.
+- **En la tarjeta de la lista**: cada botón se muestra como un chip azul pequeño
+  (tappable). Al pulsarlo navega directamente a la URL/ruta sin abrir el modal.
+- **En el modal de detalle**: se apilan como botones CTA. El **primero** destaca en
+  estilo primario (relleno); los siguientes van en estilo secundario (borde).
 
-**Cuándo usarlo:** Cuando la notificación tiene una acción específica nombrada, distinta de simplemente "ir a una sección". Ej: "Ver más", "Leer artículo", "Ver evento".
+**Máximo:** 3 botones (`MAX_ACTION_BUTTONS` en `utils/notificationRoutes.ts`). Si el
+panel manda más, la app usa los 3 primeros e ignora el resto.
+
+**Cuándo usarlo:** Cuando la notificación tiene una o varias acciones específicas
+nombradas, distintas de simplemente "ir a una sección". Ej: "Apuntarme" + "Ver fechas",
+"Sí asistiré" + "No puedo", "Leer artículo".
+
+#### Compatibilidad: `actionButton` (singular, legacy)
+
+El formato antiguo de **un solo botón** sigue soportado:
+
+```json
+"actionButton": { "text": "Ver artículo", "url": "https://ejemplo.com/articulo", "isInternal": false }
+```
+
+La app lo trata como un array de un elemento. Si llegan **ambos** (`actionButton` +
+`actionButtons`), se combinan y se deduplica por `url|text`. El formato recomendado
+para nuevos envíos es **`actionButtons` (array)**, aunque sea de un solo botón.
+
+> ⚠️ **iOS / Android — botones en la notificación del sistema:** estos botones se
+> renderizan **dentro de la app** (tarjeta + modal del centro de notificaciones).
+> Los botones en la propia notificación del sistema iOS dependen de *categorías*
+> pre-registradas (`categoryId` → `general`/`eventos`/`fotos`, 1 botón cada una) y
+> NO se pueden definir dinámicamente desde el payload. Para varios botones nativos
+> haría falta registrar nuevas categorías en la app (build nativo). Ver §3 del
+> contrato.
 
 ---
 
@@ -121,7 +148,7 @@ El campo `actionButton` es un **call-to-action explícito** con texto personaliz
 
 Una notificación puede tener los dos:
 - `internalRoute` indica la sección asociada (botón "Ir a X" en el modal)
-- `actionButton` tiene el CTA explícito (chip en tarjeta + botón CTA en modal)
+- `actionButtons` tiene los CTA explícitos (chips en tarjeta + botones CTA en modal)
 
 **Ejemplo:**
 ```json
@@ -129,21 +156,20 @@ Una notificación puede tener los dos:
   "title": "¡Nuevas canciones en el cantoral!",
   "body": "Hemos añadido 5 canciones nuevas de Adviento.",
   "internalRoute": "/(tabs)/cancionero",
-  "actionButton": {
-    "text": "Ver novedades",
-    "url": "https://mcmespana.com/novedades",
-    "isInternal": false
-  }
+  "actionButtons": [
+    { "text": "Ver novedades", "url": "https://mcmespana.com/novedades", "isInternal": false },
+    { "text": "Escuchar", "url": "https://open.spotify.com/...", "isInternal": false }
+  ]
 }
 ```
-→ En la tarjeta: chip "Cantoral" + chip tappable "Ver novedades"
-→ En el modal: botón "Ir a Cantoral" + botón CTA "Ver novedades"
+→ En la tarjeta: chip "Cantoral" + chips tappables "Ver novedades" y "Escuchar"
+→ En el modal: botón "Ir a Cantoral" + botón CTA "Ver novedades" (primario) + "Escuchar" (secundario)
 
 ---
 
 ### Sin ninguno de los dos
 
-Si no hay `internalRoute` ni `actionButton`, la notificación solo muestra título, cuerpo y fecha. El modal sigue siendo accesible tocando la tarjeta.
+Si no hay `internalRoute` ni `actionButtons`, la notificación solo muestra título, cuerpo y fecha. El modal sigue siendo accesible tocando la tarjeta.
 
 Al tocar la push desde la bandeja del sistema, la app abre el centro de
 notificaciones y **despliega automáticamente esa notificación en grande**
@@ -184,8 +210,8 @@ Usuario abre pantalla de notificaciones
     ├── Toca tarjeta → abre modal de detalle (siempre)
     │   ├── Modal muestra body completo + imagen (si hay)
     │   ├── Botón "Ir a [Sección]" (si hay internalRoute)
-    │   └── Botón CTA grande (si hay actionButton)
-    ├── Toca chip actionButton en tarjeta → navega directamente (sin modal)
+    │   └── Botones CTA apilados, hasta 3 (si hay actionButtons)
+    ├── Toca chip de actionButton en tarjeta → navega directamente (sin modal)
     ├── Toca ✓ en tarjeta → marca como leída sin abrir modal
     └── Swipe derecha → marca como leída sin abrir modal
 ```
@@ -246,7 +272,10 @@ El backend debe:
     "internalRoute": "/(tabs)/cancionero",
     "icon": "https://...",
     "imageUrl": "https://...",
-    "actionButton": { "text": "Ver más", "url": "https://..." }
+    "actionButtons": [
+      { "text": "Ver más", "url": "https://...", "isInternal": false },
+      { "text": "Calendario", "url": "/(tabs)/calendario", "isInternal": true }
+    ]
   },
   "categoryId": "general",
   "priority": "default",
@@ -262,7 +291,7 @@ El backend debe:
 
 #### UI del panel
 - Dashboard con estadísticas
-- Formulario: título (50 chars max), body (200 chars), categoría, prioridad, icono URL, imagen URL, ruta interna, botón de acción
+- Formulario: título (50 chars max), body (200 chars), categoría, prioridad, icono URL, imagen URL, ruta interna, **hasta 3 botones de acción** (texto + URL/ruta + interno/externo cada uno)
 - Autenticación simple (usuario/contraseña via env vars)
 - Historial de notificaciones enviadas
 

--- a/NOTIFICACIONES_CONTRATO.md
+++ b/NOTIFICACIONES_CONTRATO.md
@@ -22,9 +22,10 @@
    (`joven`/`responsable`/`"Castellón"`) que **no existen**. Los campos reales son
    `profileType`, `delegationId` y, sobre todo, **`topics[]`** (la clave de
    segmentación). Detalle y valores válidos abajo.
-3. **Botón de acción**: el contrato manda `data.actionButtons` (array). La app usa
-   `actionButton` (objeto con `isInternal`). La app ya **acepta ambos**, pero el
-   formato canónico recomendado es el objeto singular con `isInternal`.
+3. **Botones de acción**: la app ahora soporta **hasta 3 botones** (`data.actionButtons`,
+   array). Sigue aceptando el objeto único `data.actionButton` (legacy) por
+   compatibilidad. **Formato canónico recomendado: `actionButtons` (array)**, cada
+   elemento `{ text, url, isInternal }`. Ver §3.
 4. **`categoryId`**: la app solo registra categorías iOS `general`, `eventos`,
    `fotos`. Mandar `evento`/`actividad`/`cantoral`/`jubileo`/`urgente` como
    `categoryId` no aporta botones (se ignora). Conviene **desacoplar** `categoryId`
@@ -127,26 +128,45 @@ acción del sistema iOS**. No lo igualéis a la categoría de negocio. Mandad:
 > Nota: el contrato manda `evento` (singular); la categoría iOS registrada es
 > `eventos` (plural). Si queréis el botón "Ver Evento", usad `eventos`.
 
-### `actionButtons` vs `actionButton`
+### `actionButtons` — varios botones (hasta 3)
 
-La app trabaja con un **único** `actionButton`:
+La app soporta **hasta 3 botones de acción** por notificación. El formato canónico
+recomendado es el array `data.actionButtons`:
 
 ```jsonc
 "data": {
-  "actionButton": {
-    "text": "Ver novedades",
-    "url": "https://mcmespana.com/x",   // o ruta interna: "/(tabs)/fotos"
-    "isInternal": false                  // true = navega dentro de la app
-  }
+  "actionButtons": [
+    {
+      "text": "Apuntarme",
+      "url": "https://mcmespana.com/inscripcion", // o ruta interna: "/(tabs)/fotos"
+      "isInternal": false                          // true = navega dentro de la app
+    },
+    { "text": "Ver fechas", "url": "/(tabs)/calendario", "isInternal": true }
+  ]
 }
 ```
 
-La app **ya acepta también** `data.actionButtons: [{ text, url }]` (usa el primer
-elemento) e infiere `isInternal` (interno si la `url` no empieza por `http`). Aun así,
-**el formato canónico recomendado es el objeto singular con `isInternal` explícito.**
+Reglas que aplica la app (`utils/notificationRoutes.ts` → `extractActionButtons`):
 
-`internalRoute` (sección asociada) y `actionButton` (CTA explícito) son
+- **Máximo 3** botones (`MAX_ACTION_BUTTONS`). Si mandáis más, se usan los 3 primeros.
+- Cada botón necesita **`url`** (los que no la tengan se descartan).
+- `text` por defecto `"Ver"` si falta. `isInternal` se **infiere** si no viene:
+  interno cuando la `url` NO empieza por `http(s)://`.
+- **Render**: en la tarjeta, un chip por botón; en el modal, botones apilados (el
+  1.º primario, los siguientes secundarios).
+
+**Compatibilidad (legacy):** sigue aceptándose el objeto único `data.actionButton`
+(equivale a un array de uno). Si llegan **ambos**, se combinan y se deduplica por
+`url|text`. Para envíos nuevos, **usad siempre `actionButtons` (array)**, aunque sea
+de un solo botón.
+
+`internalRoute` (sección asociada) y `actionButtons` (CTA explícitos) son
 complementarios — ver `NOTIFICACIONES.md` §"Arquitectura de botones y navegación".
+
+> ⚠️ Estos botones son **in-app** (tarjeta + modal del centro de notificaciones).
+> Los botones de la notificación del **sistema iOS** dependen de las *categorías*
+> pre-registradas (`categoryId`, ver tabla arriba) y NO se pueden generar
+> dinámicamente desde el payload.
 
 ## 4. Imagen
 
@@ -271,8 +291,8 @@ para la **velocidad de entrega** (FCM). Para diferenciar visualmente `high` vs
 | `mutableContent`         | 🟡 | iOS lo ignora en la práctica (sin NSE) |
 | `data.id`                | ✅ | **Crítico**: dedup / marca leído |
 | `data.internalRoute`     | ✅ | Navegación (con normalización + alias) |
-| `data.actionButton`      | ✅ | CTA en tarjeta + modal |
-| `data.actionButtons[]`   | ✅ | Aceptado (usa el primero) → mapeado a `actionButton` |
+| `data.actionButtons[]`   | ✅ | **Hasta 3** CTA en tarjeta + modal (formato recomendado) |
+| `data.actionButton`      | ✅ | Legacy (un botón) → se trata como array de uno |
 | `data.imageUrl`          | ✅ | Imagen en el modal de detalle in-app |
 | `data.icon`              | ✅ | Miniatura en la tarjeta in-app |
 | `data.category`          | 🟡 | Se guarda; sin efecto visual todavía |

--- a/PROMPT_MCMPANEL_NOTIS_BOTONES.md
+++ b/PROMPT_MCMPANEL_NOTIS_BOTONES.md
@@ -1,0 +1,96 @@
+# Prompt para el agente de **mcmpanel** — Varios botones de acción en notificaciones
+
+> Contexto: en la app MCM (repo `mcmapp`, carpeta `mcm-app/`) las notificaciones
+> push ahora soportan **hasta 3 botones de acción** por notificación (antes solo
+> uno). El panel `mcmpanel` debe poder componer esos botones en el formulario de
+> envío y mandarlos en el payload con el formato correcto. Este documento describe
+> qué cambió en la app y qué implementar en el panel.
+
+---
+
+## 1. Qué cambió en la app (contexto)
+
+- Antes la app solo renderizaba **un** botón de acción (campo `data.actionButton`,
+  objeto). El array `data.actionButtons` se aceptaba pero **solo se usaba el primer
+  elemento**.
+- Ahora la app renderiza **hasta 3 botones** (`MAX_ACTION_BUTTONS = 3`):
+  - En la **tarjeta** del centro de notificaciones: un chip tappable por botón.
+  - En el **modal de detalle**: botones apilados (el 1.º primario, el resto
+    secundarios).
+- Lógica de la app en `mcm-app/utils/notificationRoutes.ts` → `extractActionButtons()`.
+- Compatibilidad: el objeto único `data.actionButton` (legacy) se sigue aceptando y
+  equivale a un array de un elemento.
+
+## 2. Formato que debe enviar el panel (canónico)
+
+En el `data` del mensaje de Expo Push (y en el registro de Firebase
+`/notifications/{id}`), enviad **`actionButtons`** como **array** de 1 a 3 objetos:
+
+```jsonc
+"data": {
+  "id": "uuid-de-firebase",            // CRÍTICO, mantenedlo siempre
+  "internalRoute": "/(tabs)/cancionero",
+  "actionButtons": [
+    {
+      "text": "Apuntarme",             // texto del botón (obligatorio en la práctica)
+      "url": "https://mcmespana.com/inscripcion", // URL externa o ruta interna
+      "isInternal": false              // true = navega dentro de la app; false = abre navegador
+    },
+    { "text": "Ver fechas", "url": "/(tabs)/calendario", "isInternal": true }
+  ]
+}
+```
+
+### Reglas que aplica la app (validar también en el panel)
+
+- **Máximo 3 botones.** Si se mandan más, la app usa los 3 primeros. Mejor limitarlo
+  en el formulario.
+- Cada botón **necesita `url`**. Los que no la tengan se descartan.
+- `text`: si falta, la app pone `"Ver"`. Recomendado: obligar a rellenarlo (máx. ~20
+  caracteres para que no se corte en el chip).
+- `isInternal`: si no viene, la app lo **infiere** (interno si la `url` NO empieza por
+  `http(s)://`). Recomendado: mandarlo **explícito** desde el panel.
+  - `isInternal: true` → `url` debe ser una **ruta interna** válida (ver tabla de
+    rutas en `NOTIFICACIONES_CONTRATO.md` §2; p. ej. `/(tabs)/fotos`).
+  - `isInternal: false` → `url` debe ser una **URL externa** `https://…`.
+
+### Compatibilidad (no romper envíos antiguos)
+
+- El formato legacy `data.actionButton` (objeto único) sigue funcionando. El panel
+  puede dejar de usarlo, pero si lo mantiene, la app lo entiende.
+- Si el panel manda **ambos** (`actionButton` + `actionButtons`), la app los combina
+  y deduplica por `url|text`. Para evitar confusión, mandad **solo `actionButtons`**.
+
+## 3. Cambios en la UI del panel (formulario de envío)
+
+1. Sustituir el bloque de "botón de acción" único por una **lista dinámica de botones**
+   (repeater) con botón **"Añadir botón"**, hasta un **máximo de 3**.
+2. Cada fila del repeater: `text` (input), `url` (input), `isInternal` (toggle/select
+   "Interno" vs "Externo"). Botón para **eliminar** la fila.
+3. Validación:
+   - 0 botones permitido (notificación sin CTA).
+   - Si `isInternal` = interno → validar contra la lista blanca de rutas internas.
+   - Si externo → validar que empiece por `https://`.
+4. Al enviar y al guardar en Firebase, serializar como `data.actionButtons: [...]`.
+   - **Importante**: no enviéis claves `undefined`/vacías dentro de los objetos del
+     array; Firebase RTDB no admite `undefined`. Omitid el campo o usad `null` según
+     vuestra convención (mejor omitir).
+
+## 4. Notas / límites
+
+- Estos botones son **in-app** (tarjeta + modal del centro de notificaciones de la
+  app). Los botones de la **notificación del sistema iOS** dependen de *categorías*
+  pre-registradas en la app (`categoryId` ∈ `general`/`eventos`/`fotos`, 1 botón cada
+  una) y **no** se pueden definir dinámicamente desde el payload. No confundir ambos.
+- En Android la notificación del sistema tampoco pinta estos botones dinámicos; son
+  para dentro de la app.
+- El cambio en la app es **OTA** (JS puro), así que no requiere build de tienda: en
+  cuanto la OTA esté publicada, los dispositivos verán varios botones.
+
+## 5. Referencias en el repo de la app
+
+- Contrato completo: `NOTIFICACIONES_CONTRATO.md` (§3 botones de acción, §2 rutas).
+- Guía funcional: `NOTIFICACIONES.md` (§"Arquitectura de botones y navegación").
+- Implementación: `mcm-app/utils/notificationRoutes.ts`
+  (`extractActionButtons`, `MAX_ACTION_BUTTONS`), `mcm-app/types/notifications.ts`
+  (`NotificationActionButtonData`), `mcm-app/app/notifications.tsx` (render).

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 2026-06-06 — Notificaciones: varios botones de acción (hasta 3)
+
+- **Antes** una notificación solo mostraba **un** botón de acción (`actionButton`);
+  el array `actionButtons` del panel se aceptaba pero solo se usaba el primer
+  elemento. **Ahora** se soportan **hasta 3 botones** por notificación, tanto en la
+  tarjeta del centro de notificaciones (un chip por botón) como en el modal de
+  detalle (botones apilados: el 1.º primario, los siguientes secundarios).
+- Nuevo `extractActionButtons()` en `utils/notificationRoutes.ts` (límite
+  `MAX_ACTION_BUTTONS = 3`): acepta el array `actionButtons` y el objeto único
+  `actionButton` (legacy), los combina y deduplica por `url|text`. Se conserva
+  `extractActionButton()` como atajo al primer botón.
+- Tipos: `NotificationActionButtonData` + campo `actionButtons[]` en
+  `NotificationData` y `ReceivedNotification` (`actionButton` se mantiene por
+  compatibilidad).
+- Archivos: `utils/notificationRoutes.ts`, `types/notifications.ts`,
+  `app/notifications.tsx`, `services/pushNotificationService.ts`,
+  `notifications/usePushNotifications.ts`, `__tests__/notificationRoutes.test.ts`.
+- Compatible con OTA (JS puro, sin código nativo). El MCM Panel debe enviar
+  `data.actionButtons` (array) — ver `NOTIFICACIONES_CONTRATO.md` §3.
+
 ## 2026-06-06 — Tab bar iOS visible + icono verde en carismochito
 
 - **Tab bar inferior translúcida/ilegible en iOS ≤18**: la barra nativa

--- a/mcm-app/__tests__/notificationRoutes.test.ts
+++ b/mcm-app/__tests__/notificationRoutes.test.ts
@@ -1,6 +1,8 @@
 import {
   normalizeNotificationRoute,
   extractActionButton,
+  extractActionButtons,
+  MAX_ACTION_BUTTONS,
 } from '@/utils/notificationRoutes';
 
 describe('normalizeNotificationRoute', () => {
@@ -76,5 +78,75 @@ describe('extractActionButton', () => {
     expect(
       extractActionButton({ actionButtons: [{ url: 'http://x.com' }] }),
     ).toEqual({ text: 'Ver', url: 'http://x.com', isInternal: false });
+  });
+});
+
+describe('extractActionButtons', () => {
+  it('devuelve un array vacío sin datos', () => {
+    expect(extractActionButtons(undefined)).toEqual([]);
+    expect(extractActionButtons({})).toEqual([]);
+  });
+
+  it('devuelve varios botones desde el array actionButtons', () => {
+    expect(
+      extractActionButtons({
+        actionButtons: [
+          { text: 'Sí', url: 'https://x.com/si' },
+          { text: 'No', url: 'https://x.com/no' },
+          { text: 'Fotos', url: '/(tabs)/fotos' },
+        ],
+      }),
+    ).toEqual([
+      { text: 'Sí', url: 'https://x.com/si', isInternal: false },
+      { text: 'No', url: 'https://x.com/no', isInternal: false },
+      { text: 'Fotos', url: '/(tabs)/fotos', isInternal: true },
+    ]);
+  });
+
+  it('envuelve el actionButton único (legacy) en un array', () => {
+    expect(
+      extractActionButtons({
+        actionButton: { text: 'Ver', url: '/(tabs)/mas', isInternal: true },
+      }),
+    ).toEqual([{ text: 'Ver', url: '/(tabs)/mas', isInternal: true }]);
+  });
+
+  it('combina actionButton + actionButtons y deduplica por url|text', () => {
+    expect(
+      extractActionButtons({
+        actionButton: { text: 'A', url: 'https://x.com/a' },
+        actionButtons: [
+          { text: 'A', url: 'https://x.com/a' }, // duplicado → se ignora
+          { text: 'B', url: 'https://x.com/b' },
+        ],
+      }),
+    ).toEqual([
+      { text: 'A', url: 'https://x.com/a', isInternal: false },
+      { text: 'B', url: 'https://x.com/b', isInternal: false },
+    ]);
+  });
+
+  it(`limita el número de botones a ${MAX_ACTION_BUTTONS}`, () => {
+    const result = extractActionButtons({
+      actionButtons: [
+        { text: '1', url: 'https://x.com/1' },
+        { text: '2', url: 'https://x.com/2' },
+        { text: '3', url: 'https://x.com/3' },
+        { text: '4', url: 'https://x.com/4' },
+      ],
+    });
+    expect(result).toHaveLength(MAX_ACTION_BUTTONS);
+    expect(result.map((b) => b.text)).toEqual(['1', '2', '3']);
+  });
+
+  it('descarta botones inválidos (sin url)', () => {
+    expect(
+      extractActionButtons({
+        actionButtons: [
+          { text: 'Sin url' },
+          { text: 'OK', url: '/(tabs)/mas' },
+        ],
+      }),
+    ).toEqual([{ text: 'OK', url: '/(tabs)/mas', isInternal: true }]);
   });
 });

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -33,7 +33,11 @@ import {
   initializeNewUserReadStatus,
   isNotificationOlderThan60Days,
 } from '@/services/pushNotificationService';
-import { NotificationData, ReceivedNotification } from '@/types/notifications';
+import {
+  NotificationData,
+  NotificationActionButtonData,
+  ReceivedNotification,
+} from '@/types/notifications';
 import { normalizeNotificationRoute } from '@/utils/notificationRoutes';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import NotificationPermissionBanner from '@/components/NotificationPermissionBanner';
@@ -85,6 +89,18 @@ const normalizeRoute = normalizeNotificationRoute;
 function getRouteLabel(route: string): { label: string; icon: string } | null {
   const norm = normalizeRoute(route);
   return ROUTE_LABELS[norm] ?? ROUTE_LABELS[route] ?? null;
+}
+
+// Devuelve los botones de acción de una notificación (hasta 3). Soporta tanto
+// el array `actionButtons` (formato actual) como el `actionButton` único
+// (legacy / notificaciones cacheadas antiguas).
+function getActionButtons(
+  notification: NotificationData | ReceivedNotification,
+): NotificationActionButtonData[] {
+  if (notification.actionButtons && notification.actionButtons.length > 0) {
+    return notification.actionButtons;
+  }
+  return notification.actionButton ? [notification.actionButton] : [];
 }
 
 export default function NotificationsScreen() {
@@ -205,7 +221,11 @@ export default function NotificationsScreen() {
   }, []);
 
   const handleActionButtonPress = useCallback(
-    (notification: NotificationData | ReceivedNotification, e: any) => {
+    (
+      notification: NotificationData | ReceivedNotification,
+      button: NotificationActionButtonData,
+      e: any,
+    ) => {
       // Prevenir que el tap llegue al card padre
       if (e?.stopPropagation) e.stopPropagation();
       if (!isNotificationRead(notification)) {
@@ -213,11 +233,11 @@ export default function NotificationsScreen() {
           console.error('Error marcando como leída:', err),
         );
       }
-      if (!notification.actionButton) return;
-      if (notification.actionButton.isInternal) {
-        safePushRoute(notification.actionButton.url);
+      if (!button) return;
+      if (button.isInternal) {
+        safePushRoute(button.url);
       } else {
-        Linking.openURL(notification.actionButton.url).catch((err) =>
+        Linking.openURL(button.url).catch((err) =>
           console.error('Error abriendo URL:', err),
         );
       }
@@ -268,6 +288,7 @@ export default function NotificationsScreen() {
     const routeInfo = notification.internalRoute
       ? getRouteLabel(notification.internalRoute)
       : null;
+    const actionButtons = getActionButtons(notification);
 
     return (
       <View style={{ marginBottom: spacing.md }}>
@@ -346,29 +367,31 @@ export default function NotificationsScreen() {
                       </Text>
                     </View>
                   )}
-                  {/* Chip de botón de acción — Pressable para evitar <button> anidado en web */}
-                  {notification.actionButton && (
+                  {/* Chips de botones de acción (hasta 3) — Pressable para
+                      evitar <button> anidado en web */}
+                  {actionButtons.map((button, idx) => (
                     <Pressable
+                      key={`${button.url}-${idx}`}
                       style={styles.actionChip}
-                      onPress={(e?) => handleActionButtonPress(notification, e)}
-                      accessibilityLabel={notification.actionButton.text}
+                      onPress={(e?) =>
+                        handleActionButtonPress(notification, button, e)
+                      }
+                      accessibilityLabel={button.text}
                       accessibilityRole="button"
                       hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
                     >
                       <Text style={styles.actionChipText} numberOfLines={1}>
-                        {notification.actionButton.text}
+                        {button.text}
                       </Text>
                       <MaterialIcons
                         name={
-                          notification.actionButton.isInternal
-                            ? 'arrow-forward'
-                            : 'open-in-new'
+                          button.isInternal ? 'arrow-forward' : 'open-in-new'
                         }
                         size={11}
                         color="#fff"
                       />
                     </Pressable>
-                  )}
+                  ))}
                 </View>
               </View>
             </View>
@@ -543,19 +566,21 @@ function NotificationDetailModal({
     }
   };
 
+  const actionButtons = notification ? getActionButtons(notification) : [];
+
   const handleInternalRoute = () => {
     if (!notification) return;
     onClose();
     safePushRoute(notification.internalRoute ?? '');
   };
 
-  const handleActionButton = () => {
-    if (!notification?.actionButton) return;
-    if (notification.actionButton.isInternal) {
+  const handleActionButton = (button: NotificationActionButtonData) => {
+    if (!button) return;
+    if (button.isInternal) {
       onClose();
-      safePushRoute(notification.actionButton.url);
+      safePushRoute(button.url);
     } else {
-      Linking.openURL(notification.actionButton.url).catch((err) =>
+      Linking.openURL(button.url).catch((err) =>
         console.error('Error abriendo URL:', err),
       );
     }
@@ -619,7 +644,7 @@ function NotificationDetailModal({
                 </Text>
 
                 {/* Separador si hay acciones */}
-                {(notification.internalRoute || notification.actionButton) && (
+                {(notification.internalRoute || actionButtons.length > 0) && (
                   <View
                     style={[
                       dStyles.divider,
@@ -654,27 +679,34 @@ function NotificationDetailModal({
                   </Button>
                 )}
 
-                {/* Botón de acción CTA */}
-                {notification.actionButton && (
+                {/* Botones de acción CTA (hasta 3). El primero destaca como
+                    primario; los siguientes van en estilo secundario. */}
+                {actionButtons.map((button, idx) => (
                   <Button
-                    variant="primary"
-                    onPress={handleActionButton}
-                    style={dStyles.actionButton}
+                    key={`${button.url}-${idx}`}
+                    variant={idx === 0 ? 'primary' : 'secondary'}
+                    onPress={() => handleActionButton(button)}
+                    style={[
+                      dStyles.actionButton,
+                      idx > 0 && dStyles.actionButtonSecondary,
+                    ]}
                   >
-                    <Button.Label style={dStyles.actionButtonText}>
-                      {notification.actionButton.text}
+                    <Button.Label
+                      style={
+                        idx === 0
+                          ? dStyles.actionButtonText
+                          : dStyles.actionButtonTextSecondary
+                      }
+                    >
+                      {button.text}
                     </Button.Label>
                     <MaterialIcons
-                      name={
-                        notification.actionButton.isInternal
-                          ? 'arrow-forward'
-                          : 'open-in-new'
-                      }
+                      name={button.isInternal ? 'arrow-forward' : 'open-in-new'}
                       size={18}
-                      color="#fff"
+                      color={idx === 0 ? '#fff' : colors.primary}
                     />
                   </Button>
-                )}
+                ))}
               </>
             )}
           </ScrollView>
@@ -734,10 +766,23 @@ const dStyles = StyleSheet.create({
     paddingHorizontal: 32,
     borderRadius: radii.lg,
     gap: 10,
+    marginBottom: spacing.md,
     ...shadows.lg,
     shadowColor: colors.primary,
   },
   actionButtonText: { color: '#fff', fontSize: 17, fontWeight: '700' },
+  actionButtonSecondary: {
+    backgroundColor: hexAlpha(colors.primary, '12'),
+    borderWidth: 1.5,
+    borderColor: colors.primary,
+    ...shadows.sm,
+    shadowColor: colors.primary,
+  },
+  actionButtonTextSecondary: {
+    color: colors.primary,
+    fontSize: 16,
+    fontWeight: '700',
+  },
 });
 
 // ============================================================================

--- a/mcm-app/notifications/usePushNotifications.ts
+++ b/mcm-app/notifications/usePushNotifications.ts
@@ -26,6 +26,7 @@ import { ReceivedNotification } from '@/types/notifications';
 import {
   normalizeNotificationRoute,
   extractActionButton,
+  extractActionButtons,
 } from '@/utils/notificationRoutes';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
@@ -149,6 +150,9 @@ export default function usePushNotifications() {
             | string
             | undefined,
           actionButton: extractActionButton(notification.request.content.data),
+          actionButtons: extractActionButtons(
+            notification.request.content.data,
+          ),
           receivedAt: new Date().toISOString(),
           isRead: false,
           category: notification.request.content.data?.category as any,
@@ -221,6 +225,7 @@ export default function usePushNotifications() {
           icon: data?.icon as string | undefined,
           imageUrl: data?.imageUrl as string | undefined,
           actionButton: extractActionButton(data),
+          actionButtons: extractActionButtons(data),
           receivedAt: new Date().toISOString(),
           isRead: false,
           category: data?.category as any,

--- a/mcm-app/services/pushNotificationService.ts
+++ b/mcm-app/services/pushNotificationService.ts
@@ -17,22 +17,25 @@ import {
   NotificationData,
   ReceivedNotification,
 } from '@/types/notifications';
-import { extractActionButton } from '@/utils/notificationRoutes';
+import { extractActionButtons } from '@/utils/notificationRoutes';
 
 /**
  * Normaliza un registro de notificación de Firebase a la forma canónica que usa
- * la app. En particular convierte `actionButtons` (array, formato del contrato
- * del panel) al `actionButton` único que renderiza la pantalla.
+ * la app. Unifica el botón único (`actionButton`, legacy) y el array
+ * (`actionButtons`, hasta 3) en el array `actionButtons` que renderiza la
+ * pantalla. Se conserva `actionButton` (= primer botón) por compatibilidad.
  */
 const normalizeNotificationRecord = (
   key: string,
   val: any,
 ): NotificationData => {
-  const actionButton = extractActionButton(val);
+  const actionButtons = extractActionButtons(val);
   return {
     ...val,
     id: val.id || key,
-    ...(actionButton ? { actionButton } : {}),
+    ...(actionButtons.length > 0
+      ? { actionButtons, actionButton: actionButtons[0] }
+      : {}),
   };
 };
 

--- a/mcm-app/types/notifications.ts
+++ b/mcm-app/types/notifications.ts
@@ -1,6 +1,16 @@
 // types/notifications.ts
 
 /**
+ * Botón de acción de una notificación: un call-to-action con texto propio que
+ * abre una URL externa o navega a una ruta interna de la app.
+ */
+export interface NotificationActionButtonData {
+  text: string; // Texto del botón, ej: "Ver más", "Abrir", "Ir a calendario"
+  url: string; // URL de destino (externa) o ruta interna
+  isInternal: boolean; // true = navegación interna, false = abrir navegador
+}
+
+/**
  * Estructura de una notificación completa en Firebase
  * Esta es la estructura que el panel de administración creará
  */
@@ -11,12 +21,12 @@ export interface NotificationData {
   icon?: string; // URL de la imagen del icono (PNG/JPG, debe ser accesible públicamente)
   imageUrl?: string; // URL de imagen grande opcional (para notificaciones ricas)
 
-  // Configuración del botón de acción (opcional)
-  actionButton?: {
-    text: string; // Texto del botón, ej: "Ver más", "Abrir", "Ir a calendario"
-    url: string; // URL de destino
-    isInternal: boolean; // true = navegación interna, false = abrir navegador
-  };
+  // Configuración del botón de acción único (legacy — usar actionButtons)
+  actionButton?: NotificationActionButtonData;
+
+  // Botones de acción (hasta 3). Es el formato recomendado; `actionButton`
+  // (singular) se mantiene por compatibilidad y equivale a un array de uno.
+  actionButtons?: NotificationActionButtonData[];
 
   // Metadata
   createdAt: string; // ISO timestamp de cuándo se creó
@@ -72,11 +82,8 @@ export interface ReceivedNotification {
   body: string;
   icon?: string;
   imageUrl?: string;
-  actionButton?: {
-    text: string;
-    url: string;
-    isInternal: boolean;
-  };
+  actionButton?: NotificationActionButtonData; // legacy (un botón)
+  actionButtons?: NotificationActionButtonData[]; // hasta 3 botones
   receivedAt: string; // ISO timestamp
   isRead: boolean;
   category?: NotificationCategory;

--- a/mcm-app/utils/notificationRoutes.ts
+++ b/mcm-app/utils/notificationRoutes.ts
@@ -11,10 +11,11 @@
 //      `jubileo`, `albums`, `wordle`). Así un error de configuración del panel
 //      no deja al usuario en una pantalla 404.
 //
-//   2. extractActionButton(): normaliza el botón de acción. El contrato del panel
-//      define `data.actionButtons` (array) pero la app trabaja con un único
-//      `actionButton` (objeto con `isInternal`). Esta función acepta ambos
-//      formatos y devuelve siempre la forma canónica.
+//   2. extractActionButtons(): normaliza los botones de acción. Una notificación
+//      puede llevar hasta 3 botones. Acepta tanto `data.actionButtons` (array)
+//      como `data.actionButton` (objeto único, legacy) y devuelve siempre un
+//      array canónico (máx. 3). `extractActionButton()` se conserva como atajo
+//      al primer botón para compatibilidad hacia atrás.
 
 /**
  * Rutas que el panel puede enviar pero que NO existen como ruta propia en el
@@ -88,23 +89,17 @@ export interface NotificationActionButton {
   isInternal: boolean;
 }
 
+/** Máximo de botones de acción que la app renderiza por notificación. */
+export const MAX_ACTION_BUTTONS = 3;
+
 /**
- * Extrae el botón de acción de los datos de una notificación, aceptando tanto
- * el formato canónico de la app (`actionButton`, objeto) como el del contrato
- * del panel (`actionButtons`, array — se usa el primer elemento).
+ * Normaliza un objeto crudo de botón (`{ text, url, isInternal? }`) a la forma
+ * canónica. Devuelve `undefined` si no es válido (sin `url`).
  *
  * Si `isInternal` no viene explícito, se infiere: una ruta interna NO empieza
  * por `http(s)://`.
  */
-export function extractActionButton(
-  data: Record<string, any> | null | undefined,
-): NotificationActionButton | undefined {
-  if (!data) return undefined;
-
-  const raw =
-    data.actionButton ??
-    (Array.isArray(data.actionButtons) ? data.actionButtons[0] : undefined);
-
+function normalizeButton(raw: any): NotificationActionButton | undefined {
   if (!raw || typeof raw !== 'object' || !raw.url) return undefined;
 
   const url = String(raw.url);
@@ -114,4 +109,44 @@ export function extractActionButton(
       : !/^https?:\/\//i.test(url);
 
   return { text: String(raw.text ?? 'Ver'), url, isInternal };
+}
+
+/**
+ * Extrae TODOS los botones de acción de los datos de una notificación (máx. 3),
+ * aceptando tanto el formato con múltiples botones (`actionButtons`, array) como
+ * el legacy de un único botón (`actionButton`, objeto). Si vienen ambos, se
+ * combinan: primero el objeto único y después el array (deduplicando por
+ * `url|text`). El resultado siempre es un array canónico (puede estar vacío).
+ */
+export function extractActionButtons(
+  data: Record<string, any> | null | undefined,
+): NotificationActionButton[] {
+  if (!data) return [];
+
+  const candidates: any[] = [];
+  if (data.actionButton) candidates.push(data.actionButton);
+  if (Array.isArray(data.actionButtons)) candidates.push(...data.actionButtons);
+
+  const seen = new Set<string>();
+  const buttons: NotificationActionButton[] = [];
+  for (const candidate of candidates) {
+    const button = normalizeButton(candidate);
+    if (!button) continue;
+    const key = `${button.url}|${button.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    buttons.push(button);
+    if (buttons.length >= MAX_ACTION_BUTTONS) break;
+  }
+  return buttons;
+}
+
+/**
+ * Atajo: devuelve el primer botón de acción (o `undefined`). Se conserva para
+ * los puntos del código que solo necesitan un botón y para compatibilidad.
+ */
+export function extractActionButton(
+  data: Record<string, any> | null | undefined,
+): NotificationActionButton | undefined {
+  return extractActionButtons(data)[0];
 }


### PR DESCRIPTION
## Qué cambia

Antes una notificación solo renderizaba **un** botón de acción (`actionButton`); el array `actionButtons` del panel se aceptaba pero solo se usaba el primer elemento. **Ahora se soportan hasta 3 botones** por notificación.

- **Tarjeta** del centro de notificaciones: un chip tappable por botón.
- **Modal de detalle**: botones apilados (el 1.º primario, los siguientes secundarios).

## Detalles técnicos

- `utils/notificationRoutes.ts` — nuevo `extractActionButtons()` (límite `MAX_ACTION_BUTTONS = 3`). Acepta el array `actionButtons` y el objeto único `actionButton` (legacy), los combina y deduplica por `url|text`. Se conserva `extractActionButton()` como atajo al primero.
- `types/notifications.ts` — nuevo tipo `NotificationActionButtonData` + campo `actionButtons[]` en `NotificationData` y `ReceivedNotification` (`actionButton` se mantiene por compatibilidad).
- `app/notifications.tsx` — render de varios chips/botones.
- `services/pushNotificationService.ts` y `notifications/usePushNotifications.ts` — normalizan/guardan el array desde Firebase y desde foreground/tap.

## Docs

- Actualizados `NOTIFICACIONES.md` y `NOTIFICACIONES_CONTRATO.md`.
- Nuevo `PROMPT_MCMPANEL_NOTIS_BOTONES.md` con la guía para que el MCM Panel componga y envíe `actionButtons` (array, máx. 3).

## Verificación

- Tests: 101 pasan (6 nuevos para `extractActionButtons`).
- Lint limpio en los archivos tocados.
- **Compatible con OTA** (JS puro, sin código nativo).

> Nota: estos botones son in-app (tarjeta + modal). Los botones de la notificación del sistema iOS dependen de categorías pre-registradas y no se generan dinámicamente desde el payload.

https://claude.ai/code/session_01EwVGo7viVbRw2qQDuJaWsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwVGo7viVbRw2qQDuJaWsp)_