### PR TITLE
Fix modo alpha: habilitar disableAntiBrickingMeasures para el override del canal OTA preview

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,26 @@
 
 ---
 
+## 2026-06-11 — Fix: el modo alpha (7 taps) no conectaba al canal OTA preview
+
+- **Causa raíz**: `Updates.setUpdateURLAndRequestHeadersOverride()` exige que el
+  binario esté construido con `updates.disableAntiBrickingMeasures: true` en
+  `app.json`. Sin ese flag, expo-updates lanza un error que el `try/catch` de
+  `PreviewChannelContext` silenciaba — el toggle parecía funcionar pero el
+  dispositivo seguía en el canal `production`.
+- **Fix**: añadido `"disableAntiBrickingMeasures": true` al bloque `updates` de
+  `app.json`, y el `catch` ahora hace `console.warn` para que el fallo sea
+  visible en logs. (`app.json`, `contexts/PreviewChannelContext.tsx`)
+- ⚠️ **Requiere build de tienda**: el flag se hornea en el binario nativo
+  (Expo.plist / AndroidManifest). Los binarios ya instalados seguirán ignorando
+  el toggle hasta que se publique una nueva build de producción con este cambio.
+  Las OTAs no pueden activar el flag.
+- El resto de la cadena ya estaba bien: 7 taps (`SecretMenuTrigger` →
+  `useSecretTap`) → modal Laboratorio Alpha → flag en AsyncStorage → override al
+  arrancar → `useOTAUpdate` hace `checkForUpdateAsync` contra el canal `preview`.
+  El workflow `.github/workflows/ota-preview.yml` publica en la branch EAS
+  `preview` con cada push a la rama git `preview`.
+
 ## 2026-06-10 — Revisión de diseño/modo oscuro + fixes de robustez
 
 - **`useFirebaseData` tolera caché corrupta**: antes, un `JSON.parse` fallido del

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -175,7 +175,8 @@
     "updates": {
       "url": "https://u.expo.dev/aa9f2d3a-b74a-4169-bad4-e851015e30c6",
       "fallbackToCacheTimeout": 0,
-      "checkAutomatically": "ON_LOAD"
+      "checkAutomatically": "ON_LOAD",
+      "disableAntiBrickingMeasures": true
     }
   }
 }

--- a/mcm-app/contexts/PreviewChannelContext.tsx
+++ b/mcm-app/contexts/PreviewChannelContext.tsx
@@ -79,8 +79,11 @@ function applyPreviewOverride(active: boolean) {
       updateUrl,
       requestHeaders: { 'expo-channel-name': PREVIEW_CHANNEL },
     });
-  } catch {
+  } catch (err) {
     // No bloqueante: si el override falla, la app sigue en su canal nativo.
+    // Requiere `updates.disableAntiBrickingMeasures: true` en app.json — en
+    // binarios construidos sin ese flag, expo-updates lanza aquí.
+    console.warn('[PreviewChannel] No se pudo aplicar el override OTA:', err);
   }
 }
 


### PR DESCRIPTION
setUpdateURLAndRequestHeadersOverride exige updates.disableAntiBrickingMeasures
en app.json; sin él lanzaba un error silenciado por el try/catch y el toggle de
7 taps nunca cambiaba el canal. Requiere nueva build de tienda para surtir efecto.

https://claude.ai/code/session_013Cvzdszef2qK2KTFhJHpBu