### PR TITLE
⚡ Bolt: Optimize Wordle leaderboard processing

### DIFF
--- a/mcm-app/hooks/useWordleLeaderboard.ts
+++ b/mcm-app/hooks/useWordleLeaderboard.ts
@@ -57,27 +57,37 @@ export default function useWordleLeaderboard(
 
         if (statsSnap.exists()) {
           const statsData = statsSnap.val() as Record<string, any>;
-          const entries = Object.entries(statsData).map(([uid, data]) => {
-            const totalAttempts = data.distribution
-              ? Object.entries(data.distribution).reduce(
-                  (sum, [k, v]) => sum + Number(k) * Number(v),
-                  0,
-                )
-              : 0;
-            const played = data.played || 0;
-            const avg = played ? totalAttempts / played : Infinity;
-            return {
-              userId: uid,
-              name: data.userName || users[uid]?.name || 'Anónimo',
-              place: data.userLocation || users[uid]?.place || '',
-              played,
-              average: avg,
-            };
-          });
+          const entries: LeaderboardEntry[] = [];
 
-          const general = [...entries].sort((a, b) => a.average - b.average);
-          const participation = [...entries].sort(
-            (a, b) => b.played - a.played,
+          for (const uid in statsData) {
+            if (Object.prototype.hasOwnProperty.call(statsData, uid)) {
+              const data = statsData[uid];
+              let totalAttempts = 0;
+
+              if (data.distribution) {
+                for (const k in data.distribution) {
+                  if (Object.prototype.hasOwnProperty.call(data.distribution, k)) {
+                    totalAttempts += Number(k) * Number(data.distribution[k]);
+                  }
+                }
+              }
+
+              const played = data.played || 0;
+              const avg = played ? totalAttempts / played : Infinity;
+
+              entries.push({
+                userId: uid,
+                name: data.userName || users[uid]?.name || 'Anónimo',
+                place: data.userLocation || users[uid]?.place || '',
+                played,
+                average: avg,
+              });
+            }
+          }
+
+          const general = entries.slice().sort((a, b) => (a.average ?? Infinity) - (b.average ?? Infinity));
+          const participation = entries.slice().sort(
+            (a, b) => (b.played ?? 0) - (a.played ?? 0),
           );
 
           setGeneralRanking(general.slice(0, 5));


### PR DESCRIPTION
💡 **What**: Replaced chained `Object.entries().map()` and `Object.entries().reduce()` array methods with native `for...in` loops in the `useWordleLeaderboard` hook. The array spreading before sorting (`[...entries]`) was also replaced with `.slice()`.

🎯 **Why**: When processing potentially unbounded collections of user stats retrieved from Firebase on the client side, chained array prototype methods implicitly allocate intermediate Arrays for every item transformation, which is quickly discarded causing significant Garbage Collection pressure and dropping frames. The spread operator iteration introduces slight overhead as well compared to a fast `.slice()`

📊 **Impact**: Reduces peak memory usage and garbage collection pauses when computing Wordle leaderboards in `useWordleLeaderboard`.
 
🔬 **Measurement**: Verify by running `npm run test --prefix mcm-app` and ensuring all leaderboard integration and unit tests continue to pass with the new data transformations, which were verified successfully before this PR.

---
*PR created automatically by Jules for task [597698984953610958](https://jules.google.com/task/597698984953610958) started by @mcmespana*