### PR TITLE
fix(playlist): QR unificado, contador correcto y tono transportado real

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,37 @@
 
 ---
 
+## 2026-06-18 17:30 — Playlist: QR unificado, contador correcto y tono transportado real
+
+- **Bug grave en el tono transportado**: `transposeKey` **siempre devolvía el
+  tono original** sin transponer. Miraba `lines[0]` del ChordPro parseado, que
+  es la línea de la directiva `{key:}` (el acorde queda en `lines[1]`), así que
+  nunca encontraba el `ChordLyricsPair`. Resultado: una canción en La subida +5
+  mostraba "La̶ → La +5" en vez de "La̶ Re". Ahora recorre todas las líneas
+  hasta dar con el acorde. Además se normalizan las claves que llegan en
+  mayúsculas ("Am" → "AM", "Bb" → "BB"), formas que ChordSheetJS no entendía y
+  que rompían menores y bemoles. Afecta también al **PDF exportado** y al
+  **texto de WhatsApp**, que usaban la misma función. (`utils/transposeKey.ts`,
+  nuevo `__tests__/transposeKey.test.ts`).
+- **Presentación del tono transportado**: ahora se muestra `La̶ Re (+5)` —tono
+  destino prominente y el transporte pequeño entre paréntesis— en lugar de
+  `La̶ → Re +5`. (`components/playlist/PlaylistRow.tsx`,
+  `components/SongListItem.tsx`).
+- **QR de la playlist unificado**: antes había dos opciones separadas ("Ver QR
+  offline" y "Ver QR de la playlist"). Ahora es **un único botón** "Compartir QR
+  de la playlist" que abre el modal con **dos pestañas** (con código / sin
+  conexión). Si la playlist aún no está subida, la pestaña "con código" invita a
+  subirla. (`app/screens/SelectedSongsScreen.tsx`,
+  `components/playlist/ShareQrModal.tsx`).
+- **Contador de canciones**: mostraba `selectedSongs.length`, pero la lista
+  filtra canciones que no estén en el catálogo cargado → descuadres (p. ej. "13"
+  con 12 filas). Ahora cuenta las realmente visibles (`flatSelectedSongs`), con
+  fallback al total mientras carga el catálogo. Además `normalizeOrder` **elimina
+  duplicados** por `filename` al importar/descargar, que inflaban el contador y
+  rompían las keys de la lista. (`app/screens/SelectedSongsScreen.tsx`,
+  `contexts/SelectedSongsContext.tsx`).
+- **OTA-safe** (solo JS).
+
 ## 2026-06-08 — Notificaciones: descripción extendida (`bodyLong`)
 
 - Nuevo campo opcional **`bodyLong`** en las notificaciones: descripción larga que se

--- a/mcm-app/__tests__/transposeKey.test.ts
+++ b/mcm-app/__tests__/transposeKey.test.ts
@@ -1,0 +1,38 @@
+import { transposeKey, transposeLabel } from '@/utils/transposeKey';
+
+describe('transposeKey', () => {
+  it('transpone tonos mayores devolviendo el tono destino real', () => {
+    // Caso reportado: La (A) +5 semitonos => Re (D), no "La".
+    expect(transposeKey('A', 5)).toBe('D');
+    expect(transposeKey('C', 2)).toBe('D');
+    expect(transposeKey('F#', 1)).toBe('G');
+  });
+
+  it('mantiene el tono cuando no hay transporte', () => {
+    expect(transposeKey('A', 0)).toBe('A');
+    expect(transposeKey('G', 0)).toBe('G');
+  });
+
+  it('respeta tonos menores aunque lleguen en mayúsculas ("Am" -> "AM")', () => {
+    expect(transposeKey('AM', 2)).toBe('BM');
+    expect(transposeKey('EM', 3)).toBe('GM');
+  });
+
+  it('respeta bemoles aunque lleguen en mayúsculas ("Bb" -> "BB")', () => {
+    expect(transposeKey('BB', 2)).toBe('C');
+  });
+
+  it('tolera entradas vacías', () => {
+    expect(transposeKey('', 5)).toBe('');
+    expect(transposeKey(undefined, 5)).toBe('');
+    expect(transposeKey(null, 5)).toBe('');
+  });
+});
+
+describe('transposeLabel', () => {
+  it('formatea el transporte con signo', () => {
+    expect(transposeLabel(5)).toBe('+5');
+    expect(transposeLabel(-3)).toBe('-3');
+    expect(transposeLabel(0)).toBe('');
+  });
+});

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -353,6 +353,15 @@ const SelectedSongsScreen: React.FC = () => {
     [enrichedSelected],
   );
 
+  // Contador que coincide con lo que realmente se ve en la lista. La lista
+  // filtra canciones que no estén en el catálogo cargado, así que contar
+  // `selectedSongs.length` daba descuadres (p. ej. "13" mostrando 12 filas).
+  // Mientras el catálogo aún no ha cargado, caemos al total seleccionado para
+  // no parpadear a 0.
+  const visibleCount = allSongsData
+    ? flatSelectedSongs.length
+    : selectedSongs.length;
+
   const songIndexMap = useMemo(() => {
     const m = new Map<string, number>();
     flatSelectedSongs.forEach((s, i) => m.set(s.filename, i));
@@ -878,14 +887,24 @@ const SelectedSongsScreen: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingOverwrite, selectedSongs]);
 
-  const showUploadSuccess = useCallback((code: string, name?: string) => {
-    setQrModal({
-      title: name
-        ? `¡${name} subida! Código ${code}`
-        : `¡Subida! Código ${code}`,
-      url: `${WEB_BASE_URL}/playlist?p=${code}`,
-      code,
-    });
+  const showUploadSuccess = useCallback(
+    (code: string, name?: string) => {
+      setQrModal({
+        title: name
+          ? `¡${name} subida! Código ${code}`
+          : `¡Subida! Código ${code}`,
+        url: `${WEB_BASE_URL}/playlist?p=${code}`,
+        code,
+        offlineUrl,
+      });
+    },
+    [offlineUrl],
+  );
+
+  /** Desde la pestaña "con código" del QR cuando aún no se ha subido. */
+  const handleQrRequestUpload = useCallback(() => {
+    setQrModal(null);
+    setCodeDialog({ variant: 'cloud-upload' });
   }, []);
 
   const showChoirSuccess = useCallback((code: string) => {
@@ -1088,38 +1107,30 @@ const SelectedSongsScreen: React.FC = () => {
       },
     ];
     if (offlineUrl) {
+      // Un único botón de QR: dentro, el modal ofrece dos pestañas
+      // (con código / sin conexión). Si todavía no se ha subido, la pestaña
+      // online invita a subir la playlist.
       nube.push({
-        id: 'show-qr-offline',
-        icon: 'qr-code-scanner',
-        label: 'Ver QR offline',
-        description: 'Compártela a otro dispositivo sin internet (con la app)',
+        id: 'show-qr',
+        icon: 'qr-code-2',
+        label: 'Compartir QR de la playlist',
+        description: 'Dos pestañas: con código (internet) o sin conexión',
         onPress: () =>
           setQrModal({
-            title: 'Playlist · Sin conexión',
-            offlineUrl,
+            title: lastUploadCode
+              ? `Playlist · Código ${lastUploadCode}`
+              : 'Compartir playlist',
             url: lastUploadCode
               ? `${WEB_BASE_URL}/playlist?p=${lastUploadCode}`
               : undefined,
             code: lastUploadCode ?? undefined,
-            defaultMode: 'offline',
+            offlineUrl,
+            defaultMode: lastUploadCode ? 'online' : 'offline',
           }),
       });
     }
     if (lastUploadCode) {
       nube.push(
-        {
-          id: 'show-qr-cloud',
-          icon: 'qr-code-2',
-          label: 'Ver QR de la playlist',
-          description: 'Quien lo escanee abre la playlist directamente',
-          onPress: () =>
-            setQrModal({
-              title: `Playlist · Código ${lastUploadCode}`,
-              url: `${WEB_BASE_URL}/playlist?p=${lastUploadCode}`,
-              code: lastUploadCode,
-              offlineUrl,
-            }),
-        },
         {
           id: 'change-cloud-code',
           icon: 'edit',
@@ -1386,8 +1397,7 @@ const SelectedSongsScreen: React.FC = () => {
         <View style={styles.summaryRow}>
           <View>
             <Text style={styles.selectionCount}>
-              {selectedSongs.length}{' '}
-              {selectedSongs.length === 1 ? 'canción' : 'canciones'}
+              {visibleCount} {visibleCount === 1 ? 'canción' : 'canciones'}
             </Text>
             {lastUploadCode ? (
               <Text style={styles.subInfo}>
@@ -1395,7 +1405,7 @@ const SelectedSongsScreen: React.FC = () => {
               </Text>
             ) : null}
           </View>
-          {selectedSongs.length > 1 ? (
+          {visibleCount > 1 ? (
             <View style={styles.viewToggle}>
               <TouchableOpacity
                 onPress={() => setViewMode('category')}
@@ -1590,6 +1600,7 @@ const SelectedSongsScreen: React.FC = () => {
           code={qrModal.code}
           offlineUrl={qrModal.offlineUrl}
           defaultMode={qrModal.defaultMode}
+          onRequestUpload={handleQrRequestUpload}
           onClose={() => setQrModal(null)}
         />
       ) : null}

--- a/mcm-app/components/SongListItem.tsx
+++ b/mcm-app/components/SongListItem.tsx
@@ -275,11 +275,6 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
                     <Text style={styles.toneOriginalStriked}>
                       {convertChord(song.key.toUpperCase(), notation)}
                     </Text>
-                    <MaterialIcons
-                      name="arrow-forward"
-                      size={12}
-                      color="#8E8E93"
-                    />
                     <View style={styles.keyPillTransposed}>
                       <Text style={styles.keyTextTransposed}>
                         {convertChord(
@@ -290,10 +285,10 @@ const SongListItem: React.FC<SongListItemProps> = React.memo(
                           notation,
                         )}
                       </Text>
-                      <Text style={styles.transposeBadge}>
-                        {transposeLabel(selectedTranspose)}
-                      </Text>
                     </View>
+                    <Text style={styles.transposeParenLabel}>
+                      ({transposeLabel(selectedTranspose)})
+                    </Text>
                   </View>
                 ) : (
                   <View style={styles.keyPill}>
@@ -433,7 +428,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
     keyPillTransposed: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 4,
       paddingHorizontal: 7,
       paddingVertical: 3,
       borderRadius: 6,
@@ -446,14 +440,11 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       fontWeight: '700',
       color: '#7A5A00',
     },
-    transposeBadge: {
-      fontSize: 10,
-      fontWeight: '800',
-      color: '#9D5C00',
+    transposeParenLabel: {
+      fontSize: 11,
+      fontWeight: '700',
+      color: '#8E8E93',
       fontVariant: ['tabular-nums'],
-      backgroundColor: 'rgba(255,255,255,0.7)',
-      paddingHorizontal: 3,
-      borderRadius: 3,
     },
     rightAction: {
       backgroundColor: SwipeColors.add,

--- a/mcm-app/components/playlist/PlaylistRow.tsx
+++ b/mcm-app/components/playlist/PlaylistRow.tsx
@@ -198,17 +198,14 @@ const PlaylistRow: React.FC<Props> = ({
                   <Text style={styles.toneOriginalStriked}>
                     {convertChord(originalKey, notation)}
                   </Text>
-                  <MaterialIcons
-                    name="arrow-forward"
-                    size={12}
-                    color={isDark ? '#8E8E93' : '#8E8E93'}
-                  />
                   <View style={styles.keyPillTransposed}>
                     <Text style={styles.keyTextTransposed}>
                       {convertChord(targetKey, notation)}
                     </Text>
-                    <Text style={styles.transposeBadge}>{transposeBadge}</Text>
                   </View>
+                  <Text style={styles.transposeParenLabel}>
+                    ({transposeBadge})
+                  </Text>
                 </View>
               ) : (
                 <View style={styles.keyPill}>
@@ -398,7 +395,6 @@ const createStyles = (isDark: boolean) =>
     keyPillTransposed: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 4,
       paddingHorizontal: 8,
       paddingVertical: 3,
       borderRadius: 6,
@@ -411,14 +407,11 @@ const createStyles = (isDark: boolean) =>
       fontWeight: '700',
       color: '#7A5A00',
     },
-    transposeBadge: {
+    transposeParenLabel: {
       fontSize: 11,
-      fontWeight: '800',
-      color: '#9D5C00',
+      fontWeight: '700',
+      color: isDark ? '#8E8E93' : '#8E8E93',
       fontVariant: ['tabular-nums'],
-      backgroundColor: 'rgba(255,255,255,0.7)',
-      paddingHorizontal: 4,
-      borderRadius: 4,
     },
     reorderRow: {
       flexDirection: 'column',

--- a/mcm-app/components/playlist/ShareQrModal.tsx
+++ b/mcm-app/components/playlist/ShareQrModal.tsx
@@ -37,6 +37,11 @@ interface Props {
   offlineUrl?: string;
   /** Modo inicial cuando ambos están disponibles. Por defecto 'online'. */
   defaultMode?: 'online' | 'offline';
+  /**
+   * Si se pasa, la pestaña "con código" sigue disponible aunque todavía no
+   * haya `url`: muestra una invitación a subir la playlist a la nube.
+   */
+  onRequestUpload?: () => void;
   onClose: () => void;
 }
 
@@ -47,6 +52,7 @@ const ShareQrModal: React.FC<Props> = ({
   code,
   offlineUrl,
   defaultMode = 'online',
+  onRequestUpload,
   onClose,
 }) => {
   const scheme = useColorScheme();
@@ -56,6 +62,9 @@ const ShareQrModal: React.FC<Props> = ({
 
   const hasOnline = !!url;
   const hasOffline = !!offlineUrl;
+  // La pestaña "con código" se puede elegir si ya hay enlace o si podemos
+  // ofrecer subir la playlist en el momento.
+  const onlineSelectable = hasOnline || !!onRequestUpload;
   const [mode, setMode] = useState<'online' | 'offline'>(
     defaultMode === 'offline' && hasOffline ? 'offline' : 'online',
   );
@@ -69,11 +78,14 @@ const ShareQrModal: React.FC<Props> = ({
   }, [visible]);
 
   // Modo efectivo: si solo hay uno disponible, ignoramos el toggle.
-  const effectiveMode: 'online' | 'offline' = !hasOnline
+  const effectiveMode: 'online' | 'offline' = !onlineSelectable
     ? 'offline'
     : !hasOffline
       ? 'online'
       : mode;
+  // En la pestaña online sin enlace todavía, invitamos a subir.
+  const showUploadPrompt = effectiveMode === 'online' && !hasOnline;
+  const showTabs = hasOffline && onlineSelectable;
   const activeUrl = (effectiveMode === 'offline' ? offlineUrl : url) ?? '';
 
   const switchMode = (next: 'online' | 'offline') => {
@@ -101,7 +113,7 @@ const ShareQrModal: React.FC<Props> = ({
             <View style={styles.card}>
               <Text style={styles.title}>{title}</Text>
 
-              {hasOnline && hasOffline ? (
+              {showTabs ? (
                 <View style={styles.toggle}>
                   <TouchableOpacity
                     onPress={() => switchMode('online')}
@@ -139,46 +151,84 @@ const ShareQrModal: React.FC<Props> = ({
               ) : null}
 
               <Text style={styles.subtitle}>
-                {effectiveMode === 'offline'
-                  ? 'Funciona sin internet · Escanéalo con la cámara y se abre la app con la playlist ya cargada'
-                  : 'Escanea con la cámara · Se abre en la app si la tienes, o en el navegador si no'}
+                {showUploadPrompt
+                  ? 'Sube la playlist a la nube para compartir un QR con código que se abre por internet'
+                  : effectiveMode === 'offline'
+                    ? 'Funciona sin internet · Escanéalo con la cámara y se abre la app con la playlist ya cargada'
+                    : 'Escanea con la cámara · Se abre en la app si la tienes, o en el navegador si no'}
               </Text>
 
-              {/* Marco blanco siempre: los lectores QR necesitan contraste. */}
-              <View style={styles.qrWrap}>
-                <QRCode
-                  value={activeUrl}
-                  size={200}
-                  backgroundColor="#FFFFFF"
-                />
-              </View>
-
-              {effectiveMode === 'online' && code ? (
-                <Text style={styles.code}>{code}</Text>
+              {showUploadPrompt ? (
+                <View style={styles.uploadPrompt}>
+                  <MaterialIcons
+                    name="cloud-upload"
+                    size={48}
+                    color={isDark ? '#7AB3FF' : '#253883'}
+                  />
+                  <Text style={styles.uploadPromptText}>
+                    Esta playlist aún no está en la nube
+                  </Text>
+                </View>
               ) : (
-                <View style={styles.codeSpacer} />
+                <>
+                  {/* Marco blanco siempre: los lectores QR necesitan contraste. */}
+                  <View style={styles.qrWrap}>
+                    <QRCode
+                      value={activeUrl}
+                      size={200}
+                      backgroundColor="#FFFFFF"
+                    />
+                  </View>
+
+                  {effectiveMode === 'online' && code ? (
+                    <Text style={styles.code}>{code}</Text>
+                  ) : (
+                    <View style={styles.codeSpacer} />
+                  )}
+                </>
               )}
 
               <View style={styles.buttons}>
-                <TouchableOpacity
-                  onPress={() => copy('link')}
-                  style={[styles.btn, styles.btnPrimary]}
-                >
-                  <MaterialIcons name="link" size={18} color="#fff" />
-                  <Text style={styles.btnPrimaryText}>
-                    {copied === 'link' ? '¡Enlace copiado!' : 'Copiar enlace'}
-                  </Text>
-                </TouchableOpacity>
-                {effectiveMode === 'online' && code ? (
+                {showUploadPrompt ? (
                   <TouchableOpacity
-                    onPress={() => copy('code')}
-                    style={[styles.btn, styles.btnSecondary]}
+                    onPress={() => {
+                      h.tap();
+                      onRequestUpload?.();
+                    }}
+                    style={[styles.btn, styles.btnPrimary]}
                   >
-                    <Text style={styles.btnSecondaryText}>
-                      {copied === 'code' ? '¡Código copiado!' : 'Copiar código'}
+                    <MaterialIcons name="cloud-upload" size={18} color="#fff" />
+                    <Text style={styles.btnPrimaryText}>
+                      Subir playlist a la nube
                     </Text>
                   </TouchableOpacity>
-                ) : null}
+                ) : (
+                  <>
+                    <TouchableOpacity
+                      onPress={() => copy('link')}
+                      style={[styles.btn, styles.btnPrimary]}
+                    >
+                      <MaterialIcons name="link" size={18} color="#fff" />
+                      <Text style={styles.btnPrimaryText}>
+                        {copied === 'link'
+                          ? '¡Enlace copiado!'
+                          : 'Copiar enlace'}
+                      </Text>
+                    </TouchableOpacity>
+                    {effectiveMode === 'online' && code ? (
+                      <TouchableOpacity
+                        onPress={() => copy('code')}
+                        style={[styles.btn, styles.btnSecondary]}
+                      >
+                        <Text style={styles.btnSecondaryText}>
+                          {copied === 'code'
+                            ? '¡Código copiado!'
+                            : 'Copiar código'}
+                        </Text>
+                      </TouchableOpacity>
+                    ) : null}
+                  </>
+                )}
                 <TouchableOpacity
                   onPress={onClose}
                   style={[styles.btn, styles.btnSecondary]}
@@ -274,6 +324,19 @@ const createStyles = (isDark: boolean) =>
       backgroundColor: '#FFFFFF',
       padding: 14,
       borderRadius: 14,
+    },
+    uploadPrompt: {
+      height: 228,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 12,
+      paddingHorizontal: 16,
+    },
+    uploadPromptText: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: isDark ? '#AEAEB2' : '#6B6B70',
+      textAlign: 'center',
     },
     codeSpacer: {
       height: 26,

--- a/mcm-app/contexts/SelectedSongsContext.tsx
+++ b/mcm-app/contexts/SelectedSongsContext.tsx
@@ -80,10 +80,21 @@ interface SelectedSongsProviderProps {
   children: ReactNode;
 }
 
-/** Reordena `order` para que sean enteros consecutivos empezando en 0. */
+/**
+ * Reordena `order` para que sean enteros consecutivos empezando en 0 y
+ * **elimina duplicados** por `filename` (quedándose con la primera aparición).
+ * Los duplicados se podían colar al importar/descargar playlists (un mismo
+ * `filename` repetido) e inflaban el contador y rompían las keys de la lista.
+ */
 function normalizeOrder(songs: SelectedSong[]): SelectedSong[] {
+  const seen = new Set<string>();
   return [...songs]
     .sort((a, b) => a.order - b.order || a.addedAt - b.addedAt)
+    .filter((s) => {
+      if (seen.has(s.filename)) return false;
+      seen.add(s.filename);
+      return true;
+    })
     .map((s, i) => ({ ...s, order: i }));
 }
 

--- a/mcm-app/utils/transposeKey.ts
+++ b/mcm-app/utils/transposeKey.ts
@@ -9,6 +9,25 @@ import { ChordProParser, ChordLyricsPair } from 'chordsheetjs';
 
 const cache = new Map<string, string>();
 
+/**
+ * Recupera una clave parseable por ChordSheetJS a partir de la forma en
+ * MAYÚSCULAS con la que llega (quien llama hace `song.key.toUpperCase()`, lo
+ * que convierte "Am" → "AM" y "Bb" → "BB", formas que ChordSheetJS NO entiende
+ * y que provocaban que la transposición devolviera el tono original).
+ *
+ *  - Tras la nota raíz, una "B" solo puede ser bemol → la pasamos a "b".
+ *  - Una "M" representa el modo menor → la pasamos a "m".
+ */
+function normalizeKeyForParse(upperKey: string): string {
+  if (!upperKey) return upperKey;
+  const root = upperKey[0];
+  const rest = upperKey
+    .slice(1)
+    .replace(/^B/, 'b') // bemol
+    .replace(/M/g, 'm'); // menor
+  return root + rest;
+}
+
 export function transposeKey(
   originalKey: string | undefined | null,
   semitones: number,
@@ -22,14 +41,22 @@ export function transposeKey(
   if (hit) return hit;
 
   try {
-    const tmp = new ChordProParser().parse(`{key: ${k}}\n[${k}]`);
+    // El `{key:}` ayuda a ChordSheetJS a elegir el enarmónico correcto
+    // (sostenidos vs bemoles) acorde a la tonalidad. El acorde `[${k}]` queda
+    // en una línea aparte de la directiva, así que recorremos TODAS las líneas
+    // e items buscando el primer acorde (antes se miraba solo `lines[0]`, que
+    // es la línea de la directiva `{key:}` y nunca contenía el acorde → la
+    // función devolvía el tono original sin transponer).
+    const parseKey = normalizeKeyForParse(k);
+    const tmp = new ChordProParser().parse(`{key: ${parseKey}}\n[${parseKey}]`);
     const transposed = tmp.transpose(semitones);
-    if (transposed.lines.length > 0 && transposed.lines[0].items.length > 0) {
-      const item = transposed.lines[0].items[0];
-      if (item instanceof ChordLyricsPair && item.chords) {
-        const out = item.chords.toUpperCase();
-        cache.set(cacheKey, out);
-        return out;
+    for (const line of transposed.lines) {
+      for (const item of line.items) {
+        if (item instanceof ChordLyricsPair && item.chords) {
+          const out = item.chords.toUpperCase();
+          cache.set(cacheKey, out);
+          return out;
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
- transposeKey siempre devolvía el tono original (miraba lines[0], la
  directiva {key:}, en vez del acorde en lines[1]). Ahora recorre todas
  las líneas y normaliza claves en mayúsculas (Am->AM, Bb->BB). Corrige
  también el PDF y el texto de WhatsApp. Nuevo test transposeKey.test.ts.
- Tono transportado se muestra como "La̶ Re (+5)" (tono destino prominente,
  transporte pequeño entre paréntesis) en PlaylistRow y SongListItem.
- QR de la playlist en un único botón con dos pestañas (con código / sin
  conexión); la pestaña online invita a subir si aún no está en la nube.
- Contador cuenta las canciones realmente visibles y se deduplican por
  filename al importar/descargar.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FV3MRYZ3rmJoANDwHyPevG