### PR TITLE
Fix YouTube player + add Google Drive audio playback in-app

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,32 @@
 
 ---
 
+## 2026-07-02 12:30 — Fix reproductor flotante de YouTube + audios de Drive en la app
+
+**Vídeos (fix):** el player flotante cargaba `youtube.com/embed/<id>` como
+documento principal del WebView y YouTube lo rechaza ("vídeo no disponible",
+error 153: el embed exige vivir dentro de un `<iframe>` en una página con
+referer válido — por eso en doceacordes funciona y aquí no). Ahora en nativo
+se carga un shell HTML mínimo con el embed dentro de un iframe y
+`baseUrl: https://www.youtube.com`; en web se mantiene el `<iframe>` directo.
+No hace falta tocar el repo del cantoral: valen tanto URLs `watch` como
+`embed` (la app ya normalizaba con `toYouTubeEmbedUrl`).
+
+**Audios (nuevo):** los enlaces de Google Drive ya no se abren en el
+navegador — suenan en el mismo reproductor flotante usando el endpoint
+oficial de embed de Drive (`/file/d/<id>/preview`), con botón secundario
+para abrir en el navegador. URLs no reconocidas como Drive siguen cayendo
+al navegador.
+
+- `components/song-media/FloatingYouTubePlayer.tsx` →
+  `FloatingMediaPlayer.tsx` (soporta `kind: 'youtube' | 'drive'`; sin botón
+  de pantalla completa para audio; altura reducida para el player de audio)
+- `utils/googleDrive.ts` (nuevo) + `__tests__/googleDrive.test.ts`:
+  `extractDriveFileId` / `toDrivePreviewUrl`
+- `components/song-media/SongMediaSheet.tsx`: prop `onPlayVideo` →
+  `onPlayMedia`; filas de audio reproducen in-app
+- `app/screens/SongDetailScreen.tsx`: estado `floatingVideo` → `floatingMedia`
+
 ## 2026-06-28 15:45 — Refactor: trocear GruposScreen (parcial, Fase 1.7)
 
 `app/screens/GruposScreen.tsx` pasa de **1100 → 561 líneas** (sale de la lista

--- a/mcm-app/__tests__/googleDrive.test.ts
+++ b/mcm-app/__tests__/googleDrive.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests para la normalización de URLs de Google Drive.
+ *
+ * ¿Qué testea?
+ * - Que se extraiga el ID de las formas habituales de enlace de Drive
+ *   (/file/d/ID/view, open?id=, uc?id=).
+ * - Que `toDrivePreviewUrl` devuelva la URL de preview embebible.
+ * - Que ante una URL que no es de Drive, devuelva null (fallback al navegador).
+ */
+import { extractDriveFileId, toDrivePreviewUrl } from '@/utils/googleDrive';
+
+const ID = '1INTVujFZTFoHIeJiBGTaF8PRU65-W9qx';
+
+describe('extractDriveFileId', () => {
+  it('extrae el ID de un enlace de compartir /file/d/', () => {
+    expect(
+      extractDriveFileId(
+        `https://drive.google.com/file/d/${ID}/view?usp=drive_link`,
+      ),
+    ).toBe(ID);
+  });
+
+  it('extrae el ID de una URL de preview (idempotencia)', () => {
+    expect(
+      extractDriveFileId(`https://drive.google.com/file/d/${ID}/preview`),
+    ).toBe(ID);
+  });
+
+  it('extrae el ID de open?id= y uc?export=download&id=', () => {
+    expect(extractDriveFileId(`https://drive.google.com/open?id=${ID}`)).toBe(
+      ID,
+    );
+    expect(
+      extractDriveFileId(`https://docs.google.com/uc?export=download&id=${ID}`),
+    ).toBe(ID);
+  });
+
+  it('devuelve null para URLs que no son de Drive', () => {
+    expect(extractDriveFileId('https://example.com/cancion.mp3')).toBeNull();
+    expect(
+      extractDriveFileId('https://example.com/file/d/abcdefghijk'),
+    ).toBeNull();
+    expect(extractDriveFileId('')).toBeNull();
+  });
+});
+
+describe('toDrivePreviewUrl', () => {
+  it('convierte un enlace de compartir en URL de preview', () => {
+    expect(
+      toDrivePreviewUrl(
+        `https://drive.google.com/file/d/${ID}/view?usp=drive_link`,
+      ),
+    ).toBe(`https://drive.google.com/file/d/${ID}/preview`);
+  });
+
+  it('devuelve null si no se reconoce', () => {
+    expect(toDrivePreviewUrl('https://example.com/audio.mp3')).toBeNull();
+  });
+});

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -32,9 +32,9 @@ import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/utils/firebaseApp';
 import { hasSongMedia } from '@/types/songMedia';
 import SongMediaSheet from '@/components/song-media/SongMediaSheet';
-import FloatingYouTubePlayer, {
-  type FloatingVideoSource,
-} from '@/components/song-media/FloatingYouTubePlayer';
+import FloatingMediaPlayer, {
+  type FloatingMediaSource,
+} from '@/components/song-media/FloatingMediaPlayer';
 
 // Apple iOS system green — used as a "selected/done" tint inside the
 // add/remove song button. Not part of the MCM brand palette: it's an
@@ -219,8 +219,8 @@ export default function SongDetailScreen({
   const media = useMemo(() => routeMedia ?? null, [routeMedia]);
   const songHasMedia = hasSongMedia(media);
   const [showMediaSheet, setShowMediaSheet] = useState(false);
-  const [floatingVideo, setFloatingVideo] =
-    useState<FloatingVideoSource | null>(null);
+  const [floatingMedia, setFloatingMedia] =
+    useState<FloatingMediaSource | null>(null);
 
   // Al cambiar de canción (swipe), cerramos el cajón pero conservamos el
   // reproductor flotante (sobrevive porque es la misma instancia montada).
@@ -623,14 +623,14 @@ export default function SongDetailScreen({
         onClose={() => setShowMediaSheet(false)}
         media={media}
         songTitle={_navScreenTitle}
-        onPlayVideo={(embedUrl, label) => {
+        onPlayMedia={(source) => {
           setShowMediaSheet(false);
-          setFloatingVideo({ embedUrl, label });
+          setFloatingMedia(source);
         }}
       />
-      <FloatingYouTubePlayer
-        source={floatingVideo}
-        onClose={() => setFloatingVideo(null)}
+      <FloatingMediaPlayer
+        source={floatingMedia}
+        onClose={() => setFloatingMedia(null)}
       />
       {isAdmin && (
         <ArrangementInputModal

--- a/mcm-app/components/song-media/FloatingMediaPlayer.tsx
+++ b/mcm-app/components/song-media/FloatingMediaPlayer.tsx
@@ -14,19 +14,23 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { h } from '@/utils/haptics';
 
-export interface FloatingVideoSource {
-  embedUrl: string;
+export interface FloatingMediaSource {
+  /** 'youtube' → URL de embed de YouTube · 'drive' → URL de preview de Drive. */
+  kind: 'youtube' | 'drive';
+  url: string;
   label: string;
 }
 
-interface FloatingYouTubePlayerProps {
-  source: FloatingVideoSource | null;
+interface FloatingMediaPlayerProps {
+  source: FloatingMediaSource | null;
   onClose: () => void;
 }
 
 const PLAYER_WIDTH = 208;
 // 16:9 → 208 * 9 / 16 ≈ 117 (igual que `.ytf-screen` del diseño).
-const SCREEN_HEIGHT = Math.round((PLAYER_WIDTH * 9) / 16);
+const VIDEO_HEIGHT = Math.round((PLAYER_WIDTH * 9) / 16);
+// Audio de Drive: solo hace falta la barra del reproductor.
+const AUDIO_HEIGHT = 100;
 
 /** Añade los parámetros de reproducción inline/autoplay a la URL de embed. */
 function withPlaybackParams(embedUrl: string): string {
@@ -35,14 +39,33 @@ function withPlaybackParams(embedUrl: string): string {
 }
 
 /**
- * Reproductor flotante de YouTube (estilo PiP de iOS) que se superpone a la
- * letra sin taparla del todo y se puede arrastrar por la pantalla. En web cae
- * a un `<iframe>` (la PiP nativa no está disponible).
+ * Página HTML mínima que envuelve el embed en un `<iframe>`. YouTube exige que
+ * su player de embed viva DENTRO de un iframe en una página con referer válido
+ * — cargar `youtube.com/embed/<id>` como documento principal del WebView
+ * devuelve "vídeo no disponible" (error 153, falta el referer). Con este shell
+ * + `baseUrl` de YouTube el embed funciona igual que en una web normal.
  */
-export default function FloatingYouTubePlayer({
+function embedShellHtml(src: string): string {
+  const safeSrc = src.replace(/"/g, '&quot;');
+  return `<!doctype html><html><head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<style>html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}
+iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0}</style>
+</head><body>
+<iframe src="${safeSrc}" allow="autoplay; encrypted-media; picture-in-picture; fullscreen" allowfullscreen></iframe>
+</body></html>`;
+}
+
+/**
+ * Reproductor flotante multimedia (estilo PiP de iOS) que se superpone a la
+ * letra sin taparla del todo y se puede arrastrar por la pantalla. Reproduce
+ * vídeos de YouTube (embed) y audios de Google Drive (preview). En web cae a
+ * un `<iframe>` directo, como hace cualquier página que embebe YouTube.
+ */
+export default function FloatingMediaPlayer({
   source,
   onClose,
-}: FloatingYouTubePlayerProps) {
+}: FloatingMediaPlayerProps) {
   const insets = useSafeAreaInsets();
   const [fullscreen, setFullscreen] = useState(false);
 
@@ -81,11 +104,14 @@ export default function FloatingYouTubePlayer({
       tension: 90,
       friction: 11,
     }).start();
-    // Solo cuando cambia la URL del vídeo.
+    // Solo cuando cambia la URL.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source?.embedUrl]);
+  }, [source?.url]);
 
   if (!source) return null;
+
+  const isVideo = source.kind === 'youtube';
+  const screenHeight = isVideo ? VIDEO_HEIGHT : AUDIO_HEIGHT;
 
   const handleClose = () => {
     h.tap();
@@ -93,7 +119,12 @@ export default function FloatingYouTubePlayer({
     onClose();
   };
 
-  const playUri = withPlaybackParams(source.embedUrl);
+  // YouTube necesita ir dentro de un iframe (ver embedShellHtml); el preview
+  // de Drive es una página normal y se carga directamente.
+  const playUri = isVideo ? withPlaybackParams(source.url) : source.url;
+  const nativeSource = isVideo
+    ? { html: embedShellHtml(playUri), baseUrl: 'https://www.youtube.com' }
+    : { uri: playUri };
 
   const videoSurface = (height: number | '100%') =>
     Platform.OS === 'web' ? (
@@ -113,7 +144,7 @@ export default function FloatingYouTubePlayer({
       />
     ) : (
       <WebView
-        source={{ uri: playUri }}
+        source={nativeSource}
         style={{ width: '100%', height, backgroundColor: '#000' }}
         originWhitelist={['*']}
         allowsInlineMediaPlayback
@@ -155,17 +186,19 @@ export default function FloatingYouTubePlayer({
           <Text style={styles.barLabel} numberOfLines={1}>
             {source.label}
           </Text>
-          <TouchableOpacity
-            onPress={() => {
-              h.tap();
-              setFullscreen(true);
-            }}
-            style={styles.barBtn}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            accessibilityLabel="Pantalla completa"
-          >
-            <MaterialIcons name="fullscreen" size={15} color="#fff" />
-          </TouchableOpacity>
+          {isVideo && (
+            <TouchableOpacity
+              onPress={() => {
+                h.tap();
+                setFullscreen(true);
+              }}
+              style={styles.barBtn}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityLabel="Pantalla completa"
+            >
+              <MaterialIcons name="fullscreen" size={15} color="#fff" />
+            </TouchableOpacity>
+          )}
           <TouchableOpacity
             onPress={handleClose}
             style={styles.barBtn}
@@ -175,13 +208,13 @@ export default function FloatingYouTubePlayer({
             <MaterialIcons name="close" size={15} color="#fff" />
           </TouchableOpacity>
         </View>
-        {/* Pantalla del vídeo */}
-        <View style={{ height: SCREEN_HEIGHT, backgroundColor: '#000' }}>
-          {!fullscreen && videoSurface(SCREEN_HEIGHT)}
+        {/* Pantalla del vídeo / reproductor de audio */}
+        <View style={{ height: screenHeight, backgroundColor: '#000' }}>
+          {!fullscreen && videoSurface(screenHeight)}
         </View>
       </Animated.View>
 
-      {/* Pantalla completa */}
+      {/* Pantalla completa (solo vídeo) */}
       <Modal
         visible={fullscreen}
         transparent={false}

--- a/mcm-app/components/song-media/SongMediaSheet.tsx
+++ b/mcm-app/components/song-media/SongMediaSheet.tsx
@@ -15,7 +15,9 @@ import { useToast } from '@/contexts/AppToastContext';
 import { h } from '@/utils/haptics';
 import BottomSheet from '@/components/BottomSheet';
 import brand from '@/constants/colors';
+import { toDrivePreviewUrl } from '@/utils/googleDrive';
 import type { MediaLink, SongMedia } from '@/types/songMedia';
+import type { FloatingMediaSource } from '@/components/song-media/FloatingMediaPlayer';
 
 interface SongMediaSheetProps {
   visible: boolean;
@@ -23,8 +25,8 @@ interface SongMediaSheetProps {
   media: SongMedia | null;
   /** Título de la canción — se usa como etiqueta del reproductor flotante. */
   songTitle?: string;
-  /** Abre el reproductor flotante con la URL de embed indicada. */
-  onPlayVideo: (embedUrl: string, label: string) => void;
+  /** Abre el reproductor flotante con la fuente indicada (vídeo o audio). */
+  onPlayMedia: (source: FloatingMediaSource) => void;
 }
 
 const YT_RED = '#FF3B30';
@@ -48,7 +50,7 @@ export default function SongMediaSheet({
   onClose,
   media,
   songTitle,
-  onPlayVideo,
+  onPlayMedia,
 }: SongMediaSheetProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
@@ -82,7 +84,23 @@ export default function SongMediaSheet({
 
   const playVideo = (embedUrl: string, label: string) => {
     h.tap();
-    onPlayVideo(embedUrl, label);
+    onPlayMedia({ kind: 'youtube', url: embedUrl, label });
+  };
+
+  // Audio: si es un enlace de Drive reconocible, suena en el reproductor
+  // flotante (URL de preview embebible); si no, cae al navegador.
+  const playAudio = (link: MediaLink) => {
+    const previewUrl = toDrivePreviewUrl(link.url);
+    if (!previewUrl) {
+      void openExternal(link.url);
+      return;
+    }
+    h.tap();
+    onPlayMedia({
+      kind: 'drive',
+      url: previewUrl,
+      label: link.label || 'Audio',
+    });
   };
 
   const renderVideoRow = (
@@ -117,31 +135,50 @@ export default function SongMediaSheet({
     </TouchableOpacity>
   );
 
-  const renderAudioRow = (link: MediaLink, index: number) => (
-    <TouchableOpacity
-      key={`audio-${index}`}
-      style={styles.mRow}
-      activeOpacity={0.7}
-      onPress={() => openExternal(link.url)}
-    >
-      <View style={[styles.mIco, styles.mIcoDrive]}>
-        <MaterialIcons name="headphones" size={20} color={driveTint(isDark)} />
-      </View>
-      <View style={styles.mMain}>
-        <Text style={styles.mTitle} numberOfLines={1}>
-          {link.label || 'Audio'}
-        </Text>
-        <Text style={styles.mMeta}>Google Drive</Text>
-      </View>
-      <View style={[styles.mGo, styles.mGoExt]}>
-        <MaterialIcons
-          name="open-in-new"
-          size={17}
-          color={isDark ? '#8E8E93' : '#8E8E93'}
-        />
-      </View>
-    </TouchableOpacity>
-  );
+  const renderAudioRow = (link: MediaLink, index: number) => {
+    const playsInApp = Boolean(toDrivePreviewUrl(link.url));
+    return (
+      <TouchableOpacity
+        key={`audio-${index}`}
+        style={styles.mRow}
+        activeOpacity={0.7}
+        onPress={() => playAudio(link)}
+      >
+        <View style={[styles.mIco, styles.mIcoDrive]}>
+          <MaterialIcons
+            name="headphones"
+            size={20}
+            color={driveTint(isDark)}
+          />
+        </View>
+        <View style={styles.mMain}>
+          <Text style={styles.mTitle} numberOfLines={1}>
+            {link.label || 'Audio'}
+          </Text>
+          <Text style={styles.mMeta}>
+            {playsInApp ? 'Google Drive' : 'Enlace externo'}
+          </Text>
+        </View>
+        {playsInApp && (
+          <TouchableOpacity
+            style={[styles.mGo, styles.mGoExt]}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            onPress={() => openExternal(link.url)}
+            accessibilityLabel="Abrir en el navegador"
+          >
+            <MaterialIcons name="open-in-new" size={17} color="#8E8E93" />
+          </TouchableOpacity>
+        )}
+        <View style={styles.mGo}>
+          <MaterialIcons
+            name={playsInApp ? 'play-arrow' : 'open-in-new'}
+            size={playsInApp ? 20 : 17}
+            color={playsInApp ? brand.primary : '#8E8E93'}
+          />
+        </View>
+      </TouchableOpacity>
+    );
+  };
 
   return (
     <BottomSheet visible={visible} onClose={onClose} title="Multimedia y ficha">
@@ -184,7 +221,7 @@ export default function SongMediaSheet({
                 color={isDark ? '#8E8E93' : '#8E8E93'}
               />
               <Text style={styles.secHeadText}>Audios</Text>
-              <Text style={styles.secHint}>se abren en el navegador</Text>
+              <Text style={styles.secHint}>reproductor flotante</Text>
             </View>
             {media.audioLinks?.map(renderAudioRow)}
           </View>

--- a/mcm-app/utils/googleDrive.ts
+++ b/mcm-app/utils/googleDrive.ts
@@ -1,0 +1,46 @@
+/**
+ * Utilidades para normalizar URLs de Google Drive.
+ *
+ * Los audios del cantoral viven en Drive como enlaces "de compartir"
+ * (`/file/d/<id>/view?usp=drive_link`). Para reproducirlos dentro de la app
+ * usamos el endpoint oficial de embed de Drive (`/file/d/<id>/preview`), que
+ * pinta un reproductor de audio/vídeo apto para iframes y WebViews.
+ */
+
+/**
+ * Extrae el ID de fichero de una URL de Google Drive en sus formas habituales.
+ * Devuelve `null` si no se reconoce.
+ *
+ * Soporta:
+ *  - https://drive.google.com/file/d/ID/view?usp=drive_link
+ *  - https://drive.google.com/file/d/ID/preview
+ *  - https://drive.google.com/open?id=ID
+ *  - https://drive.google.com/uc?id=ID / ?export=download&id=ID
+ *  - https://docs.google.com/uc?export=download&id=ID
+ */
+export function extractDriveFileId(input: string): string | null {
+  if (!input) return null;
+  const url = input.trim();
+  if (!/(?:drive|docs)\.google\.com/i.test(url)) return null;
+
+  const patterns = [
+    /\/file\/d\/([A-Za-z0-9_-]{10,})/, // /file/d/ID
+    /[?&]id=([A-Za-z0-9_-]{10,})/, // open?id=ID / uc?id=ID
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Convierte una URL de Drive en su URL de *preview* (embed). Si no se puede
+ * extraer el ID, devuelve `null` — quien consume decide el fallback (abrir en
+ * el navegador).
+ */
+export function toDrivePreviewUrl(input: string): string | null {
+  const id = extractDriveFileId(input);
+  return id ? `https://drive.google.com/file/d/${id}/preview` : null;
+}


### PR DESCRIPTION
## Summary

Fixes the floating YouTube player (which was failing to load videos in native WebView) and adds support for playing Google Drive audio files directly in the app using the same floating player component.

## Key Changes

- **FloatingYouTubePlayer → FloatingMediaPlayer**: Renamed and refactored to support both YouTube videos and Google Drive audio
  - YouTube videos now load via an HTML shell wrapper with proper iframe structure and `baseUrl` to satisfy YouTube's referer requirements
  - Google Drive audio uses the official preview endpoint (`/file/d/<id>/preview`)
  - Audio player has reduced height (100px) vs video (117px); fullscreen button only shows for video
  - Conditional rendering of fullscreen button based on media kind

- **Google Drive URL utilities** (`utils/googleDrive.ts`):
  - `extractDriveFileId()`: Extracts file ID from various Drive URL formats (`/file/d/`, `open?id=`, `uc?id=`)
  - `toDrivePreviewUrl()`: Converts share links to embeddable preview URLs
  - Includes comprehensive test suite (`__tests__/googleDrive.test.ts`)

- **SongMediaSheet**: Updated audio row rendering
  - Audio links now play in-app via the floating player when Drive URL is recognized
  - Unrecognized URLs fall back to opening in browser
  - Shows "Google Drive" or "Enlace externo" label based on whether it's playable in-app
  - Adds secondary "open in browser" button for Drive audio (when playable in-app)
  - Play icon (primary color) for in-app playback; external link icon for browser fallback

- **SongDetailScreen**: Updated state and prop names
  - `floatingVideo` → `floatingMedia`
  - `onPlayVideo` → `onPlayMedia`
  - Imports updated to use `FloatingMediaPlayer` and `FloatingMediaSource`

- **CHANGELOG.md**: Added detailed entry documenting the fix and new feature

## Implementation Details

The YouTube player fix addresses error 153 ("video not available") by wrapping the embed in a minimal HTML shell with proper iframe structure and setting `baseUrl: https://www.youtube.com` in the WebView source. This satisfies YouTube's requirement that embeds live within an iframe on a page with valid referer.

Google Drive audio detection is non-destructive: if a URL doesn't match Drive patterns, it opens in the browser as before. The preview endpoint is the official Google-provided embed mechanism for Drive files.

https://claude.ai/code/session_01SxdxNK5wM5rBEsV9mmHXos