### PR TITLE
Fix calendario: selección persistente + ubicaciones/descripciones de eventos

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ---
 
+## 2026-06-13 — Fix de ubicaciones y descripciones en detalle de evento
+
+- **Ubicaciones del calendario**: el parser ICS ahora desescapa `\,`, `\;` y `\\` en el campo `LOCATION` (antes salía "Plaza de la M Molas\, 1 Madrid\, España" con las barras visibles). Archivo: `hooks/useCalendarEvents.ts`.
+- **Descripciones con HTML**: las descripciones de Google Calendar pueden llegar como HTML (`<br>`, `<b>`, `&amp;`, …). El bottom sheet ahora normaliza el HTML a texto plano con saltos de línea, runs en negrita y entidades decodificadas, en lugar de mostrar las etiquetas en crudo. Archivo: `components/EventDetailsBottomSheet.tsx`.
+
 ## 2026-06-11 — Sección MCM Panel en Más (solo administradores Firebase)
 
 - **Nueva pantalla `McmPanelScreen`**: WebView que abre `mcmpanel.vercel.app`, notch violeta oscuro (`#4C1D95`) para distinguirlo visualmente del resto de pantallas.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ---
 
+## 2026-06-13 — Fix: la selección de calendarios se perdía al reabrir la app
+
+- **Bug**: la visibilidad de calendarios se guardaba como array **por índice** (`boolean[]`) y se reconciliaba contra el `fallbackConfigs` (1 solo calendario) durante el instante en que Firebase aún cargaba. Eso truncaba el array guardado a longitud 1, lo persistía, y al llegar los datos reales rellenaba con los defaults — perdiendo la selección del usuario.
+- **Fix**: la selección ahora se persiste **por ID de calendario** (`{ [id]: boolean }`) en AsyncStorage. Sobrevive a reordenamientos, altas/bajas de calendarios y al fallback transitorio. Migración one-shot del formato antiguo por índice. Archivo: `hooks/useCalendarConfigs.ts`.
+
 ## 2026-06-13 — Fix de ubicaciones y descripciones en detalle de evento
 
 - **Ubicaciones del calendario**: el parser ICS ahora desescapa `\,`, `\;` y `\\` en el campo `LOCATION` (antes salía "Plaza de la M Molas\, 1 Madrid\, España" con las barras visibles). Archivo: `hooks/useCalendarEvents.ts`.

--- a/mcm-app/components/EventDetailsBottomSheet.tsx
+++ b/mcm-app/components/EventDetailsBottomSheet.tsx
@@ -32,31 +32,84 @@ interface Props {
 // Matches http(s) URLs to make description links tappable.
 const URL_PATTERN = 'https?:\\/\\/[^\\s<>"\')]+';
 
-type DescriptionToken = { key: string; text: string; isUrl: boolean };
+// Sentinels used to preserve bold runs while stripping the rest of the HTML.
+const BOLD_OPEN = '\u0001';
+const BOLD_CLOSE = '\u0002';
 
-function tokenizeDescription(text: string): DescriptionToken[] {
-  const regex = new RegExp(URL_PATTERN, 'gi');
+type DescriptionToken = {
+  key: string;
+  text: string;
+  isUrl: boolean;
+  bold: boolean;
+};
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&amp;/gi, '&');
+}
+
+// Google Calendar descriptions can arrive as HTML (<br>, <b>, &amp;, …).
+// Normalize them to plain text with basic line breaks + bold runs.
+function normalizeDescription(input: string): string {
+  return decodeHtmlEntities(
+    input
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|li|h[1-6])>/gi, '\n')
+      .replace(/<(b|strong)>/gi, BOLD_OPEN)
+      .replace(/<\/(b|strong)>/gi, BOLD_CLOSE)
+      .replace(/<[^>]+>/g, '') // strip any remaining tags
+      .replace(/\n{3,}/g, '\n\n'), // collapse excess blank lines
+  );
+}
+
+function tokenizeDescription(rawText: string): DescriptionToken[] {
+  const normalized = normalizeDescription(rawText);
+  const urlRegex = new RegExp(URL_PATTERN, 'gi');
   const tokens: DescriptionToken[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
+  let bold = false;
   let i = 0;
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
+
+  // Split on bold sentinels, keeping track of the current bold state.
+  for (const segment of normalized.split(/([\u0001\u0002])/)) {
+    if (segment === BOLD_OPEN) {
+      bold = true;
+      continue;
+    }
+    if (segment === BOLD_CLOSE) {
+      bold = false;
+      continue;
+    }
+    if (!segment) continue;
+
+    urlRegex.lastIndex = 0;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = urlRegex.exec(segment)) !== null) {
+      if (match.index > lastIndex) {
+        tokens.push({
+          key: `t${i++}`,
+          text: segment.slice(lastIndex, match.index),
+          isUrl: false,
+          bold,
+        });
+      }
+      tokens.push({ key: `u${i++}`, text: match[0], isUrl: true, bold });
+      lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < segment.length) {
       tokens.push({
         key: `t${i++}`,
-        text: text.slice(lastIndex, match.index),
+        text: segment.slice(lastIndex),
         isUrl: false,
+        bold,
       });
     }
-    tokens.push({ key: `u${i++}`, text: match[0], isUrl: true });
-    lastIndex = match.index + match[0].length;
-  }
-  if (lastIndex < text.length) {
-    tokens.push({
-      key: `t${i++}`,
-      text: text.slice(lastIndex),
-      isUrl: false,
-    });
   }
   return tokens;
 }
@@ -270,6 +323,7 @@ export default function EventDetailsBottomSheet({
                       style={{
                         color: colors.info,
                         textDecorationLine: 'underline',
+                        fontWeight: p.bold ? '700' : undefined,
                       }}
                       onPress={() => handleOpenUrl(p.text)}
                     >
@@ -277,7 +331,14 @@ export default function EventDetailsBottomSheet({
                     </Text>
                   );
                 }
-                return <Text key={p.key}>{p.text}</Text>;
+                return (
+                  <Text
+                    key={p.key}
+                    style={p.bold ? { fontWeight: '700' } : undefined}
+                  >
+                    {p.text}
+                  </Text>
+                );
               })}
             </Text>
           </View>

--- a/mcm-app/components/EventDetailsBottomSheet.tsx
+++ b/mcm-app/components/EventDetailsBottomSheet.tsx
@@ -59,6 +59,18 @@ function decodeHtmlEntities(text: string): string {
 function normalizeDescription(input: string): string {
   return decodeHtmlEntities(
     input
+      // Keep <a href> links reachable: show the label and surface the URL so
+      // the plain-text URL tokenizer can make it tappable.
+      .replace(
+        /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+        (_full, href, inner) => {
+          const label = inner.replace(/<[^>]+>/g, '').trim();
+          if (!label || href.includes(label) || label.includes(href)) {
+            return href;
+          }
+          return `${label} (${href})`;
+        },
+      )
       .replace(/<br\s*\/?>/gi, '\n')
       .replace(/<\/(p|div|li|h[1-6])>/gi, '\n')
       .replace(/<(b|strong)>/gi, BOLD_OPEN)

--- a/mcm-app/hooks/useCalendarConfigs.ts
+++ b/mcm-app/hooks/useCalendarConfigs.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFirebaseData } from './useFirebaseData';
 import { useResolvedProfileConfig } from './useResolvedProfileConfig';
@@ -17,7 +17,15 @@ export interface CalendarConfig {
   color: string;
 }
 
-const CALENDAR_SETTINGS_KEY = '@mcm_calendar_settings';
+// La selección se guarda por ID de calendario ({ [id]: boolean }), no por
+// índice. Así sobrevive a reordenamientos, altas/bajas de calendarios y al
+// fallback transitorio mientras Firebase carga (que antes truncaba el array
+// guardado y perdía la selección del usuario).
+const CALENDAR_SELECTION_KEY = '@mcm_calendar_selection_v2';
+// Clave antigua (array booleano por índice) — se migra una sola vez.
+const LEGACY_SETTINGS_KEY = '@mcm_calendar_settings';
+
+type SelectionMap = Record<string, boolean>;
 
 export function useCalendarConfigs() {
   const {
@@ -27,10 +35,6 @@ export function useCalendarConfigs() {
   } = useFirebaseData<CalendarConfigFirebase[]>('calendars', 'calendars');
 
   const resolved = useResolvedProfileConfig();
-
-  const [visibleCalendars, setVisibleCalendars] = useState<boolean[]>([]);
-  const [calendarConfigs, setCalendarConfigs] = useState<CalendarConfig[]>([]);
-  const [settingsLoaded, setSettingsLoaded] = useState(false);
 
   // Fallback configuration in case Firebase data is not available
   const fallbackConfigs: CalendarConfigFirebase[] = useMemo(
@@ -46,105 +50,126 @@ export function useCalendarConfigs() {
     [],
   );
 
-  // Load user calendar settings from AsyncStorage
+  const calendarsToUse = useMemo(
+    () =>
+      calendarData && calendarData.length > 0 ? calendarData : fallbackConfigs,
+    [calendarData, fallbackConfigs],
+  );
+
+  // `null` mientras no se ha leído AsyncStorage; mapa explícito del usuario una
+  // vez cargado. Las claves ausentes caen al default del perfil/calendario.
+  const [selection, setSelection] = useState<SelectionMap | null>(null);
+  const legacyRef = useRef<boolean[] | null>(null);
+  const migratedRef = useRef(false);
+
+  // Default de un calendario cuando el usuario no lo ha tocado explícitamente.
+  const defaultFor = useCallback(
+    (cal: CalendarConfigFirebase) => {
+      const profileDefaults = resolved.defaultCalendars;
+      if (profileDefaults && profileDefaults.length > 0) {
+        return profileDefaults.includes(cal.id);
+      }
+      return cal.defaultSelected;
+    },
+    [resolved.defaultCalendars],
+  );
+
+  // Carga la selección persistida una sola vez.
   useEffect(() => {
+    let mounted = true;
     async function loadSettings() {
       try {
-        const storedSettings = await AsyncStorage.getItem(
-          CALENDAR_SETTINGS_KEY,
-        );
-        if (storedSettings) {
-          const parsedSettings = JSON.parse(storedSettings);
-          setVisibleCalendars(parsedSettings);
+        const stored = await AsyncStorage.getItem(CALENDAR_SELECTION_KEY);
+        if (stored) {
+          migratedRef.current = true;
+          if (mounted) setSelection(JSON.parse(stored));
+          return;
         }
+        // Si no hay clave nueva, recordamos la antigua para migrarla cuando
+        // tengamos la lista real de calendarios (no el fallback).
+        const legacy = await AsyncStorage.getItem(LEGACY_SETTINGS_KEY);
+        if (legacy) legacyRef.current = JSON.parse(legacy);
       } catch (error) {
         console.error('Error loading calendar settings:', error);
       } finally {
-        setSettingsLoaded(true);
+        if (mounted) {
+          setSelection((prev) => prev ?? {});
+        }
       }
     }
     loadSettings();
+    return () => {
+      mounted = false;
+    };
   }, []);
 
-  // Process calendar data when it's available
+  // Migración one-shot del array por índice → mapa por ID, en cuanto llega la
+  // lista real de Firebase (no el fallback).
   useEffect(() => {
-    if (!settingsLoaded) return;
+    if (migratedRef.current) return;
+    if (!calendarData || calendarData.length === 0) return;
+    migratedRef.current = true;
+    const legacy = legacyRef.current;
+    if (!legacy) return;
+    const map: SelectionMap = {};
+    calendarData.forEach((cal, idx) => {
+      if (idx < legacy.length) map[cal.id] = legacy[idx];
+    });
+    setSelection(map);
+    AsyncStorage.setItem(CALENDAR_SELECTION_KEY, JSON.stringify(map)).catch(
+      () => {},
+    );
+    AsyncStorage.removeItem(LEGACY_SETTINGS_KEY).catch(() => {});
+  }, [calendarData]);
 
-    const calendarsToUse = calendarData || fallbackConfigs;
+  const calendarConfigs: CalendarConfig[] = useMemo(
+    () =>
+      calendarsToUse.map((cal) => ({
+        name: cal.name,
+        url: cal.url,
+        color: cal.color,
+      })),
+    [calendarsToUse],
+  );
 
-    // Convert Firebase format to CalendarConfig format
-    const configs: CalendarConfig[] = calendarsToUse.map((cal) => ({
-      name: cal.name,
-      url: cal.url,
-      color: cal.color,
-    }));
+  // Booleanos alineados con `calendarConfigs` (interfaz que esperan los
+  // consumidores), derivados del mapa por ID + defaults.
+  const visibleCalendars = useMemo(() => {
+    if (selection === null) return [];
+    return calendarsToUse.map((cal) =>
+      Object.prototype.hasOwnProperty.call(selection, cal.id)
+        ? selection[cal.id]
+        : defaultFor(cal),
+    );
+  }, [selection, calendarsToUse, defaultFor]);
 
-    setCalendarConfigs(configs);
-
-    // If no user settings exist, derive defaults from the resolved profile
-    // config (IDs de calendario por perfil + extras por delegación). Si el
-    // perfil no define `defaultCalendars`, caemos al flag `defaultSelected`
-    // del propio calendario para retrocompatibilidad.
-    if (visibleCalendars.length === 0) {
-      const profileDefaults = new Set(resolved.defaultCalendars);
-      const useProfileDefaults = profileDefaults.size > 0;
-      const defaultSelection = calendarsToUse.map((cal) =>
-        useProfileDefaults ? profileDefaults.has(cal.id) : cal.defaultSelected,
-      );
-      setVisibleCalendars(defaultSelection);
-    } else if (visibleCalendars.length !== calendarsToUse.length) {
-      // Adjust array length if number of calendars changed.
-      // Para nuevos calendarios remotos: respetar `defaultSelected` para que
-      // el usuario los vea por defecto si así lo decidió el panel admin
-      // (en lugar de quedar siempre ocultos hasta activación manual).
-      const newSelection = [...visibleCalendars];
-      while (newSelection.length < calendarsToUse.length) {
-        const idx = newSelection.length;
-        newSelection.push(calendarsToUse[idx]?.defaultSelected ?? false);
-      }
-      if (newSelection.length > calendarsToUse.length) {
-        newSelection.splice(calendarsToUse.length);
-      }
-      setVisibleCalendars(newSelection);
-    }
-  }, [
-    calendarData,
-    settingsLoaded,
-    fallbackConfigs,
-    visibleCalendars,
-    resolved.defaultCalendars,
-  ]);
-
-  // Save user settings to AsyncStorage whenever they change
-  useEffect(() => {
-    if (!settingsLoaded || visibleCalendars.length === 0) return;
-
-    async function saveSettings() {
-      try {
-        await AsyncStorage.setItem(
-          CALENDAR_SETTINGS_KEY,
-          JSON.stringify(visibleCalendars),
-        );
-      } catch (error) {
-        console.error('Error saving calendar settings:', error);
-      }
-    }
-    saveSettings();
-  }, [visibleCalendars, settingsLoaded]);
-
-  const toggleCalendarVisibility = (index: number) => {
-    if (index >= 0 && index < visibleCalendars.length) {
-      const newVisibility = [...visibleCalendars];
-      newVisibility[index] = !newVisibility[index];
-      setVisibleCalendars(newVisibility);
-    }
-  };
+  const toggleCalendarVisibility = useCallback(
+    (index: number) => {
+      const cal = calendarsToUse[index];
+      if (!cal) return;
+      setSelection((prev) => {
+        const base = prev ?? {};
+        const current = Object.prototype.hasOwnProperty.call(base, cal.id)
+          ? base[cal.id]
+          : defaultFor(cal);
+        const next: SelectionMap = { ...base, [cal.id]: !current };
+        AsyncStorage.setItem(
+          CALENDAR_SELECTION_KEY,
+          JSON.stringify(next),
+        ).catch((error) => {
+          console.error('Error saving calendar settings:', error);
+        });
+        return next;
+      });
+    },
+    [calendarsToUse, defaultFor],
+  );
 
   return {
     calendarConfigs,
     visibleCalendars,
     toggleCalendarVisibility,
-    loading: loading || !settingsLoaded,
+    loading: loading || selection === null,
     offline,
   };
 }

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -88,7 +88,10 @@ function parseICS(text: string): Omit<CalendarEvent, 'calendarIndex'>[] {
       current.location =
         line
           .slice('LOCATION:'.length)
-          .replace(/\\n/g, '\n')
+          .replace(/\\n/gi, '\n')
+          .replace(/\\,/g, ',')
+          .replace(/\\;/g, ';')
+          .replace(/\\\\/g, '\\')
           .trim()
           .split('\n')
           .filter((part) => part.trim().toLowerCase() !== 'españa')


### PR DESCRIPTION
## Qué arregla

### 1. La selección de calendarios se perdía al reabrir la app
La visibilidad se guardaba como array **por índice** (`boolean[]`) y se reconciliaba contra el `fallbackConfigs` (1 solo calendario) durante el instante en que Firebase aún cargaba. Eso truncaba el array guardado a longitud 1, lo persistía, y al llegar los datos reales lo rellenaba con los defaults → se perdía lo que el usuario eligió.

**Fix:** la selección ahora se persiste **por ID de calendario** (`{ [id]: boolean }`). Sobrevive a reordenamientos, altas/bajas de calendarios y al fallback transitorio. Incluye migración one-shot del formato antiguo. (`hooks/useCalendarConfigs.ts`)

### 2. Ubicaciones con barras de escape visibles
El parser ICS no desescapaba `\,` `\;` `\\` en `LOCATION` (salía "Plaza de la M Molas\, 1"). Ahora sí. (`hooks/useCalendarEvents.ts`)

### 3. Descripciones de evento mostraban HTML en crudo
Las descripciones de Google Calendar llegan como HTML (`<br>`, `<b>`, `<a href>`, entidades). El bottom sheet ahora las normaliza a texto plano con saltos de línea, negritas, entidades decodificadas y enlaces clicables (incluidos `<a href>` con texto distinto a la URL). (`components/EventDetailsBottomSheet.tsx`)

Cambios solo de JS (aptos para OTA).

https://claude.ai/code/session_014SzK9i6ndXmvytMV3eLuTR

---
_Generated by [Claude Code](https://claude.ai/code/session_014SzK9i6ndXmvytMV3eLuTR)_