### PR TITLE
docs(integraciones): plan de auditoría app↔panel↔cantoral + contratos al día

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Si cambias uno de estos formatos, actualiza el contrato.
 | --------- | --------- |
 | [MEJORAS.md](planes/MEJORAS.md) | Análisis técnico transversal (rendimiento, arquitectura, seguridad, DX, CI) con plan priorizado |
 | [PLAN_CALIDAD.md](planes/PLAN_CALIDAD.md) | Plan de saneamiento de código por fases (archivos gigantes, contexts, tipos, tests) |
+| [PLAN_INTEGRACIONES.md](planes/PLAN_INTEGRACIONES.md) | Auditoría de integraciones app ↔ panel ↔ cantoral (2026-07): arreglos aplicados y acciones pendientes ejecutables una a una |
 
 Las tareas accionables derivadas de estos planes están en
 [`mcm-app/TODO.md`](../mcm-app/TODO.md).

--- a/docs/SEGURIDAD.md
+++ b/docs/SEGURIDAD.md
@@ -20,9 +20,26 @@ Firestore ni Storage de forma activa. La autenticación es Google/Apple Sign-In
    login (reportes del cantoral, reflexiones, tokens push, evaluaciones, juego,
    playlists/coros compartidos).
 4. **Datos personales** (`/users/$uid`) requieren login y ser el dueño.
-5. El **backend/panel** (mcmpanel) y el **scraper de lecturas** escriben con el
-   **Admin SDK**, que **ignora** estas reglas. Por eso `notifications`,
-   `seccion_oracion`, `profileConfig`, etc. son solo-lectura desde la app.
+5. La **intención** es que el backend/panel (mcmpanel) y el scraper de lecturas
+   escriban con credencial de servidor (Admin SDK / token), que ignora estas
+   reglas. Por eso `notifications`, `seccion_oracion`, `profileConfig`, etc.
+   son solo-lectura desde la app.
+
+> ### ⚠️ NO DESPLIEGUES ESTAS REGLAS TODAVÍA — romperían mcmpanel
+>
+> A fecha 2026-07: **mcmpanel NO usa Admin SDK**. El panel escribe con el SDK
+> cliente de Firebase **sin autenticación**, y sus funciones serverless
+> (`api/_lib/push.ts`) usan la API REST **sin token** (`.json` sin `?auth=`).
+> Solo el uploader del cantoral (`mcmapp-cantoral/scripts/update_firebase.py`)
+> usa token. Con estas reglas desplegadas, el panel perdería: la lectura de la
+> raíz (usa `onValue('/')`), todas las escrituras de secciones
+> (`/albums`, `/calendars`, `/profileConfig`, `/activities`, `/surveys`,
+> `/users/*/isAdmin`…), la lectura de `/pushTokens` para enviar push y la
+> escritura de `/notifications` y `/scheduledNotifications` (este último nodo
+> ni siquiera aparece en las reglas). **Prerequisito para desplegar**: dar al
+> panel auth real (Firebase Auth + allowlist `/admins`) o mover sus escrituras
+> a las funciones de `api/` con credencial de servidor. Ver
+> `docs/planes/PLAN_INTEGRACIONES.md` (Integración D).
 
 El fichero está **dividido por secciones comentadas**. Para **desactivar** una
 sección concreta (por si algo se descontrola), pon su `.read`/`.write` a `false`

--- a/docs/contratos/PANEL_PERFILES.md
+++ b/docs/contratos/PANEL_PERFILES.md
@@ -1,12 +1,12 @@
 # MCM Panel — Gestión del Sistema de Perfiles
 
-> Documento para el agente que va a adaptar **mcmpanel** (Next.js admin) al
-> nuevo sistema de perfiles/delegaciones de la app MCM. Aquí se describe la
-> estructura en Firebase Realtime Database, qué controla cada cosa, y cómo
-> debería ser la UI de administración.
+> Contrato de datos del sistema de perfiles/delegaciones entre **mcmpanel**
+> (React/Vite admin, ya adaptado — sección "Perfiles") y la app MCM. Describe
+> la estructura en Firebase Realtime Database y qué controla cada cosa.
 >
-> **Diseño técnico completo de la app cliente**: `mcm-app/TODO_SISTEMA_PERFILES.md`.
 > **Seed inicial listo para importar**: `mcm-app/firebase-seed/profileConfig.json`.
+> **Implementación del panel**: `mcmpanel/src/components/sections/ProfileConfigSection.tsx`
+> (+ `profile/*`, `lib/profileCatalog.ts`, `lib/profileConfigSeed.ts`).
 
 ---
 
@@ -101,14 +101,18 @@ Cada array es una **lista de IDs** que la app conoce. Si el panel mete un ID
 que la app no conoce, el cliente lo descarta silenciosamente con un warning
 (no rompe la UI). Los IDs válidos son los del catálogo:
 
-| Campo                | IDs aceptados                                                                            | Notas                                               |
-| -------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `tabs`               | `index`, `cancionero`, `contigo`, `calendario`, `fotos`, `comunica`, `mas`               | Pestañas de la barra inferior                        |
-| `homeButtons`        | `comunica`, `cancionero`, `fotos`, `evangelio`, `mas`                                    | Botones del grid de la Home                          |
-| `masItems`           | `comunica`, `comunica-gestion`, `jubileo`                                                | Items del menú "Más"                                 |
-| `albumTags`          | `all`, `general`, `encuentros`, `interno`, `monitores`, `miembros`                       | Tags de visibilidad de fotos. `"all"` = ver todo     |
-| `notificationTopics` | `general`, `eventos`, `familias`, `monitores`, `miembros`                                | Topics base. Las delegaciones añaden los suyos       |
-| `defaultCalendars`   | IDs de `/calendars` (ej. `mcm-europa`)                                                   | **No validados contra catálogo** — ojo con typos    |
+| Campo                | IDs aceptados                                                                             | Notas                                               |
+| -------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `tabs`               | `index`, `cancionero`, `contigo`, `visitapapa`, `calendario`, `fotos`, `comunica`, `mas` | Pestañas de la barra inferior                        |
+| `homeButtons`        | `comunica`, `cancionero`, `fotos`, `evangelio`, `visitapapa`, `mas`                       | Botones del grid de la Home                          |
+| `masItems`           | `comunica`, `comunica-gestion`, `jubileo`, `eventos-pasados`                              | Items del menú "Más"                                 |
+| `albumTags`          | `all`, `general`, `encuentros`, `interno`, `monitores`, `miembros`                        | Tags de visibilidad de fotos. `"all"` = ver todo     |
+| `notificationTopics` | `general`, `eventos`, `familias`, `monitores`, `miembros`                                 | Topics base. Las delegaciones añaden los suyos       |
+| `defaultCalendars`   | IDs de `/calendars` (ej. `mcm-europa`)                                                    | **No validados contra catálogo** — ojo con typos    |
+
+> La lista viva está en `mcm-app/constants/profileCatalog.ts` (app) y su espejo
+> `mcmpanel/src/lib/profileCatalog.ts` (panel). Si añades un ID nuevo, actualiza
+> **ambos** ficheros; esta tabla es orientativa.
 
 **UX recomendada del panel para editar un perfil**:
 
@@ -163,23 +167,26 @@ también, aunque solo tengan `label` (heredan resto de `_default`).
 > nuevas sin tocar código de la app. Convención: usar slug en kebab-case
 > (`castellon`, `mcm-madrid`).
 
-### 1.4. `data.delegationList` — lista para el selector
+### 1.4. `data.delegationList` — ⚠️ DERIVADA, la app la ignora
 
-Array ordenado de las delegaciones que aparecen en el onboarding y en
-Ajustes. Es independiente de `data.delegations` para permitir reordenar /
-ocultar sin perder la config:
+**La app ya NO lee `delegationList` de Firebase.** El cliente la deriva
+siempre de `data.delegations` (todas las claves menos `_default`, en el orden
+en que Firebase devuelve el objeto) — ver
+`mcm-app/contexts/ProfileConfigContext.tsx → deriveDelegationList()`. Esto
+elimina el riesgo de que ambas fuentes se desincronicen.
 
-```json
-[
-  { "id": "mcm-espana", "label": "MCM España" },
-  { "id": "mcm-castellon", "label": "MCM Castellón" },
-  { "id": "mcm-madrid", "label": "MCM Madrid" }
-]
-```
+Implicaciones para el panel:
 
-> **Importante**: si una delegación está en `data.delegations` pero NO en
-> `data.delegationList`, el usuario no podrá seleccionarla en el onboarding.
-> El panel debería avisar al admin si detecta esa inconsistencia.
+- **Toda delegación en `data.delegations` es seleccionable** en el onboarding
+  y en Ajustes. No se puede "ocultar" una delegación quitándola de la lista;
+  para ocultarla hay que borrarla de `delegations`.
+- **El orden del selector no se controla desde `delegationList`** (RTDB
+  devuelve las claves de objeto en orden lexicográfico). Si algún día hace
+  falta orden manual, habría que reintroducir el soporte en la app.
+- El nodo `delegationList` puede seguir existiendo en Firebase (el panel aún
+  lo escribe y lo usa para poblar sus propios selectores, p. ej. el de
+  delegaciones del composer de notificaciones), pero es **redundante** de cara
+  a la app.
 
 ### 1.5. `data.overrides` — combinaciones específicas perfil:delegación
 
@@ -420,8 +427,6 @@ sin querer.
 | `tabs` no contiene `index`                                                                                       | warning   | Aviso: "El usuario no podrá volver a Inicio". Permitir guardar.                                   |
 | `tabs` está vacío                                                                                                | error     | Bloquear. La app caería al fallback.                                                              |
 | `defaultCalendars` referencia un ID que ya no está en `/calendars`                                                | warning   | Avisar y ofrecer limpiar.                                                                         |
-| `delegationList` tiene un id que no existe en `delegations`                                                       | warning   | Crear automáticamente la entrada con solo `label`.                                                |
-| `delegations.{id}` existe pero no está en `delegationList`                                                        | warning   | Avisar: "El usuario no podrá seleccionar esta delegación".                                        |
 | `notificationTopic` con caracteres raros (espacios, mayúsculas)                                                   | warning   | Auto-slugify (`"MCM Castellón"` → `"mcm-castellon"`).                                             |
 | `overrides[k]` con clave malformada (no `perfil:delegacion`)                                                      | error     | Bloquear.                                                                                         |
 | `minAppVersion` no es semver válido                                                                                | error     | Bloquear. La app interpretaría `0.0.0` y no bloquearía nada.                                      |
@@ -533,25 +538,18 @@ Si el agente del panel quiere ver cómo lo consume la app cliente:
 | Pantalla de onboarding | `mcm-app/app/onboarding.tsx`                       |
 | Pantalla de bloqueo    | `mcm-app/components/MaintenanceScreen.tsx`         |
 | Token + topics         | `mcm-app/services/pushNotificationService.ts`      |
-| Diseño técnico         | `mcm-app/TODO_SISTEMA_PERFILES.md`                 |
 
 ---
 
-## 10. Checklist para el agente que adapte mcmpanel
+## 10. Estado de la adaptación de mcmpanel
 
-- [ ] Pantalla de edición de los 3 perfiles con multiselects contra catálogo.
-- [ ] Pantalla de edición de delegaciones (CRUD + extras + override).
-- [ ] Sincronización automática `delegations` ↔ `delegationList`.
-- [ ] Pantalla de overrides perfil:delegación.
-- [ ] Pantalla de flags globales (mantenimiento, minAppVersion, ...).
-- [ ] Selector de calendarios en `defaultCalendars` poblado desde `/calendars`.
-- [ ] Selector de tags en álbumes poblado con catálogo.
-- [ ] Composer de notificaciones con filtro por perfil + delegación, con
-      preview de recuento.
-- [ ] Forzar `updatedAt` en cada escritura de `/profileConfig`.
-- [ ] Validaciones del §5 antes de guardar.
-- [ ] Botón "Inicializar profileConfig desde seed" si el nodo está vacío.
-- [ ] Reglas de seguridad RTDB actualizadas.
+La adaptación descrita en este documento **ya está hecha** (sección "Perfiles"
+del panel: editores de perfiles, delegaciones, overrides y sistema; composer de
+notificaciones con audiencia por perfil/delegación/evento y preview de
+recuento; `updatedAt` forzado en cada guardado; botón de inicializar desde
+seed). Pendiente conocido: reglas de seguridad RTDB (ver `docs/SEGURIDAD.md`
+— el panel aún escribe sin autenticación, no desplegar las reglas hasta
+resolverlo).
 
 ---
 
@@ -616,15 +614,16 @@ export interface ProfileConfigDocument {
   data: ProfileConfigData;
 }
 
-// Catálogos de IDs aceptados (deben coincidir con el cliente)
+// Catálogos de IDs aceptados (deben coincidir con el cliente —
+// fuente viva: mcm-app/constants/profileCatalog.ts)
 export const KNOWN_TABS = [
-  'index', 'cancionero', 'contigo', 'calendario', 'fotos', 'comunica', 'mas',
+  'index', 'cancionero', 'contigo', 'visitapapa', 'calendario', 'fotos', 'comunica', 'mas',
 ] as const;
 export const KNOWN_HOME_BUTTONS = [
-  'comunica', 'cancionero', 'fotos', 'evangelio', 'mas',
+  'comunica', 'cancionero', 'fotos', 'evangelio', 'visitapapa', 'mas',
 ] as const;
 export const KNOWN_MAS_ITEMS = [
-  'comunica', 'comunica-gestion', 'jubileo',
+  'comunica', 'comunica-gestion', 'jubileo', 'eventos-pasados',
 ] as const;
 export const KNOWN_ALBUM_TAGS = [
   'all', 'general', 'encuentros', 'interno', 'monitores', 'miembros',
@@ -717,11 +716,9 @@ await update(ref(db), {
    altere el timestamp. Solución: forzar el update siempre, idealmente desde
    un wrapper `saveProfileConfig()` único.
 
-2. **Editar `delegations` sin tocar `delegationList`**: la delegación
-   existirá técnicamente pero el usuario no podrá seleccionarla en el
-   onboarding. Solución: cuando el admin crea una delegación nueva, añadirla
-   automáticamente a `delegationList` (con un toggle "ocultar del selector"
-   para casos especiales).
+2. **Creer que `delegationList` controla el selector**: la app la deriva de
+   `delegations` (ver §1.4). Añadir/quitar una delegación del selector =
+   añadirla/quitarla de `data.delegations`. No hay "ocultar del selector".
 
 3. **IDs con typos en arrays del perfil**: la app descarta IDs desconocidos
    en silencio (warning solo en dev). El admin pensará que "no funciona" sin

--- a/docs/funcionalidades/EVENTOS.md
+++ b/docs/funcionalidades/EVENTOS.md
@@ -36,6 +36,29 @@ activities/
     └── …
 ```
 
+### 3. Evento activo global — `activities/_meta`
+
+La app decide qué evento está "destacado" (tab propia + botón Home + banner)
+leyendo este nodo (`contexts/ActiveEventContext.tsx`), con fallback al
+`ACTIVE_EVENT_ID` hardcodeado en `constants/events.ts`:
+
+```
+activities/_meta
+├── updatedAt: "2026-07-06T..."          (ISO — invalida la caché)
+└── data
+    └── activeEventId: "visitapapa26"    (id del registry de events.ts)
+```
+
+> ⚠️ La forma es `{ updatedAt, data: {...} }` (patrón `useFirebaseData`), NO
+> campos en plano. El panel MCM escribe este nodo desde Actividades → "Modo
+> evento global".
+
+**Metadatos por evento** (`activities/<evento>/_meta` con `status`, `title`,
+`tintColor`, `bannerText`): el panel permite editarlos, pero **la app hoy NO
+los lee** — título, color, banner y estado activo/archivado salen del registry
+hardcodeado (`constants/events.ts`). Consumirlos desde Firebase es una mejora
+pendiente (ver `docs/planes/PLAN_INTEGRACIONES.md`, Integración B).
+
 ### Forma de cada sección
 
 Cada sección (nodo hijo del evento) tiene siempre:

--- a/docs/funcionalidades/NOTIFICACIONES.md
+++ b/docs/funcionalidades/NOTIFICACIONES.md
@@ -325,7 +325,7 @@ El backend debe:
 
 #### UI del panel
 - Dashboard con estadísticas
-- Formulario: título (80 chars max), body (200 chars), **descripción detallada opcional `bodyLong` (~2000 chars, scrollable en la app)**, categoría, prioridad, icono URL, imagen URL, ruta interna, **hasta 3 botones de acción** (texto + URL/ruta + interno/externo cada uno)
+- Formulario: título (50 chars max), body (200 chars), **descripción detallada opcional `bodyLong` (~2000 chars, scrollable en la app)**, categoría, prioridad, icono URL, imagen URL, ruta interna, **hasta 3 botones de acción** (texto + URL/ruta + interno/externo cada uno)
 - Autenticación simple (usuario/contraseña via env vars)
 - Historial de notificaciones enviadas
 

--- a/docs/planes/PLAN_INTEGRACIONES.md
+++ b/docs/planes/PLAN_INTEGRACIONES.md
@@ -1,0 +1,261 @@
+# PLAN_INTEGRACIONES — Coherencia mcmapp ↔ mcmpanel ↔ mcmapp-cantoral
+
+> Resultado de la auditoría de integraciones (2026-07-06). Cada acción es
+> **autocontenida y ejecutable por separado**: pide "ejecuta la acción B1" (o
+> "las acciones A1 y A2") y con el contexto de este documento basta.
+>
+> Convención: **[app]** = repo `mcmapp` (código en `mcm-app/`),
+> **[panel]** = repo `mcmpanel`, **[cantoral]** = repo `mcmapp-cantoral`.
+
+---
+
+## ✅ Arreglos ya aplicados en la auditoría (2026-07-06)
+
+No requieren acción, se listan para contexto:
+
+1. **[panel]** El selector de evento del composer de notificaciones usaba el id
+   `visitapapa` — el id real del registry de la app es `visitapapa26` (topic
+   `event-visitapapa26`). Corregido en `NotificationsSection.tsx`.
+2. **[panel]** "Marcar como evento activo global" escribía `activities/_meta`
+   en plano (`{activeEventId, updatedAt}`); la app espera
+   `{updatedAt, data: {activeEventId}}`. Corregido en `ActivitiesSection.tsx`
+   (lee ambas formas, escribe la canónica).
+3. **[panel]** Reordenar canciones en el Cantoral guardaba `/songs` solo con
+   `{data, updatedAt}`, borrando las colas `ediciones`/`solicitudes`/`fallitos`
+   que escribe la app. Corregido en `SongsSection.tsx`.
+4. **[panel]** El listener en tiempo real de la raíz (`JSONManager`) pisaba las
+   ediciones locales sin guardar cada vez que la app escribía cualquier cosa
+   (heartbeats de `/pushTokens` cada pocos minutos por dispositivo), y el
+   guardado escribía el estado ya pisado → pérdida silenciosa de cambios.
+   Corregido: el refresco remoto respeta las secciones con cambios pendientes
+   y el guardado escribe siempre el valor pendiente.
+5. **Docs**: reescritos `mcmpanel/CLAUDE.md` y `mcmpanel/AGENTS.md` (estaban
+   desfasados: Lovable, secciones inexistentes); simplificado
+   `mcmpanel/docs/notificaciones-contrato-mcm-app.md`; actualizado
+   `PANEL_PERFILES.md` (delegationList derivada, catálogos con `visitapapa` y
+   `eventos-pasados`, checklist cerrado); `EVENTOS.md` documenta
+   `activities/_meta`; `SEGURIDAD.md` avisa de que las reglas NO se pueden
+   desplegar aún; `NOTIFICACIONES.md` corrige el límite del título (50).
+
+---
+
+## Integración A — Notificaciones
+
+### A1. Filtrar el historial in-app por audiencia · [app] · prioridad ALTA
+
+**Problema**: el panel segmenta el envío push (`audience` de 4 ejes), pero la
+app pinta TODO el nodo `/notifications` en el centro de notificaciones. Una
+notificación "solo monitores de Madrid" la ve cualquiera que abra la campana.
+
+**Acción**: en la app, al listar el historial de Firebase
+(`services/pushNotificationService.ts → getNotificationsHistory/subscribeToNotifications`
+y su consumo en `app/notifications.tsx`), filtrar cada registro contra el
+usuario actual usando `notification.audience` (misma semántica que
+`mcmpanel/src/lib/audience.ts → tokenMatchesAudience`):
+
+- Usuario = `profileType` + `delegationId` (de `UserProfileContext`) + topics
+  resueltos (`useResolvedProfileConfig().notificationTopics` + suscripciones
+  `event-<id>` de `EventSubscriptionsContext`).
+- Registro sin `audience` (o sin ejes activos) → visible para todos
+  (retrocompatible con el histórico).
+- Añadir tests en `__tests__` (la lógica de match puede vivir en
+  `utils/notificationAudience.ts` puro).
+
+### A2. Proteger los endpoints de envío · [panel] · prioridad ALTA
+
+**Problema**: `POST /api/notifications/send` y `/api/notifications/schedule`
+no exigen ninguna credencial: cualquiera que descubra la URL del panel puede
+mandar push a todos los usuarios. Solo el cron (`process-scheduled`) valida
+`CRON_SECRET`.
+
+**Acción mínima** (consciente de sus límites): exigir un secreto compartido
+(`x-panel-key` header) validado en `send.ts` y `schedule.ts` contra una env de
+Vercel (`PANEL_API_KEY`), y que el frontend lo envíe tras el login. Como el
+login del panel es client-side, el secreto acaba en el bundle: esto solo sube
+el listón. La solución real es la Integración D (auth de verdad).
+
+### A3. Poblar el selector de eventos desde `/activities` · [panel] · prioridad BAJA
+
+**Problema**: el desplegable "evento" del composer se autodescubre de los
+topics `event-*` presentes en `/pushTokens` + una lista hardcodeada
+(`EVENT_LABELS`). Un evento nuevo sin suscriptores y no listado no aparece.
+
+**Acción**: unir también los ids de los nodos de `/activities` (excluyendo
+`_meta`) y `jubileo` al construir `eventOptions` en `NotificationsSection.tsx`,
+con su `_meta.title` como etiqueta si existe.
+
+### A4. Mejoras ya identificadas en el contrato · [app] · prioridad BAJA
+
+Referencia: `docs/contratos/NOTIFICACIONES_CONTRATO.md § Mejoras futuras` —
+NSE de iOS para imagen en la notificación del sistema, deep link a un evento
+concreto, channels Android por tipo, uso visual de `data.category`.
+
+---
+
+## Integración B — Eventos y sus secciones
+
+### B1. Consumir `activities/<id>/_meta` en la app · [app] · prioridad MEDIA
+
+**Problema**: el panel edita `title`, `tintColor`, `bannerText` y `status`
+(activo/archivado) por evento, pero la app lo ignora todo: el registry
+(`constants/events.ts`) está hardcodeado. Hoy solo funciona
+`activities/_meta.data.activeEventId` (evento activo global).
+
+**Acción**: en la app, mergear `activities/<id>/_meta` (con caché
+`useFirebaseData`-style y fallback al registry) sobre la `EventConfig` local:
+`title`, `tintColor`, `bannerText`, `status`. Con esto el panel podría archivar
+un evento o cambiar el banner sin release. Nota: crear un evento 100% nuevo
+seguirá requiriendo registrarlo en `events.ts` (las `sections` y pantallas son
+código).
+
+### B2. Sincerar la UI de metadatos del panel · [panel] · prioridad MEDIA
+
+Mientras B1 no esté hecho, el card "Metadatos del evento" de
+`ActivitiesSection.tsx` es engañoso (el admin cambia "Estado en la app" y no
+pasa nada). **Acción**: añadir un aviso visible en ese card ("la app aún no
+lee estos campos, solo el evento activo global") o deshabilitar los campos no
+consumidos. Retirar el aviso al completar B1.
+
+### B3. Avisar al crear una actividad nueva · [panel] · prioridad BAJA
+
+**Acción**: en el diálogo "Crear Nueva Actividad", añadir nota: "El evento no
+aparecerá en la app hasta que se registre en `mcm-app/constants/events.ts`
+(ver EVENTOS.md del repo mcmapp)".
+
+### B4. No pisar datos que escribe la app al guardar `/activities` · [panel] · prioridad MEDIA
+
+**Problema**: el guardado del panel hace `set()` del nodo `/activities`
+completo con su copia en memoria. La app escribe dentro de ese árbol
+(`<evento>/evaluacion/respuestas/<deviceId>` y `<evento>/compartiendo`): una
+respuesta que llegue entre el snapshot y el `set()` se pierde.
+
+**Acción**: guardar Actividades con escrituras granulares (`update()` multi-path
+por subsección editada: `activities/<evento>/<subseccion>` y
+`activities/_meta`) en vez de `set('/activities')`. Aplicar el mismo criterio
+a `/jubileo` (subnodo `compartiendo`) y revisar `/app` (subnodo `feedback`,
+`evaluations`).
+
+---
+
+## Integración C — Perfiles, visibilidad y onboarding
+
+### C1. Retirar la gestión manual de `delegationList` · [panel] · prioridad MEDIA
+
+**Contexto**: la app deriva la lista de delegaciones de `data.delegations` e
+ignora `delegationList` (ver PANEL_PERFILES.md §1.4 actualizado). El panel
+sigue manteniendo la lista a mano (`DelegationsEditor.tsx`, flag "hidden") y
+sugiere un control (orden/ocultar) que no existe.
+
+**Acción**: en `DelegationsEditor.tsx` eliminar la edición de
+`delegationList`/"hidden" y derivarla al guardar (igual que la app:
+`Object.keys(delegations)` sin `_default`) para mantener el nodo coherente
+para consumidores internos del panel (composer de notificaciones). Quitar las
+validaciones de desincronización en `ProfileConfigSection.tsx`, ya sin sentido.
+
+### C2. Unificar los seeds de profileConfig · [panel] · prioridad BAJA
+
+`mcmpanel/src/lib/profileConfigSeed.ts` y
+`mcm-app/firebase-seed/profileConfig.json` han divergido (tabs/homeButtons
+distintos, panel sin las 16 delegaciones). **Acción**: hacer del JSON de la app
+la única fuente (copiar su contenido al seed del panel y anotar en ambos
+ficheros que se sincronizan a mano, o importarlo en build si se prefiere).
+
+### C3. Documentar `appReviewMode` en el contrato · [app] · prioridad BAJA
+
+El panel escribe `global.appReviewMode` + `data.appReviewBackup` (modo revisión
+de stores que oculta Cantoral/Comunica reescribiendo perfiles). La app no
+conoce esos campos (los ignora — el efecto llega vía tabs reescritas).
+**Acción**: añadir una sección breve a `PANEL_PERFILES.md` explicando el
+mecanismo y, opcionalmente, tipar ambos campos como opcionales en
+`mcm-app/types/profileConfig.ts` para que el contrato de tipos sea completo.
+
+### C4. Completar validaciones del §5 del contrato · [panel] · prioridad BAJA
+
+Revisar que el guardado de Perfiles valide: clave de override malformada
+(bloquear), `minAppVersion` semver (bloquear), slugify de `notificationTopic`,
+y aviso si `tabs` no contiene `index`. Hoy `ProfileConfigSection.tsx` solo
+avisa de tabs vacías, calendarios inexistentes y (ya sin sentido, ver C1)
+desincronización de delegationList.
+
+---
+
+## Integración D — Seguridad Firebase (transversal) · prioridad MÁXIMA
+
+**Contexto** (ver aviso en `docs/SEGURIDAD.md`): `mcm-app/database.rules.json`
+asume que el panel escribe con Admin SDK, pero el panel usa el SDK cliente sin
+auth y sus funciones `api/` usan REST sin token. Hoy las reglas reales de
+producción están abiertas; desplegar las del repo rompería el panel entero.
+Hay un workflow (`deploy-firebase-rules.yml`) listo para desplegarlas en
+cuanto alguien configure el secret — **riesgo de rotura accidental**.
+
+Secuencia (no desplegar reglas hasta completar D1–D3):
+
+### D1. Dar credencial de servidor a las funciones del panel · [panel]
+
+`api/_lib/push.ts`: añadir `?auth=<FIREBASE_DB_SECRET>` (o token de service
+account) a todas las llamadas REST, con la env en Vercel. Es lo que ya hace el
+uploader del cantoral.
+
+### D2. Auth real para las escrituras del panel · [panel]
+
+Opción recomendada: Firebase Auth (Google) en el panel + nodo `/admins/<uid>`
+y reglas `".write": "auth != null && root.child('admins').child(auth.uid).val() === true"`
+para los nodos de contenido. Alternativa más rápida: mover TODAS las
+escrituras del panel a funciones `api/` (protegidas con D1 + sesión), dejando
+el frontend solo-lectura. Decidir y ejecutar.
+
+### D3. Completar las reglas · [app]
+
+Añadir a `database.rules.json`: nodo `/scheduledNotifications` (hoy ausente =
+denegado), lecturas que el panel necesita según lo decidido en D2 (p. ej.
+`/pushTokens` solo desde servidor), y revisar `/users` (el panel lista todos
+los usuarios y escribe `isAdmin`; con D2 pasaría a reglas de admin).
+
+### D4. Desplegar y smoke test
+
+Desplegar reglas (`firebase deploy --only database`), probar: app (cantoral,
+eventos, notificaciones, reflexiones, evaluaciones, login/Contigo, tokens) y
+panel (cada sección + envío push + programadas).
+
+### D5. `CRON_SECRET` en Vercel
+
+Verificar que `CRON_SECRET` está configurado en producción para
+`process-scheduled` (si no, cualquiera puede forzar el procesado; el daño es
+limitado pero gratis de cerrar).
+
+---
+
+## Integración E — Cantoral (mcmapp-cantoral → /songs)
+
+### E1. Proteger las ediciones del panel frente al uploader · [panel]/[cantoral] · prioridad MEDIA
+
+**Problema**: la fuente de verdad de `/songs/data` es el repo cantoral: cada
+push a `main` regenera `songs-vX.json` y hace **PUT completo** de
+`songs/data`. Cualquier edición hecha en la sección Cantoral del panel
+(reordenar, editar canción) que no haya pasado por el repo se pierde en el
+siguiente push. El flujo de vuelta existente es la cola `songs/ediciones`
+(app → `sincronizaCambiosDeFirebase.py` → ficheros `.cho`), no el panel.
+
+**Acción** (elegir una):
+- (a) Hacer la edición de canciones del panel **solo lectura** (mantener
+  gestión de `fallitos`/`solicitudes`, que sí es su función real), con nota
+  "el cantoral se edita en el repo mcmapp-cantoral"; o
+- (b) que las ediciones del panel escriban también en `songs/ediciones` para
+  que el script las sincronice al repo.
+  Recomendación: (a), es lo simple y honesto con el flujo real.
+
+### E2. Nota de coherencia `updatedAt` · sin acción
+
+El uploader escribe `songs/updatedAt` como epoch (string numérica) y el panel
+como ISO. La app solo compara strings por desigualdad, así que funciona. Si
+algún día se ordena por fecha, unificar a ISO.
+
+---
+
+## Orden sugerido si se ejecuta todo
+
+1. **D** completa (seguridad) — es lo único con riesgo real de incidente.
+2. **A1 + A2** (notificaciones: privacidad del historial + endpoints).
+3. **B2 + B4** (panel honesto y sin pisar datos), luego **B1** cuando haya
+   hueco de app release/OTA.
+4. **C1 + C2** (perfiles), **E1** (cantoral), y el resto de prioridad baja.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,20 @@
 
 ---
 
+## 2026-07-06 17:00 — Auditoría de integraciones app ↔ panel ↔ cantoral (solo docs en este repo)
+
+- Nuevo `docs/planes/PLAN_INTEGRACIONES.md`: hallazgos de la auditoría, arreglos
+  ya aplicados en mcmpanel (id de evento `visitapapa26` en el composer, forma
+  canónica de `activities/_meta`, preservación de colas de `/songs`, guardado
+  del JSONManager sin pisar ediciones) y acciones pendientes ejecutables una a
+  una (A1…E2).
+- Docs corregidos: `PANEL_PERFILES.md` (la app deriva `delegationList` de
+  `delegations`; catálogos con `visitapapa`/`eventos-pasados`; checklist
+  cerrado), `EVENTOS.md` (documenta `activities/_meta` y que la app no lee los
+  `_meta` por evento), `SEGURIDAD.md` (⚠️ el panel NO usa Admin SDK: no
+  desplegar las reglas hasta darle auth), `NOTIFICACIONES.md` (título máx. 50).
+- Sin cambios de código en la app.
+
 ## 2026-07-02 12:30 — Fix reproductor flotante de YouTube + audios de Drive en la app
 
 **Vídeos (fix):** el player flotante cargaba `youtube.com/embed/<id>` como


### PR DESCRIPTION
Parte documental de la auditoría de integraciones (2026-07-06). **Sin cambios de código en la app** — los arreglos de código van en mcmespana/mcmpanel#32.

## Qué incluye

- **Nuevo `docs/planes/PLAN_INTEGRACIONES.md`**: hallazgos de la auditoría, arreglos ya aplicados en el panel y acciones pendientes (A1…E2) autocontenidas para ejecutarlas una a una. Indexado en `docs/README.md`.
- **`docs/SEGURIDAD.md`** ⚠️ aviso crítico: mcmpanel **no** usa Admin SDK (escribe con SDK cliente sin auth, y sus funciones `api/` usan REST sin token). Desplegar las reglas actuales de `database.rules.json` rompería el panel entero; prerequisitos en el plan (Integración D).
- **`docs/contratos/PANEL_PERFILES.md`**: la app deriva `delegationList` de `delegations` (la lista manual ya no controla el selector); catálogos actualizados con `visitapapa` y `eventos-pasados`; checklist de adaptación cerrado; referencias muertas eliminadas (`TODO_SISTEMA_PERFILES.md`).
- **`docs/funcionalidades/EVENTOS.md`**: documenta `activities/_meta` (evento activo global, forma `{updatedAt, data}`) y aclara que los `_meta` por evento aún no los lee la app.
- **`docs/funcionalidades/NOTIFICACIONES.md`**: límite real del título (50 chars, no 80).
- Entrada en `mcm-app/CHANGELOG.md`.

Al ser solo documentación, no requiere OTA ni build de tienda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFwPCUwrQWpDTwLN2RghcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFwPCUwrQWpDTwLN2RghcK)_