### PR TITLE
Fix (v2): API oficial de YouTube IFrame + ajuste tamaño audio

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,22 @@
 
 ---
 
+## 2026-07-03 01:15 — Player flotante: fullscreen sin recargar + audios abren la app de Drive
+
+- **Pantalla completa fluida:** el modo grande ya no monta un segundo WebView
+  en un Modal (que recargaba el vídeo desde el principio). Ahora el propio
+  contenedor flotante se expande a pantalla completa con una
+  `LayoutAnimation` — el WebView es siempre la misma instancia y la
+  reproducción continúa sin cortes al entrar y salir. El botón alterna
+  fullscreen/fullscreen-exit y el arrastre se desactiva mientras está en
+  grande.
+- **Audios → app de Google Drive:** el botón "abrir fuera" de los audios (y
+  cualquier enlace de Drive de la ficha) pasa de `WebBrowser` (navegador
+  in-app, que se salta los universal links) a `Linking.openURL` — si la app
+  de Google Drive está instalada, el enlace la abre directamente.
+- `components/song-media/FloatingMediaPlayer.tsx` (sin Modal, −60 líneas),
+  `components/song-media/SongMediaSheet.tsx` (`openExternal` con rama Drive).
+
 ## 2026-07-02 19:00 — Fix (v3, definitivo): Referer HTTP real en el embed + abrir la app de YouTube
 
 La v2 (IFrame API en HTML inyectado) seguía cayendo al fallback en

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,31 @@
 
 ---
 
+## 2026-07-02 18:20 — Fix (v2): API oficial de YouTube IFrame + ajuste tamaño audio
+
+El fix anterior (iframe crudo dentro de un shell HTML) resolvía el caso
+general pero seguía fallando en vídeos concretos (p.ej. "Yo celebraré",
+Entrada #11: "vídeo no disponible"), aunque el endpoint oembed de YouTube
+confirma que esos vídeos SÍ admiten embed en cualquier web. Causa: un
+`<iframe src="…/embed/ID">` suelto cargado vía `loadHTMLString` no manda un
+`Referer` real y YouTube lo puede rechazar de forma inconsistente.
+
+- Se sustituye el iframe suelto por la **API oficial de IFrame de YouTube**
+  (`https://www.youtube.com/iframe_api` + `new YT.Player(...)`), que hace el
+  handshake por `postMessage` y con `playerVars.origin` fijo es mucho más
+  fiable dentro de un WebView.
+- Si aun así el vídeo da error (`onError` de la API: embed deshabilitado por
+  el autor, restricción regional…), se muestra un fallback dentro de la
+  propia página con botón "Ver en YouTube" que abre el navegador. Además hay
+  un botón fijo (icono ↗ rojo) en la barra del reproductor para abrir
+  YouTube manualmente en cualquier momento, igual que hace doceacordes.
+- Audio (Drive): el reproductor pasa de 208×100 a **ancho casi completo de
+  pantalla × 64 de alto** — el player de Drive se veía apretado en un ancho
+  tan estrecho como el del PiP de vídeo.
+- `components/song-media/FloatingMediaPlayer.tsx`: nuevo `embedShellHtml`
+  basado en la API oficial + `onMessage` del WebView para el fallback +
+  `useWindowDimensions` para el ancho del audio.
+
 ## 2026-07-02 12:30 — Fix reproductor flotante de YouTube + audios de Drive en la app
 
 **Vídeos (fix):** el player flotante cargaba `youtube.com/embed/<id>` como

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,29 @@
 
 ---
 
+## 2026-07-02 19:00 — Fix (v3, definitivo): Referer HTTP real en el embed + abrir la app de YouTube
+
+La v2 (IFrame API en HTML inyectado) seguía cayendo al fallback en
+dispositivo. Diagnóstico definitivo: **todo lo que se carga en el WebView vía
+`loadHTMLString` sale sin cabecera HTTP `Referer`** — da igual el baseUrl, el
+iframe o la IFrame API — y el embed de YouTube rechaza peticiones sin Referer
+(códigos 152/153). Doceacordes funciona porque su navegador manda
+`Referer: https://doceacordes.es/` de verdad.
+
+- **El fix:** cargar la URL de embed real (`youtube.com/embed/<id>`) como
+  `source={{ uri, headers: { Referer: 'https://mcmespana.github.io/' } }}` —
+  el WebView de RN sí permite cabeceras en la petición inicial. YouTube nos
+  ve exactamente igual que a una web que embebe el vídeo.
+- **Abrir la app de YouTube (no la web):** el botón de la barra y cualquier
+  navegación que el propio player intente hacia `watch?v=`/`youtu.be` (p.ej.
+  tocar el logo o el "Ver en YouTube" del error) se interceptan con
+  `onShouldStartLoadWithRequest` y abren la app nativa vía
+  `Linking.openURL('youtube://…' / 'vnd.youtube://…')`, con fallback a la URL
+  https (que también abre la app por universal link si está instalada).
+- Se elimina el shell HTML con la IFrame API y el puente `onMessage` (ya no
+  hacen falta) y `WebBrowser` deja de usarse para YouTube.
+- `components/song-media/FloatingMediaPlayer.tsx`.
+
 ## 2026-07-02 18:20 — Fix (v2): API oficial de YouTube IFrame + ajuste tamaño audio
 
 El fix anterior (iframe crudo dentro de un shell HTML) resolvía el caso

--- a/mcm-app/components/song-media/FloatingMediaPlayer.tsx
+++ b/mcm-app/components/song-media/FloatingMediaPlayer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
+  Linking,
   Modal,
   PanResponder,
   Platform,
@@ -10,9 +11,8 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
-import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import { WebView } from 'react-native-webview';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import * as WebBrowser from 'expo-web-browser';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { h } from '@/utils/haptics';
 import { extractYouTubeId } from '@/utils/youtube';
@@ -40,70 +40,36 @@ const AUDIO_HEIGHT = 64;
 const SIDE_MARGIN = 14;
 
 /**
- * Página HTML mínima que instancia el reproductor con la **API oficial de
- * IFrame de YouTube** (`iframe_api`), en vez de un `<iframe src="…/embed/…">`
- * suelto. Un `<iframe>` a pelo cargado dentro de un WebView (vía
- * `loadHTMLString`/`loadDataWithBaseURL`) no manda un `Referer` real y
- * YouTube lo trata como un embed no fiable — algunos vídeos responden con
- * "vídeo no disponible" aunque el propio vídeo permita embeberse en
- * cualquier web (comprobable con el endpoint oembed). La API oficial hace el
- * handshake vía `postMessage` y con `playerVars.origin` fijo funciona de
- * forma consistente. Si aun así el vídeo da error (embed deshabilitado por
- * el autor, restricción regional, etc.), mostramos un fallback dentro de la
- * propia página con un botón que abre YouTube en el navegador.
+ * Referer que mandamos al cargar la página de embed de YouTube.
+ *
+ * CLAVE de por qué el player fallaba con "vídeo no disponible" (códigos
+ * 152/153): YouTube exige que la petición del embed llegue con una cabecera
+ * HTTP `Referer` real, como cuando una web (doceacordes) embebe el iframe.
+ * Todo lo que se carga en el WebView vía `loadHTMLString` (HTML inyectado,
+ * con o sin baseUrl, con o sin la IFrame API) sale SIN Referer y YouTube lo
+ * rechaza según el vídeo. La solución es cargar la URL de embed real con
+ * `source.headers.Referer` — el valor solo tiene que existir y ser una URL
+ * plausible; no hace falta que el dominio sirva nada.
  */
-function embedShellHtml(videoId: string): string {
-  const safeId = videoId.replace(/[^A-Za-z0-9_-]/g, '');
-  return `<!doctype html><html><head>
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<style>
-html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}
-#player{position:absolute;inset:0}
-#player iframe{position:absolute!important;top:0;left:0;width:100%!important;height:100%!important;border:0}
-#fallback{display:none;position:absolute;inset:0;flex-direction:column;align-items:center;justify-content:center;background:#141414;padding:16px;box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,sans-serif;text-align:center}
-#fallback.show{display:flex}
-#fallback p{color:#fff;opacity:.75;font-size:12.5px;line-height:1.4;margin:0 0 12px}
-#fallback button{background:${YT_RED};color:#fff;border:0;border-radius:16px;padding:9px 16px;font-size:12.5px;font-weight:600}
-</style>
-</head><body>
-<div id="player"></div>
-<div id="fallback">
-  <p>Este vídeo no se puede reproducir aquí.</p>
-  <button id="fallback-btn">Ver en YouTube</button>
-</div>
-<script>
-function post(msg){ if (window.ReactNativeWebView) window.ReactNativeWebView.postMessage(JSON.stringify(msg)); }
-document.getElementById('fallback-btn').addEventListener('click', function(){ post({ type: 'open-youtube' }); });
-var tag = document.createElement('script');
-tag.src = 'https://www.youtube.com/iframe_api';
-document.body.appendChild(tag);
-function onYouTubeIframeAPIReady() {
-  new YT.Player('player', {
-    videoId: '${safeId}',
-    playerVars: { playsinline: 1, autoplay: 1, rel: 0, origin: 'https://www.youtube.com' },
-    events: {
-      onError: function (e) {
-        document.getElementById('fallback').classList.add('show');
-        post({ type: 'yt-error', code: e && e.data });
-      },
-    },
-  });
-}
-</script>
-</body></html>`;
-}
+const EMBED_REFERER = 'https://mcmespana.github.io/';
 
-/** Añade los parámetros de reproducción inline/autoplay a la URL de embed (solo web). */
+/** Añade los parámetros de reproducción inline/autoplay a la URL de embed. */
 function withPlaybackParams(embedUrl: string): string {
   const sep = embedUrl.includes('?') ? '&' : '?';
   return `${embedUrl}${sep}playsinline=1&autoplay=1&rel=0`;
 }
 
+/** ¿La URL es una página de vídeo de YouTube (no de embed)? */
+function isYouTubeWatchUrl(url: string): boolean {
+  return /youtube\.com\/watch|youtu\.be\/|m\.youtube\.com/.test(url);
+}
+
 /**
  * Reproductor flotante multimedia (estilo PiP de iOS) que se superpone a la
  * letra sin taparla del todo y se puede arrastrar por la pantalla. Reproduce
- * vídeos de YouTube (embed) y audios de Google Drive (preview). En web cae a
- * un `<iframe>` directo, como hace cualquier página que embebe YouTube.
+ * vídeos de YouTube (embed con Referer real) y audios de Google Drive
+ * (preview). En web cae a un `<iframe>` directo, como cualquier página que
+ * embebe YouTube.
  */
 export default function FloatingMediaPlayer({
   source,
@@ -152,26 +118,28 @@ export default function FloatingMediaPlayer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source?.url]);
 
-  const openInYouTube = useCallback((videoId: string | null) => {
+  /**
+   * Abre el vídeo preferentemente en la APP de YouTube (scheme nativo). Si
+   * la app no está instalada, `openURL` del scheme falla y caemos a la URL
+   * https vía Linking — que en iOS/Android también abre la app por universal
+   * link si existe, y si no, el navegador.
+   */
+  const openInYouTube = useCallback(async (videoId: string | null) => {
     if (!videoId) return;
-    void WebBrowser.openBrowserAsync(
-      `https://www.youtube.com/watch?v=${videoId}`,
-    );
-  }, []);
-
-  const handleWebViewMessage = useCallback(
-    (event: WebViewMessageEvent, videoId: string | null) => {
+    const appUrl =
+      Platform.OS === 'ios'
+        ? `youtube://www.youtube.com/watch?v=${videoId}`
+        : `vnd.youtube://watch?v=${videoId}`;
+    try {
+      await Linking.openURL(appUrl);
+    } catch {
       try {
-        const msg = JSON.parse(event.nativeEvent.data);
-        if (msg?.type === 'open-youtube') {
-          openInYouTube(videoId);
-        }
+        await Linking.openURL(`https://www.youtube.com/watch?v=${videoId}`);
       } catch {
-        /* mensaje no reconocido; se ignora */
+        /* sin YouTube ni navegador no hay nada que hacer */
       }
-    },
-    [openInYouTube],
-  );
+    }
+  }, []);
 
   if (!source) return null;
 
@@ -189,35 +157,31 @@ export default function FloatingMediaPlayer({
     onClose();
   };
 
-  const videoSurface = (height: number | '100%') => {
-    if (Platform.OS === 'web') {
-      const webSrc = isVideo ? withPlaybackParams(source.url) : source.url;
-      return (
-        // @ts-ignore — iframe sólo existe en web
-        <iframe
-          src={webSrc}
-          style={{
-            width: '100%',
-            height,
-            border: 'none',
-            display: 'block',
-            backgroundColor: '#000',
-          }}
-          allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
-          allowFullScreen
-          title={source.label}
-        />
-      );
-    }
-    const nativeSource = isVideo
-      ? {
-          html: embedShellHtml(videoId ?? ''),
-          baseUrl: 'https://www.youtube.com',
-        }
-      : { uri: source.url };
-    return (
+  const playUri = isVideo ? withPlaybackParams(source.url) : source.url;
+
+  const videoSurface = (height: number | '100%') =>
+    Platform.OS === 'web' ? (
+      // @ts-ignore — iframe sólo existe en web
+      <iframe
+        src={playUri}
+        style={{
+          width: '100%',
+          height,
+          border: 'none',
+          display: 'block',
+          backgroundColor: '#000',
+        }}
+        allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+        allowFullScreen
+        title={source.label}
+      />
+    ) : (
       <WebView
-        source={nativeSource}
+        source={
+          isVideo
+            ? { uri: playUri, headers: { Referer: EMBED_REFERER } }
+            : { uri: playUri }
+        }
         style={{ width: '100%', height, backgroundColor: '#000' }}
         originWhitelist={['*']}
         allowsInlineMediaPlayback
@@ -226,10 +190,19 @@ export default function FloatingMediaPlayer({
         mediaPlaybackRequiresUserAction={false}
         javaScriptEnabled
         domStorageEnabled
-        onMessage={(e) => handleWebViewMessage(e, videoId)}
+        setSupportMultipleWindows={false}
+        onShouldStartLoadWithRequest={(req) => {
+          // Cualquier intento de salir del embed hacia la página de vídeo
+          // (p.ej. tocar el logo o el "Ver en YouTube" del propio player) se
+          // intercepta y se abre la app de YouTube en su lugar.
+          if (isVideo && isYouTubeWatchUrl(req.url)) {
+            void openInYouTube(videoId ?? extractYouTubeId(req.url));
+            return false;
+          }
+          return true;
+        }}
       />
     );
-  };
 
   const enterTranslateY = enter.interpolate({
     inputRange: [0, 1],
@@ -266,13 +239,13 @@ export default function FloatingMediaPlayer({
             <TouchableOpacity
               onPress={() => {
                 h.tap();
-                openInYouTube(videoId);
+                void openInYouTube(videoId);
               }}
               style={styles.barBtn}
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityLabel="Ver en YouTube"
+              accessibilityLabel="Abrir en la app de YouTube"
             >
-              <MaterialIcons name="open-in-new" size={13} color={YT_RED} />
+              <MaterialIcons name="smart-display" size={13} color={YT_RED} />
             </TouchableOpacity>
           )}
           {isVideo && (

--- a/mcm-app/components/song-media/FloatingMediaPlayer.tsx
+++ b/mcm-app/components/song-media/FloatingMediaPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Modal,
@@ -7,12 +7,15 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from 'react-native';
-import { WebView } from 'react-native-webview';
+import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as WebBrowser from 'expo-web-browser';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { h } from '@/utils/haptics';
+import { extractYouTubeId } from '@/utils/youtube';
 
 export interface FloatingMediaSource {
   /** 'youtube' → URL de embed de YouTube · 'drive' → URL de preview de Drive. */
@@ -26,34 +29,74 @@ interface FloatingMediaPlayerProps {
   onClose: () => void;
 }
 
+const YT_RED = '#FF3B30';
 const PLAYER_WIDTH = 208;
 // 16:9 → 208 * 9 / 16 ≈ 117 (igual que `.ytf-screen` del diseño).
 const VIDEO_HEIGHT = Math.round((PLAYER_WIDTH * 9) / 16);
-// Audio de Drive: solo hace falta la barra del reproductor.
-const AUDIO_HEIGHT = 100;
+// Audio de Drive: barra de reproducción compacta, no necesita tanto alto
+// como el vídeo pero sí casi todo el ancho disponible (el player de Drive
+// se ve apretado en un ancho tan estrecho como el del PiP de vídeo).
+const AUDIO_HEIGHT = 64;
+const SIDE_MARGIN = 14;
 
-/** Añade los parámetros de reproducción inline/autoplay a la URL de embed. */
+/**
+ * Página HTML mínima que instancia el reproductor con la **API oficial de
+ * IFrame de YouTube** (`iframe_api`), en vez de un `<iframe src="…/embed/…">`
+ * suelto. Un `<iframe>` a pelo cargado dentro de un WebView (vía
+ * `loadHTMLString`/`loadDataWithBaseURL`) no manda un `Referer` real y
+ * YouTube lo trata como un embed no fiable — algunos vídeos responden con
+ * "vídeo no disponible" aunque el propio vídeo permita embeberse en
+ * cualquier web (comprobable con el endpoint oembed). La API oficial hace el
+ * handshake vía `postMessage` y con `playerVars.origin` fijo funciona de
+ * forma consistente. Si aun así el vídeo da error (embed deshabilitado por
+ * el autor, restricción regional, etc.), mostramos un fallback dentro de la
+ * propia página con un botón que abre YouTube en el navegador.
+ */
+function embedShellHtml(videoId: string): string {
+  const safeId = videoId.replace(/[^A-Za-z0-9_-]/g, '');
+  return `<!doctype html><html><head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<style>
+html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}
+#player{position:absolute;inset:0}
+#player iframe{position:absolute!important;top:0;left:0;width:100%!important;height:100%!important;border:0}
+#fallback{display:none;position:absolute;inset:0;flex-direction:column;align-items:center;justify-content:center;background:#141414;padding:16px;box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,sans-serif;text-align:center}
+#fallback.show{display:flex}
+#fallback p{color:#fff;opacity:.75;font-size:12.5px;line-height:1.4;margin:0 0 12px}
+#fallback button{background:${YT_RED};color:#fff;border:0;border-radius:16px;padding:9px 16px;font-size:12.5px;font-weight:600}
+</style>
+</head><body>
+<div id="player"></div>
+<div id="fallback">
+  <p>Este vídeo no se puede reproducir aquí.</p>
+  <button id="fallback-btn">Ver en YouTube</button>
+</div>
+<script>
+function post(msg){ if (window.ReactNativeWebView) window.ReactNativeWebView.postMessage(JSON.stringify(msg)); }
+document.getElementById('fallback-btn').addEventListener('click', function(){ post({ type: 'open-youtube' }); });
+var tag = document.createElement('script');
+tag.src = 'https://www.youtube.com/iframe_api';
+document.body.appendChild(tag);
+function onYouTubeIframeAPIReady() {
+  new YT.Player('player', {
+    videoId: '${safeId}',
+    playerVars: { playsinline: 1, autoplay: 1, rel: 0, origin: 'https://www.youtube.com' },
+    events: {
+      onError: function (e) {
+        document.getElementById('fallback').classList.add('show');
+        post({ type: 'yt-error', code: e && e.data });
+      },
+    },
+  });
+}
+</script>
+</body></html>`;
+}
+
+/** Añade los parámetros de reproducción inline/autoplay a la URL de embed (solo web). */
 function withPlaybackParams(embedUrl: string): string {
   const sep = embedUrl.includes('?') ? '&' : '?';
   return `${embedUrl}${sep}playsinline=1&autoplay=1&rel=0`;
-}
-
-/**
- * Página HTML mínima que envuelve el embed en un `<iframe>`. YouTube exige que
- * su player de embed viva DENTRO de un iframe en una página con referer válido
- * — cargar `youtube.com/embed/<id>` como documento principal del WebView
- * devuelve "vídeo no disponible" (error 153, falta el referer). Con este shell
- * + `baseUrl` de YouTube el embed funciona igual que en una web normal.
- */
-function embedShellHtml(src: string): string {
-  const safeSrc = src.replace(/"/g, '&quot;');
-  return `<!doctype html><html><head>
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<style>html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}
-iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0}</style>
-</head><body>
-<iframe src="${safeSrc}" allow="autoplay; encrypted-media; picture-in-picture; fullscreen" allowfullscreen></iframe>
-</body></html>`;
 }
 
 /**
@@ -67,6 +110,7 @@ export default function FloatingMediaPlayer({
   onClose,
 }: FloatingMediaPlayerProps) {
   const insets = useSafeAreaInsets();
+  const { width: windowWidth } = useWindowDimensions();
   const [fullscreen, setFullscreen] = useState(false);
 
   // Drag (arrastre) + animación de entrada.
@@ -108,10 +152,36 @@ export default function FloatingMediaPlayer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source?.url]);
 
+  const openInYouTube = useCallback((videoId: string | null) => {
+    if (!videoId) return;
+    void WebBrowser.openBrowserAsync(
+      `https://www.youtube.com/watch?v=${videoId}`,
+    );
+  }, []);
+
+  const handleWebViewMessage = useCallback(
+    (event: WebViewMessageEvent, videoId: string | null) => {
+      try {
+        const msg = JSON.parse(event.nativeEvent.data);
+        if (msg?.type === 'open-youtube') {
+          openInYouTube(videoId);
+        }
+      } catch {
+        /* mensaje no reconocido; se ignora */
+      }
+    },
+    [openInYouTube],
+  );
+
   if (!source) return null;
 
   const isVideo = source.kind === 'youtube';
+  const videoId = isVideo ? extractYouTubeId(source.url) : null;
   const screenHeight = isVideo ? VIDEO_HEIGHT : AUDIO_HEIGHT;
+  // El pip de vídeo es estrecho a propósito (estilo PiP); el de audio
+  // aprovecha casi todo el ancho de pantalla porque el reproductor de Drive
+  // necesita más sitio para sus controles.
+  const floatWidth = isVideo ? PLAYER_WIDTH : windowWidth - SIDE_MARGIN * 2;
 
   const handleClose = () => {
     h.tap();
@@ -119,30 +189,33 @@ export default function FloatingMediaPlayer({
     onClose();
   };
 
-  // YouTube necesita ir dentro de un iframe (ver embedShellHtml); el preview
-  // de Drive es una página normal y se carga directamente.
-  const playUri = isVideo ? withPlaybackParams(source.url) : source.url;
-  const nativeSource = isVideo
-    ? { html: embedShellHtml(playUri), baseUrl: 'https://www.youtube.com' }
-    : { uri: playUri };
-
-  const videoSurface = (height: number | '100%') =>
-    Platform.OS === 'web' ? (
-      // @ts-ignore — iframe sólo existe en web
-      <iframe
-        src={playUri}
-        style={{
-          width: '100%',
-          height,
-          border: 'none',
-          display: 'block',
-          backgroundColor: '#000',
-        }}
-        allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
-        allowFullScreen
-        title={source.label}
-      />
-    ) : (
+  const videoSurface = (height: number | '100%') => {
+    if (Platform.OS === 'web') {
+      const webSrc = isVideo ? withPlaybackParams(source.url) : source.url;
+      return (
+        // @ts-ignore — iframe sólo existe en web
+        <iframe
+          src={webSrc}
+          style={{
+            width: '100%',
+            height,
+            border: 'none',
+            display: 'block',
+            backgroundColor: '#000',
+          }}
+          allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+          allowFullScreen
+          title={source.label}
+        />
+      );
+    }
+    const nativeSource = isVideo
+      ? {
+          html: embedShellHtml(videoId ?? ''),
+          baseUrl: 'https://www.youtube.com',
+        }
+      : { uri: source.url };
+    return (
       <WebView
         source={nativeSource}
         style={{ width: '100%', height, backgroundColor: '#000' }}
@@ -153,8 +226,10 @@ export default function FloatingMediaPlayer({
         mediaPlaybackRequiresUserAction={false}
         javaScriptEnabled
         domStorageEnabled
+        onMessage={(e) => handleWebViewMessage(e, videoId)}
       />
     );
+  };
 
   const enterTranslateY = enter.interpolate({
     inputRange: [0, 1],
@@ -171,6 +246,7 @@ export default function FloatingMediaPlayer({
         style={[
           styles.floatWrap,
           {
+            width: floatWidth,
             bottom: insets.bottom + 96,
             opacity: enter,
             transform: [
@@ -186,6 +262,19 @@ export default function FloatingMediaPlayer({
           <Text style={styles.barLabel} numberOfLines={1}>
             {source.label}
           </Text>
+          {isVideo && (
+            <TouchableOpacity
+              onPress={() => {
+                h.tap();
+                openInYouTube(videoId);
+              }}
+              style={styles.barBtn}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityLabel="Ver en YouTube"
+            >
+              <MaterialIcons name="open-in-new" size={13} color={YT_RED} />
+            </TouchableOpacity>
+          )}
           {isVideo && (
             <TouchableOpacity
               onPress={() => {
@@ -257,8 +346,7 @@ export default function FloatingMediaPlayer({
 const styles = StyleSheet.create({
   floatWrap: {
     position: 'absolute',
-    right: 14,
-    width: PLAYER_WIDTH,
+    right: SIDE_MARGIN,
     borderRadius: 14,
     overflow: 'hidden',
     backgroundColor: '#111',

--- a/mcm-app/components/song-media/FloatingMediaPlayer.tsx
+++ b/mcm-app/components/song-media/FloatingMediaPlayer.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
+  LayoutAnimation,
   Linking,
-  Modal,
   PanResponder,
   Platform,
   StyleSheet,
@@ -68,8 +68,12 @@ function isYouTubeWatchUrl(url: string): boolean {
  * Reproductor flotante multimedia (estilo PiP de iOS) que se superpone a la
  * letra sin taparla del todo y se puede arrastrar por la pantalla. Reproduce
  * vídeos de YouTube (embed con Referer real) y audios de Google Drive
- * (preview). En web cae a un `<iframe>` directo, como cualquier página que
- * embebe YouTube.
+ * (preview). En web cae a un `<iframe>` directo.
+ *
+ * El modo "grande" NO usa un Modal: el propio contenedor flotante se expande
+ * a pantalla completa con una LayoutAnimation. Así el WebView es siempre la
+ * MISMA instancia y el vídeo sigue reproduciéndose sin recargar al entrar o
+ * salir de pantalla completa.
  */
 export default function FloatingMediaPlayer({
   source,
@@ -141,15 +145,23 @@ export default function FloatingMediaPlayer({
     }
   }, []);
 
+  const toggleFullscreen = useCallback(() => {
+    h.tap();
+    // Anima el cambio de tamaño/posición del contenedor — el WebView es el
+    // mismo, así que la reproducción continúa sin recargar.
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setFullscreen((f) => !f);
+  }, []);
+
   if (!source) return null;
 
   const isVideo = source.kind === 'youtube';
   const videoId = isVideo ? extractYouTubeId(source.url) : null;
-  const screenHeight = isVideo ? VIDEO_HEIGHT : AUDIO_HEIGHT;
+  const pipHeight = isVideo ? VIDEO_HEIGHT : AUDIO_HEIGHT;
   // El pip de vídeo es estrecho a propósito (estilo PiP); el de audio
   // aprovecha casi todo el ancho de pantalla porque el reproductor de Drive
   // necesita más sitio para sus controles.
-  const floatWidth = isVideo ? PLAYER_WIDTH : windowWidth - SIDE_MARGIN * 2;
+  const pipWidth = isVideo ? PLAYER_WIDTH : windowWidth - SIDE_MARGIN * 2;
 
   const handleClose = () => {
     h.tap();
@@ -159,14 +171,18 @@ export default function FloatingMediaPlayer({
 
   const playUri = isVideo ? withPlaybackParams(source.url) : source.url;
 
-  const videoSurface = (height: number | '100%') =>
+  // IMPORTANTE: una única superficie de vídeo en una posición fija del árbol
+  // de componentes. Entre PiP y pantalla completa SOLO cambian estilos de los
+  // contenedores — nunca desmontar/remontar el WebView/iframe, o el vídeo se
+  // recarga desde el principio.
+  const videoSurface =
     Platform.OS === 'web' ? (
       // @ts-ignore — iframe sólo existe en web
       <iframe
         src={playUri}
         style={{
           width: '100%',
-          height,
+          height: '100%',
           border: 'none',
           display: 'block',
           backgroundColor: '#000',
@@ -182,7 +198,7 @@ export default function FloatingMediaPlayer({
             ? { uri: playUri, headers: { Referer: EMBED_REFERER } }
             : { uri: playUri }
         }
-        style={{ width: '100%', height, backgroundColor: '#000' }}
+        style={{ flex: 1, backgroundColor: '#000' }}
         originWhitelist={['*']}
         allowsInlineMediaPlayback
         allowsPictureInPictureMediaPlayback
@@ -214,112 +230,91 @@ export default function FloatingMediaPlayer({
   });
 
   return (
-    <>
-      <Animated.View
-        style={[
-          styles.floatWrap,
-          {
-            width: floatWidth,
-            bottom: insets.bottom + 96,
-            opacity: enter,
-            transform: [
-              { translateX: pan.x },
-              { translateY: Animated.add(pan.y, enterTranslateY) },
-              { scale: enterScale },
-            ],
-          },
-        ]}
+    <Animated.View
+      style={[
+        styles.floatWrap,
+        fullscreen
+          ? styles.fsWrap
+          : {
+              width: pipWidth,
+              right: SIDE_MARGIN,
+              bottom: insets.bottom + 96,
+              opacity: enter,
+              transform: [
+                { translateX: pan.x },
+                { translateY: Animated.add(pan.y, enterTranslateY) },
+                { scale: enterScale },
+              ],
+            },
+      ]}
+    >
+      {/* Barra superior — arrastre (solo PiP) + título + acciones */}
+      <View
+        style={[styles.bar, fullscreen && { paddingTop: insets.top + 8 }]}
+        {...(fullscreen ? {} : panResponder.panHandlers)}
       >
-        {/* Barra superior — arrastre + título + cerrar */}
-        <View style={styles.bar} {...panResponder.panHandlers}>
-          <Text style={styles.barLabel} numberOfLines={1}>
-            {source.label}
-          </Text>
-          {isVideo && (
-            <TouchableOpacity
-              onPress={() => {
-                h.tap();
-                void openInYouTube(videoId);
-              }}
-              style={styles.barBtn}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityLabel="Abrir en la app de YouTube"
-            >
-              <MaterialIcons name="smart-display" size={13} color={YT_RED} />
-            </TouchableOpacity>
-          )}
-          {isVideo && (
-            <TouchableOpacity
-              onPress={() => {
-                h.tap();
-                setFullscreen(true);
-              }}
-              style={styles.barBtn}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityLabel="Pantalla completa"
-            >
-              <MaterialIcons name="fullscreen" size={15} color="#fff" />
-            </TouchableOpacity>
-          )}
+        <Text style={styles.barLabel} numberOfLines={1}>
+          {source.label}
+        </Text>
+        {isVideo && (
           <TouchableOpacity
-            onPress={handleClose}
+            onPress={() => {
+              h.tap();
+              void openInYouTube(videoId);
+            }}
             style={styles.barBtn}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            accessibilityLabel="Cerrar reproductor"
+            accessibilityLabel="Abrir en la app de YouTube"
           >
-            <MaterialIcons name="close" size={15} color="#fff" />
+            <MaterialIcons name="smart-display" size={13} color={YT_RED} />
           </TouchableOpacity>
-        </View>
-        {/* Pantalla del vídeo / reproductor de audio */}
-        <View style={{ height: screenHeight, backgroundColor: '#000' }}>
-          {!fullscreen && videoSurface(screenHeight)}
-        </View>
-      </Animated.View>
-
-      {/* Pantalla completa (solo vídeo) */}
-      <Modal
-        visible={fullscreen}
-        transparent={false}
-        animationType="fade"
-        onRequestClose={() => setFullscreen(false)}
-        supportedOrientations={[
-          'portrait',
-          'landscape-left',
-          'landscape-right',
-        ]}
+        )}
+        {isVideo && (
+          <TouchableOpacity
+            onPress={toggleFullscreen}
+            style={styles.barBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityLabel={
+              fullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'
+            }
+          >
+            <MaterialIcons
+              name={fullscreen ? 'fullscreen-exit' : 'fullscreen'}
+              size={15}
+              color="#fff"
+            />
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.barBtn}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityLabel="Cerrar reproductor"
+        >
+          <MaterialIcons name="close" size={15} color="#fff" />
+        </TouchableOpacity>
+      </View>
+      {/* Pantalla del vídeo / reproductor de audio. En fullscreen el área
+          crece y el vídeo se centra a 16:9; el WebView interior es siempre
+          la misma instancia. */}
+      <View
+        style={
+          fullscreen
+            ? styles.fsVideoArea
+            : { height: pipHeight, backgroundColor: '#000' }
+        }
       >
-        <View style={styles.fsRoot}>
-          <View style={[styles.fsBar, { paddingTop: insets.top + 6 }]}>
-            <Text style={styles.fsLabel} numberOfLines={1}>
-              {source.label}
-            </Text>
-            <TouchableOpacity
-              onPress={() => {
-                h.tap();
-                setFullscreen(false);
-              }}
-              style={styles.fsClose}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              accessibilityLabel="Salir de pantalla completa"
-            >
-              <MaterialIcons name="close" size={22} color="#fff" />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.fsVideo}>
-            {fullscreen && (
-              <View style={styles.fsVideoInner}>{videoSurface('100%')}</View>
-            )}
-          </View>
+        <View style={fullscreen ? styles.fsVideoInner : styles.videoFill}>
+          {videoSurface}
         </View>
-      </Modal>
-    </>
+      </View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   floatWrap: {
     position: 'absolute',
-    right: SIDE_MARGIN,
     borderRadius: 14,
     overflow: 'hidden',
     backgroundColor: '#111',
@@ -334,6 +329,16 @@ const styles = StyleSheet.create({
         elevation: 12,
       },
     }),
+  },
+  fsWrap: {
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: '100%',
+    borderRadius: 0,
+    backgroundColor: '#000',
+    zIndex: 90,
   },
   bar: {
     flexDirection: 'row',
@@ -358,32 +363,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginLeft: 8,
   },
-  fsRoot: {
+  videoFill: {
     flex: 1,
-    backgroundColor: '#000',
   },
-  fsBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingBottom: 6,
-    backgroundColor: '#000',
-  },
-  fsLabel: {
-    flex: 1,
-    fontSize: 15,
-    fontWeight: '600',
-    color: '#fff',
-  },
-  fsClose: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: 'rgba(255,255,255,0.14)',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  fsVideo: {
+  fsVideoArea: {
     flex: 1,
     justifyContent: 'center',
     backgroundColor: '#000',

--- a/mcm-app/components/song-media/SongMediaSheet.tsx
+++ b/mcm-app/components/song-media/SongMediaSheet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Dimensions,
+  Linking,
   Platform,
   ScrollView,
   StyleSheet,
@@ -15,7 +16,7 @@ import { useToast } from '@/contexts/AppToastContext';
 import { h } from '@/utils/haptics';
 import BottomSheet from '@/components/BottomSheet';
 import brand from '@/constants/colors';
-import { toDrivePreviewUrl } from '@/utils/googleDrive';
+import { extractDriveFileId, toDrivePreviewUrl } from '@/utils/googleDrive';
 import type { MediaLink, SongMedia } from '@/types/songMedia';
 import type { FloatingMediaSource } from '@/components/song-media/FloatingMediaPlayer';
 
@@ -74,6 +75,19 @@ export default function SongMediaSheet({
 
   const openExternal = async (url: string) => {
     h.tap();
+    // Los enlaces de Drive van por Linking (no por el navegador in-app):
+    // así el universal/app link lo captura la app de Google Drive si está
+    // instalada. WebBrowser abriría un Safari/Chrome embebido y se la
+    // saltaría siempre.
+    if (extractDriveFileId(url)) {
+      toast.show({ label: 'Abriendo en Google Drive…' });
+      try {
+        await Linking.openURL(url);
+      } catch {
+        /* sin app ni navegador no hay nada que hacer */
+      }
+      return;
+    }
     toast.show({ label: 'Abriendo en el navegador…' });
     try {
       await WebBrowser.openBrowserAsync(url);


### PR DESCRIPTION
## Summary

Follow-up to #278 (already merged). The previous fix (raw `<iframe>` inside an HTML shell) solved the general case but some specific videos still failed with "vídeo no disponible" — e.g. "Yo celebraré" (Entrada #11) — even though YouTube's own oEmbed endpoint confirms those videos allow embedding anywhere. Root cause: a bare `<iframe src="…/embed/ID">` loaded via `loadHTMLString`/`loadDataWithBaseURL` doesn't send a real `Referer`, and YouTube can reject it inconsistently.

## Key Changes

- **`FloatingMediaPlayer.tsx`**: replaced the raw iframe with the **official YouTube IFrame Player API** (`https://www.youtube.com/iframe_api` + `new YT.Player(...)`), which does the handshake via `postMessage` and is far more reliable inside a WebView with `playerVars.origin` fixed.
- If the video still errors (`onError` from the API — embedding disabled by the owner, regional restriction, etc.), an in-page fallback shows a "Ver en YouTube" button that opens the browser via a `postMessage` bridge (`onMessage` on the WebView).
- Added a persistent small button (red ↗ icon) in the player bar to manually open YouTube at any time, matching the reference UX (doceacordes) shown by the user.
- **Audio (Drive) sizing**: the floating player for audio now uses **almost the full screen width × 64px height** instead of the narrow 208×100 video PiP size — the Drive preview UI looked cramped at the narrow width.
- `CHANGELOG.md`: new entry documenting the v2 fix.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 210/210 passing
- [x] `npm run lint` — clean on changed file
- [ ] Manual verification on device: play "Yo celebraré" (Entrada #11) video and a Drive audio track

https://claude.ai/code/session_01SxdxNK5wM5rBEsV9mmHXos

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxdxNK5wM5rBEsV9mmHXos)_