### PR TITLE
⚡ Bolt: Optimize useWordleLeaderboard hook

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-06-16 - [ListHeaderComponent React Element Memory Leak]
 **Learning:** [Defining a React Element for \`ListHeaderComponent\` directly inside the parent render loop without memoization causes the `FlatList` to unmount and remount the header entirely on every parent re-render (like keystrokes in a search input). This also forces the \`FlatList\` internal layout mechanics to recalculate.]
 **Action:** [Always wrap \`ListHeaderComponent\` elements defined inside functional components with \`useMemo\`, or extract them into separate memoized components outside the main render loop.]
+## 2026-07-03 - [Avoid intermediate arrays in large Firebase loops]
+**Learning:** In client-side loops processing unbounded Firebase collections (like the all-users stats node for Wordle leaderboard), using chained array methods `Object.entries().map()` or `.reduce()` inside iterates over the entire node. It forces the allocation of thousands of intermediate tuple arrays which are immediately discarded, increasing GC pressure and affecting framerate.
+**Action:** Use native `for...in` or `for...of` loops with scalar variables directly over the data objects when calculating derived stats or distributions over unbounded structures, skipping `Object.entries()`.

--- a/mcm-app/hooks/useWordleLeaderboard.ts
+++ b/mcm-app/hooks/useWordleLeaderboard.ts
@@ -57,27 +57,36 @@ export default function useWordleLeaderboard(
 
         if (statsSnap.exists()) {
           const statsData = statsSnap.val() as Record<string, any>;
-          const entries = Object.entries(statsData).map(([uid, data]) => {
-            const totalAttempts = data.distribution
-              ? Object.entries(data.distribution).reduce(
-                  (sum, [k, v]) => sum + Number(k) * Number(v),
-                  0,
-                )
-              : 0;
+
+          // ⚡ Bolt Optimization: Replace O(N) map and reduce allocations with native loops.
+          // Since the stats payload includes all Wordle players, it can be large.
+          // Avoiding Object.entries() skips creating thousands of intermediate tuple arrays.
+          const entries: LeaderboardEntry[] = [];
+          for (const uid in statsData) {
+            const data = statsData[uid];
+            let totalAttempts = 0;
+
+            if (data.distribution) {
+              for (const k in data.distribution) {
+                totalAttempts += Number(k) * Number(data.distribution[k]);
+              }
+            }
+
             const played = data.played || 0;
             const avg = played ? totalAttempts / played : Infinity;
-            return {
+
+            entries.push({
               userId: uid,
               name: data.userName || users[uid]?.name || 'Anónimo',
               place: data.userLocation || users[uid]?.place || '',
               played,
               average: avg,
-            };
-          });
+            });
+          }
 
-          const general = [...entries].sort((a, b) => a.average - b.average);
+          const general = [...entries].sort((a, b) => a.average! - b.average!);
           const participation = [...entries].sort(
-            (a, b) => b.played - a.played,
+            (a, b) => b.played! - a.played!,
           );
 
           setGeneralRanking(general.slice(0, 5));


### PR DESCRIPTION
Replaced Object.entries().map() and reduce() chains with native for...in loops.

What: Refactored the array mapping and reduction in the useWordleLeaderboard hook to use imperative for...in loops directly on the statsData object.
Why: The statsData payload represents the entire Wordle user base, which grows unbounded over time. Calling Object.entries() on this large object followed by a map/reduce chain causes the engine to allocate thousands of intermediate tuple arrays [key, value] that are immediately discarded. This puts unnecessary pressure on the Garbage Collector, causing frame drops during the React render cycle when the stats drawer is opened.
Impact: Reduces memory allocation by O(N) tuple arrays per render of the leaderboard, significantly reducing GC pauses when the user base scales.
Measurement: Compare memory profiling allocations before and after opening the Wordle stats sheet.

---
*PR created automatically by Jules for task [3093961692428363557](https://jules.google.com/task/3093961692428363557) started by @mcmespana*