### PR TITLE
Revisión de diseño/modo oscuro: fixes de robustez, leaks y lint

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,24 @@
 
 ---
 
+## 2026-06-10 — Revisión de diseño/modo oscuro + fixes de robustez
+
+- **`useFirebaseData` tolera caché corrupta**: antes, un `JSON.parse` fallido del
+  caché local abortaba también el fetch remoto (pantalla vacía permanente hasta
+  borrar datos). Ahora se descarta la entrada corrupta y se continúa con la
+  descarga completa. (`hooks/useFirebaseData.ts`)
+- **Fix memory leak en `HorarioScreen`**: la animación del último día (fade
+  recursivo vía `setTimeout` + shake inicial) seguía ejecutándose para siempre
+  tras salir de la pantalla; ahora se cancelan todos los timers en el cleanup.
+- **Splash de bienvenida respeta el modo oscuro**: el contenedor de la animación
+  inicial tenía fondo blanco fijo y provocaba un flash blanco al abrir la app en
+  oscuro. (`app/_layout.tsx`)
+- **Fix error de tipos en `SocialLoginSection`**: guard `Platform.OS !== 'android'`
+  redundante (Android ya hace early-return antes) que hacía fallar `tsc --noEmit`.
+- Lint a cero: corregidos los 2 errores de `react/no-unescaped-entities` en
+  `contigo/revision.tsx` y los avisos de Prettier pendientes (`--fix`).
+- **OTA-safe** (solo JS).
+
 ## 2026-06-09 — Encuestas: banners automáticos + identidad real (auth)
 
 - **Banners automáticos** de encuestas genéricas sin depender de push. La app lee

--- a/mcm-app/app/(tabs)/contigo/revision.tsx
+++ b/mcm-app/app/(tabs)/contigo/revision.tsx
@@ -275,7 +275,7 @@ export default function RevisionScreen() {
             style={[styles.pillText, { color: purple }]}
             accessibilityLabel="Revisión: agradecer y revisar"
           >
-            ✦ EXAMEN ESTILO 'AGRADECER Y REVISAR'
+            ✦ EXAMEN ESTILO &apos;AGRADECER Y REVISAR&apos;
           </Text>
         </View>
       </View>

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -119,7 +119,10 @@ export default function FotosScreen() {
         await Linking.openURL(albumUrl);
       } catch (error) {
         console.error('Failed to open URL:', error);
-        Alert.alert('Error', 'No seh a podido abrir el link que pena más grande');
+        Alert.alert(
+          'Error',
+          'No se ha podido abrir el link, qué pena más grande',
+        );
       }
     } else {
       console.warn(`Don't know how to open this URL: ${albumUrl}`);

--- a/mcm-app/app/_layout.tsx
+++ b/mcm-app/app/_layout.tsx
@@ -196,7 +196,12 @@ function InnerLayout() {
 
   if (showAnimation) {
     return (
-      <View style={styles.animationContainer}>
+      <View
+        style={[
+          styles.animationContainer,
+          scheme === 'dark' && styles.animationContainerDark,
+        ]}
+      >
         <HelloWave />
       </View>
     );
@@ -277,5 +282,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#fff',
+  },
+  animationContainerDark: {
+    backgroundColor: '#2C2C2E',
   },
 });

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -529,8 +529,8 @@ function WelcomeScreen({
             entering={FadeInUp.delay(280).duration(420)}
             style={welcomeStyles.body}
           >
-            Una sencilla app para cuidar la Vida del MCM:
-            calendario, cantoral, un espacio para tus momentos de oración...
+            Una sencilla app para cuidar la Vida del MCM: calendario, cantoral,
+            un espacio para tus momentos de oración...
           </Animated.Text>
         </View>
 
@@ -697,7 +697,8 @@ function ProfileScreen({
           ¿Quién eres? (1 minuto)
         </Text>
         <Text style={[stepStyles.heroSub, { color: TT.muted }]}>
-          Según tu perfil te mostraremos lo más adecuado. Puedes cambiarlo después.
+          Según tu perfil te mostraremos lo más adecuado. Puedes cambiarlo
+          después.
         </Text>
       </Animated.View>
 
@@ -848,7 +849,7 @@ function DelegationScreen({
           ¿De qué localidad?
         </Text>
         <Text style={[stepStyles.heroSub, { color: TT.muted }]}>
-          En el futuro, recibirás  notificaciones y calendario de tu MCM Local.
+          En el futuro, recibirás notificaciones y calendario de tu MCM Local.
         </Text>
       </Animated.View>
 

--- a/mcm-app/app/screens/HorarioScreen.tsx
+++ b/mcm-app/app/screens/HorarioScreen.tsx
@@ -84,6 +84,8 @@ export default function HorarioScreen() {
   // Trigger animations for last day
   useEffect(() => {
     if (isLastDay) {
+      let cancelled = false;
+      let fadeTimeout: ReturnType<typeof setTimeout> | undefined;
       // Subtle shake animation
       const shake = () => {
         Animated.sequence([
@@ -125,18 +127,24 @@ export default function HorarioScreen() {
           }),
         ]).start(() => {
           // Repeat fade animation
-          setTimeout(fade, 2000);
+          if (cancelled) return;
+          fadeTimeout = setTimeout(fade, 2000);
         });
       };
 
       // Start animations with delays
-      setTimeout(shake, 1000);
+      const shakeTimeout = setTimeout(shake, 1000);
       fade();
 
       // Repeat shake every 8 seconds
       const shakeInterval = setInterval(shake, 8000);
 
-      return () => clearInterval(shakeInterval);
+      return () => {
+        cancelled = true;
+        clearTimeout(shakeTimeout);
+        if (fadeTimeout) clearTimeout(fadeTimeout);
+        clearInterval(shakeInterval);
+      };
     }
   }, [isLastDay, shakeAnim, fadeAnim]);
 

--- a/mcm-app/app/screens/ProfundizaScreen.tsx
+++ b/mcm-app/app/screens/ProfundizaScreen.tsx
@@ -122,9 +122,7 @@ export default function ProfundizaScreen() {
 
   const secciones = normalizeSecciones(profundizaData ?? null);
   const hasContent = secciones.some(
-    (s) =>
-      s.introduccion ||
-      (Array.isArray(s.paginas) && s.paginas.length > 0),
+    (s) => s.introduccion || (Array.isArray(s.paginas) && s.paginas.length > 0),
   );
 
   if (!hasContent) {

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -462,7 +462,9 @@ export default function ReflexionesScreen() {
               </Pressable>
 
               <View style={styles.field}>
-                <Text style={styles.inputLabel}>¿Quién la envía? (opcional)</Text>
+                <Text style={styles.inputLabel}>
+                  ¿Quién la envía? (opcional)
+                </Text>
                 <TextInput
                   value={autor}
                   onChangeText={setAutor}

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -464,7 +464,9 @@ export default function SongsListScreen({
   );
 
   if ((isLoading || loadingSongs) && songs.length === 0) {
-    return <ProgressWithMessage message="Cargando canciones un momentito porfi..." />;
+    return (
+      <ProgressWithMessage message="Cargando canciones un momentito porfi..." />
+    );
   }
 
   if (error) {

--- a/mcm-app/components/SocialLoginSection.tsx
+++ b/mcm-app/components/SocialLoginSection.tsx
@@ -381,7 +381,9 @@ export default function SocialLoginSection({
       : scheme === 'dark'
         ? 'rgba(255,255,255,0.06)'
         : hexAlpha(brandColors.primary, '10');
-    const csIcon = onDarkBackground ? 'rgba(255,255,255,0.85)' : brandColors.primary;
+    const csIcon = onDarkBackground
+      ? 'rgba(255,255,255,0.85)'
+      : brandColors.primary;
     const csTitle = onDarkBackground ? '#fff' : theme.text;
     const csBody = onDarkBackground ? 'rgba(255,255,255,0.75)' : theme.icon;
     return (
@@ -469,32 +471,30 @@ export default function SocialLoginSection({
         </Text>
       </TouchableOpacity>
 
-      {/* Apple — iOS y web */}
-      {Platform.OS !== 'android' && (
-        <TouchableOpacity
-          style={[
-            styles.socialBtn,
-            styles.appleBtn,
-            !onDarkBackground && scheme === 'dark'
-              ? { borderColor: 'rgba(255,255,255,0.18)' }
-              : null,
-            ...(signingIn && signingIn !== 'apple' ? [styles.btnDisabled] : []),
-          ]}
-          onPress={handleAppleSignIn}
-          disabled={!!signingIn}
-          accessibilityRole="button"
-          accessibilityLabel="Continuar con Apple"
-        >
-          {signingIn === 'apple' ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <MaterialIcons name="apple" size={20} color="#fff" />
-          )}
-          <Text style={[styles.socialBtnLabel, { color: '#fff' }]}>
-            Continuar con Apple
-          </Text>
-        </TouchableOpacity>
-      )}
+      {/* Apple — iOS y web (Android ya salió antes con su aviso propio) */}
+      <TouchableOpacity
+        style={[
+          styles.socialBtn,
+          styles.appleBtn,
+          !onDarkBackground && scheme === 'dark'
+            ? { borderColor: 'rgba(255,255,255,0.18)' }
+            : null,
+          ...(signingIn && signingIn !== 'apple' ? [styles.btnDisabled] : []),
+        ]}
+        onPress={handleAppleSignIn}
+        disabled={!!signingIn}
+        accessibilityRole="button"
+        accessibilityLabel="Continuar con Apple"
+      >
+        {signingIn === 'apple' ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <MaterialIcons name="apple" size={20} color="#fff" />
+        )}
+        <Text style={[styles.socialBtnLabel, { color: '#fff' }]}>
+          Continuar con Apple
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -164,7 +164,8 @@ const SongControls: React.FC<SongControlsProps> = ({
   const handleSecretPanelSuccess = () => {
     toast.show({
       variant: 'success',
-      label: '¡Gracias por tu aviso totalmente secreto! Cada 48 horas se sincronizan estos cambios',
+      label:
+        '¡Gracias por tu aviso totalmente secreto! Cada 48 horas se sincronizan estos cambios',
       actionLabel: 'OK',
       onActionPress: ({ hide }) => hide(),
     });

--- a/mcm-app/components/contigo/BreathingPhase.tsx
+++ b/mcm-app/components/contigo/BreathingPhase.tsx
@@ -68,7 +68,9 @@ export function BreathingPhase({ onDone }: { onDone: () => void }) {
         <View style={styles.touch}>
           <View style={styles.headWrap}>
             <Text style={styles.title}>Para un momento...</Text>
-            <Text style={styles.subtitle}>Haz un STOP antes de revisar tu día</Text>
+            <Text style={styles.subtitle}>
+              Haz un STOP antes de revisar tu día
+            </Text>
           </View>
           <View style={styles.ringStack}>
             <Animated.View

--- a/mcm-app/components/contigo/HomeWidgets.tsx
+++ b/mcm-app/components/contigo/HomeWidgets.tsx
@@ -145,7 +145,7 @@ export function HeroCard({
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//            Eliminado un trocito 
+//            Eliminado un trocito
 //               <View style={styles.heroChip}>
 //                  <Text style={styles.heroChipEmoji}>⏱</Text>
 //                  <Text style={styles.heroChipText}>{totalMins} min</Text>

--- a/mcm-app/hooks/useFirebaseData.ts
+++ b/mcm-app/hooks/useFirebaseData.ts
@@ -33,12 +33,23 @@ export function useFirebaseData<T>(
             AsyncStorage.getItem(`${storageKey}_hidden`),
           ]);
 
+        // Caché corrupta (JSON inválido) no debe impedir el fetch remoto:
+        // se descarta y se sigue como si no hubiera caché.
+        let hasLocalCache = false;
         if (localDataStr && localDataStr !== 'undefined') {
-          const parsed = JSON.parse(localDataStr);
-          const transformed = transform ? transform(parsed) : (parsed as T);
-          if (isMounted) setData(transformed);
-          if (isMounted) setHidden(localHiddenStr === 'true');
-          setLoading(false); // show existing data while fetching remote
+          try {
+            const parsed = JSON.parse(localDataStr);
+            const transformed = transform ? transform(parsed) : (parsed as T);
+            if (isMounted) setData(transformed);
+            if (isMounted) setHidden(localHiddenStr === 'true');
+            setLoading(false); // show existing data while fetching remote
+            hasLocalCache = true;
+          } catch {
+            await AsyncStorage.multiRemove([
+              `${storageKey}_data`,
+              `${storageKey}_updatedAt`,
+            ]).catch(() => {});
+          }
         }
 
         const db = getDatabase(getFirebaseApp());
@@ -47,7 +58,6 @@ export function useFirebaseData<T>(
         // sólo el metadato (pocos bytes) y descargo `data` únicamente si
         // ha cambiado. Esto evita bajar megas de `songs`/`albums` en cada
         // arranque cuando el contenido remoto no se ha tocado.
-        const hasLocalCache = !!localDataStr && localDataStr !== 'undefined';
 
         if (hasLocalCache && localUpdatedAt) {
           const [metaSnap, hiddenSnap] = await Promise.all([


### PR DESCRIPTION
- useFirebaseData: una caché local corrupta (JSON inválido) ya no aborta
  el fetch remoto; se descarta la entrada y se continúa con la descarga
- HorarioScreen: cancelar los timers de las animaciones del último día
  (fade recursivo + shake) en el cleanup del efecto (memory leak)
- Splash de bienvenida con fondo acorde al tema (evita flash blanco en
  modo oscuro)
- SocialLoginSection: eliminar guard redundante de Platform.OS que hacía
  fallar tsc --noEmit
- fotos: corregir typo en mensaje de error visible al usuario
- Lint a cero: escapar comillas en contigo/revision.tsx y aplicar
  Prettier --fix a los avisos pendientes

https://claude.ai/code/session_012LJV45iDcdXDiVFqJFCG3f