### PR TITLE
feat: seccion MCM Panel en Mas para administradores Firebase

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,16 @@
 
 ---
 
+## 2026-06-11 — Sección MCM Panel en Más (solo administradores Firebase)
+
+- **Nueva pantalla `McmPanelScreen`**: WebView que abre `mcmpanel.vercel.app`, notch violeta oscuro (`#4C1D95`) para distinguirlo visualmente del resto de pantallas.
+- **Nuevo hook `useAdminStatus`**: lee `users/{uid}/isAdmin` de Firebase RTDB en tiempo real. Devuelve `true` solo si el usuario está autenticado Y tiene ese campo a `true` en la base de datos. Completamente independiente del `isAdmin` local de `SettingsContext` (ese es para editar arreglos del cantoral).
+- **`MasHomeScreen`**: añade la tarjeta "MCM Panel" (violeta, icono `tune`, emoji 🎛️) al final de la lista. Solo aparece cuando `useAdminStatus().isAdmin === true` — nunca visible a usuarios no conectados o sin el flag en Firebase.
+- **`mas.tsx`**: añadida ruta `McmPanel` al stack de navegación.
+- Archivos: `hooks/useAdminStatus.ts` (nuevo), `app/screens/McmPanelScreen.tsx` (nuevo), `app/(tabs)/mas.tsx`, `app/screens/MasHomeScreen.tsx`
+
+---
+
 ## 2026-06-10 — Revisión de diseño/modo oscuro + fixes de robustez
 
 - **`useFirebaseData` tolera caché corrupta**: antes, un `JSON.parse` fallido del

--- a/mcm-app/app/(tabs)/mas.tsx
+++ b/mcm-app/app/(tabs)/mas.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MasHomeScreen from '../screens/MasHomeScreen';
 import ComunicaScreen from '../screens/ComunicaScreen';
 import ComunicaGestionScreen from '../screens/ComunicaGestionScreen';
+import McmPanelScreen from '../screens/McmPanelScreen';
 import AlbumListScreen from '../screens/AlbumListScreen';
 import CalendarioScreen from './calendario';
 import EventosPasadosScreen from '../screens/EventosPasadosScreen';
@@ -30,6 +31,7 @@ export type MasStackParamList = EventStackParamList & {
   Calendario: undefined;
   Comunica: undefined;
   ComunicaGestion: undefined;
+  McmPanel: undefined;
   EventosPasados: undefined;
 };
 
@@ -154,6 +156,13 @@ export default function MasTab() {
         <Stack.Screen
           name="ComunicaGestion"
           component={ComunicaGestionScreen}
+          options={{
+            headerShown: false, // Pantalla completa — sin header
+          }}
+        />
+        <Stack.Screen
+          name="McmPanel"
+          component={McmPanelScreen}
           options={{
             headerShown: false, // Pantalla completa — sin header
           }}

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -22,6 +22,7 @@ import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import AppFeedbackModal from '@/components/AppFeedbackModal';
 import { MasStackParamList } from '../(tabs)/mas';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
+import { useAdminStatus } from '@/hooks/useAdminStatus';
 import { takePendingMasScreen } from '@/utils/masNavigation';
 import PageContainer from '@/components/ui/PageContainer';
 import ScreenHero from '@/components/ui/ScreenHero';
@@ -43,6 +44,15 @@ interface NavigationItem {
   /** Id del evento a pasar como route param cuando target === 'JubileoHome'. */
   eventId?: string;
 }
+
+const MCM_PANEL_ITEM: NavigationItem = {
+  label: 'MCM Panel',
+  subtitle: 'Panel de administración de la app',
+  emoji: '🎛️',
+  materialIcon: 'tune',
+  target: 'McmPanel',
+  tintColor: '#6D28D9',
+};
 
 const MAS_ITEM_CATALOG: Record<string, NavigationItem> = {
   comunica: {
@@ -99,6 +109,7 @@ export default function MasHomeScreen() {
   const { isMd, isWeb } = useResponsive();
   const useTwoColumns = isWeb && isMd;
   const resolved = useResolvedProfileConfig();
+  const { isAdmin } = useAdminStatus();
   const navigationItems = React.useMemo(() => {
     const items: NavigationItem[] = [];
 
@@ -137,8 +148,12 @@ export default function MasHomeScreen() {
       if (entry) items.push(entry);
     }
 
+    if (isAdmin) {
+      items.push(MCM_PANEL_ITEM);
+    }
+
     return items;
-  }, [resolved.masItems, resolved.tabs]);
+  }, [resolved.masItems, resolved.tabs, isAdmin]);
 
   // Deep-link desde la Home: si hay una pantalla pendiente, navegar a ella
   useFocusEffect(

--- a/mcm-app/app/screens/McmPanelScreen.tsx
+++ b/mcm-app/app/screens/McmPanelScreen.tsx
@@ -1,0 +1,130 @@
+// app/screens/McmPanelScreen.tsx
+// WebView para mcmpanel.vercel.app — solo accesible para administradores.
+// Sin header, pantalla completa, cookies persistentes.
+
+import React, { useState, useCallback, useMemo } from 'react';
+import {
+  Platform,
+  View,
+  StyleSheet,
+  StatusBar,
+  ActivityIndicator,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { WebView } from 'react-native-webview';
+import { useToast } from '@/contexts/AppToastContext';
+import { Colors as ThemeColors } from '@/constants/colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+// CSS module reutilizado del iframe (solo aplica en web)
+/* eslint-disable @typescript-eslint/no-require-imports */
+const iframeStyles =
+  Platform.OS === 'web' ? require('../../styles/comunica.module.css') : null;
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const MCM_PANEL_URL = 'https://mcmpanel.vercel.app';
+
+// Violeta oscuro — evoca "panel de administración", distinto del azul MCM.
+const NOTCH_COLOR = '#4C1D95';
+
+export default function McmPanelScreen() {
+  const scheme = useColorScheme() ?? 'light';
+  const insets = useSafeAreaInsets();
+  const tintColor = ThemeColors[scheme].tint;
+  const [isLoading, setIsLoading] = useState(true);
+  const { toast } = useToast();
+
+  const dynamicStyles = useMemo(
+    () =>
+      StyleSheet.create({
+        loadingContainer: {
+          ...StyleSheet.absoluteFillObject,
+          justifyContent: 'center' as const,
+          alignItems: 'center' as const,
+          backgroundColor:
+            scheme === 'dark' ? 'rgba(0,0,0,0.7)' : 'rgba(255,255,255,0.85)',
+        },
+      }),
+    [scheme],
+  );
+
+  const onLoadEnd = useCallback(() => setIsLoading(false), []);
+  const onError = useCallback(() => {
+    toast.show({
+      variant: 'danger',
+      label: 'Error al cargar el panel. Verifica tu conexión a internet.',
+      actionLabel: 'Cerrar',
+      onActionPress: ({ hide }) => hide(),
+    });
+    setIsLoading(false);
+  }, [toast]);
+
+  // ── Web: iframe ──────────────────────────────────────────────────────────
+  if (Platform.OS === 'web') {
+    return (
+      <View style={styles.container}>
+        <iframe
+          src={MCM_PANEL_URL}
+          title="MCM Panel"
+          className={iframeStyles?.iframe}
+          style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}
+          onLoad={onLoadEnd}
+        />
+        {isLoading && (
+          <View style={dynamicStyles.loadingContainer}>
+            <ActivityIndicator size="large" color={tintColor} />
+          </View>
+        )}
+      </View>
+    );
+  }
+
+  // ── iOS / Android: WebView nativo con barra de color en el notch ────────
+  return (
+    <View style={styles.container}>
+      <StatusBar
+        barStyle="light-content"
+        backgroundColor={NOTCH_COLOR}
+        translucent
+      />
+      {insets.top > 0 && (
+        <View
+          style={[
+            styles.notchBar,
+            { backgroundColor: NOTCH_COLOR, height: insets.top },
+          ]}
+        />
+      )}
+      <WebView
+        source={{ uri: MCM_PANEL_URL }}
+        style={styles.webview}
+        javaScriptEnabled={true}
+        domStorageEnabled={true}
+        sharedCookiesEnabled={true}
+        thirdPartyCookiesEnabled={true}
+        contentInsetAdjustmentBehavior="never"
+        automaticallyAdjustContentInsets={false}
+        renderLoading={() => (
+          <View style={dynamicStyles.loadingContainer}>
+            <ActivityIndicator size="large" color={tintColor} />
+          </View>
+        )}
+        onLoadEnd={onLoadEnd}
+        onError={onError}
+        onHttpError={onError}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  notchBar: {
+    width: '100%',
+  },
+  webview: {
+    flex: 1,
+  } as any,
+});

--- a/mcm-app/hooks/useAdminStatus.ts
+++ b/mcm-app/hooks/useAdminStatus.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { getDatabase, ref, onValue } from 'firebase/database';
+import { getFirebaseApp } from '@/utils/firebaseApp';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Lee el flag `isAdmin` del nodo `users/{uid}/isAdmin` en Firebase RTDB.
+ * Solo devuelve `true` si el usuario está autenticado Y tiene ese campo a `true`
+ * en la base de datos. Nunca se basa en estado local ni en la contraseña del
+ * panel secreto.
+ */
+export function useAdminStatus(): { isAdmin: boolean; loading: boolean } {
+  const { user, loading: authLoading } = useAuth();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!user) {
+      setIsAdmin(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const db = getDatabase(getFirebaseApp());
+    const adminRef = ref(db, `users/${user.uid}/isAdmin`);
+    const unsub = onValue(
+      adminRef,
+      (snap) => {
+        setIsAdmin(snap.val() === true);
+        setLoading(false);
+      },
+      () => {
+        setIsAdmin(false);
+        setLoading(false);
+      },
+    );
+    return () => unsub();
+  }, [user, authLoading]);
+
+  return { isAdmin, loading };
+}


### PR DESCRIPTION
Anade una tarjeta MCM Panel al final de la pantalla Mas que abre
mcmpanel.vercel.app en un WebView. Solo visible a usuarios autenticados
con isAdmin=true en Firebase RTDB (users/{uid}/isAdmin).

- hooks/useAdminStatus.ts: nuevo hook que escucha users/{uid}/isAdmin en
  tiempo real via onValue. Independiente del isAdmin local de SettingsContext.
- app/screens/McmPanelScreen.tsx: WebView con notch violeta oscuro.
- app/(tabs)/mas.tsx: ruta McmPanel anadida al stack.
- app/screens/MasHomeScreen.tsx: tarjeta MCM Panel renderizada solo si isAdmin.

https://claude.ai/code/session_01K57Mo3EMLzieeFg6Bw9B8U