### PR TITLE
[production] Contigo: subrayado de lecturas, bookmarks duraderos y tamaño de letra propio

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,38 @@
 
 ---
 
+## 2026-07-15 18:30 — Contigo: subrayado de lecturas, bookmarks duraderos y tamaño de letra propio
+
+- **Bookmarks duraderos en Firebase.** El Job del scraper borra
+  `seccion_oracion/lecturas/{fecha}` pasados 30 días, así que un evangelio
+  guardado perdía su texto al reinstalar o cambiar de dispositivo. Ahora el
+  bookmark guarda el **texto completo** también en el subárbol del propio
+  usuario (`users/{uid}/contigo/bookmarks/{date}`): crecimiento acotado
+  (solo lo que cada usuario guarda) y se conserva para siempre sin hinchar el
+  nodo común. Al abrir la sección se **hidrata** lo local desde RTDB, de modo
+  que los guardados sobreviven a reinstalaciones y al borrado a 30 días.
+- **Subrayado de lecturas (evangelio y salmo).** Nuevo modo «subrayar»: un toque
+  marca la frase; la selección nativa (copiar, buscar, herramientas de escritura
+  de iOS) sigue disponible con pulsación larga. Subrayar **auto-guarda** el día
+  como bookmark y almacena las frases subrayadas (visibles en «Guardados»).
+- **Tamaño de letra propio de Contigo + modo oscuro.** El botón de ajustes de la
+  lectura abre un bottom sheet dedicado (`ReaderSettingsSheet`) con vista previa
+  en vivo, tamaño de letra y tema. El tamaño es **independiente del global**,
+  pero si no se ha configurado uno propio, **hereda** del general (transición
+  suave). Mecanismo reutilizable (`useSectionFontScale`) para futuras secciones
+  de lectura (p.ej. materiales de eventos). Las lecturas secundarias suben de 16
+  a 17 pt para acercarse al evangelio.
+- **Datos:** nuevo campo con texto completo y `highlights` en
+  `users/{uid}/contigo/bookmarks/{date}`. Sin cambios en las reglas RTDB (el
+  nodo ya era privado del dueño).
+- Archivos: `hooks/useSectionFontScale.ts`, `hooks/useReaderBookmarks.ts`,
+  `utils/contigoBookmarks.ts`, `utils/readingSegments.ts`,
+  `components/contigo/HighlightableText.tsx`,
+  `components/contigo/ReaderSettingsSheet.tsx`,
+  `components/contigo/ReadingCard.tsx`, `contexts/AppSettingsContext.tsx`,
+  `utils/authHelpers.ts`, `app/(tabs)/contigo/evangelio.tsx`,
+  `app/(tabs)/contigo/bookmarks.tsx`.
+
 ## 2026-07-07 19:20 — B4 (panel): escrituras granulares de Actividades
 
 - Cambio en el repo **mcmpanel** (aquí solo se documenta, es contrato de datos).

--- a/mcm-app/__tests__/contigoBookmarks.test.ts
+++ b/mcm-app/__tests__/contigoBookmarks.test.ts
@@ -1,0 +1,93 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  BOOKMARKS_KEY,
+  countHighlights,
+  hasHighlights,
+  loadLocalBookmarks,
+  upsertLocalBookmark,
+  removeLocalBookmark,
+  mergeRemoteBookmarks,
+  type StoredBookmark,
+} from '@/utils/contigoBookmarks';
+
+const mk = (
+  date: string,
+  bookmarkedAt: number,
+  extra: Partial<StoredBookmark> = {},
+): StoredBookmark => ({
+  date,
+  bookmarkedAt,
+  readings: null,
+  ...extra,
+});
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('countHighlights / hasHighlights', () => {
+  it('cuenta las frases subrayadas de todas las fuentes', () => {
+    const b = mk('2026-01-01', 1, {
+      highlights: { evangelio: ['a', 'b'], salmo: ['c'] },
+    });
+    expect(countHighlights(b)).toBe(3);
+    expect(hasHighlights(b)).toBe(true);
+  });
+
+  it('devuelve 0 / false sin subrayados', () => {
+    expect(countHighlights(mk('2026-01-01', 1))).toBe(0);
+    expect(hasHighlights(mk('2026-01-01', 1))).toBe(false);
+    expect(hasHighlights(null)).toBe(false);
+  });
+});
+
+describe('almacenamiento local', () => {
+  it('migra el formato antiguo (array de strings) descartándolo', async () => {
+    await AsyncStorage.setItem(
+      BOOKMARKS_KEY,
+      JSON.stringify(['2026-01-01', '2026-01-02']),
+    );
+    expect(await loadLocalBookmarks()).toEqual([]);
+  });
+
+  it('upsert reemplaza por fecha y ordena por bookmarkedAt desc', async () => {
+    await upsertLocalBookmark(mk('2026-01-01', 100));
+    await upsertLocalBookmark(mk('2026-01-02', 200));
+    const next = await upsertLocalBookmark(mk('2026-01-01', 300));
+    expect(next.map((b) => b.date)).toEqual(['2026-01-01', '2026-01-02']);
+    expect(next).toHaveLength(2);
+  });
+
+  it('remove elimina por fecha', async () => {
+    await upsertLocalBookmark(mk('2026-01-01', 100));
+    await upsertLocalBookmark(mk('2026-01-02', 200));
+    const next = await removeLocalBookmark('2026-01-01');
+    expect(next.map((b) => b.date)).toEqual(['2026-01-02']);
+  });
+});
+
+describe('mergeRemoteBookmarks', () => {
+  it('el remoto más reciente aporta el texto y sobrevive al borrado', async () => {
+    await upsertLocalBookmark(mk('2026-01-01', 100)); // local sin texto
+    const remote = [
+      mk('2026-01-01', 200, {
+        readings: { evangelio: { texto: 'T', cita: 'Jn 1', comentario: '', comentarista: '', url: '' } },
+      }),
+      mk('2026-02-02', 50),
+    ];
+    const merged = await mergeRemoteBookmarks(remote);
+    const jan = merged.find((b) => b.date === '2026-01-01');
+    expect(jan?.readings?.evangelio?.texto).toBe('T');
+    expect(merged.map((b) => b.date)).toContain('2026-02-02');
+  });
+
+  it('conserva las readings locales si el remoto no las trae', async () => {
+    await upsertLocalBookmark(
+      mk('2026-01-01', 100, {
+        readings: { evangelio: { texto: 'local', cita: '', comentario: '', comentarista: '', url: '' } },
+      }),
+    );
+    const merged = await mergeRemoteBookmarks([mk('2026-01-01', 300)]);
+    expect(merged[0].readings?.evangelio?.texto).toBe('local');
+  });
+});

--- a/mcm-app/__tests__/readingSegments.test.ts
+++ b/mcm-app/__tests__/readingSegments.test.ts
@@ -1,0 +1,53 @@
+import {
+  segmentReading,
+  tokenizeReading,
+  normalizeSegment,
+} from '@/utils/readingSegments';
+
+describe('segmentReading', () => {
+  it('divide un texto en frases', () => {
+    const segs = segmentReading(
+      'Yo soy la luz del mundo. El que me sigue no caminará en tinieblas.',
+    );
+    expect(segs).toEqual([
+      'Yo soy la luz del mundo.',
+      'El que me sigue no caminará en tinieblas.',
+    ]);
+  });
+
+  it('respeta los saltos de línea como límites de frase', () => {
+    const segs = segmentReading('Primera línea.\nSegunda línea sin punto');
+    expect(segs).toEqual(['Primera línea.', 'Segunda línea sin punto']);
+  });
+
+  it('mantiene los signos de exclamación/interrogación pegados', () => {
+    const segs = segmentReading('¿Quién eres tú? ¡Soy yo!');
+    expect(segs).toEqual(['¿Quién eres tú?', '¡Soy yo!']);
+  });
+
+  it('devuelve vacío para texto vacío', () => {
+    expect(segmentReading('')).toEqual([]);
+    expect(segmentReading('   \n  ')).toEqual([]);
+  });
+});
+
+describe('tokenizeReading', () => {
+  it('marca breakAfter en la última frase de cada línea salvo la última', () => {
+    const tokens = tokenizeReading('Uno. Dos.\nTres.');
+    expect(tokens.map((t) => t.text)).toEqual(['Uno.', 'Dos.', 'Tres.']);
+    expect(tokens.map((t) => t.breakAfter)).toEqual([false, true, false]);
+  });
+
+  it('es coherente con segmentReading', () => {
+    const text = 'Frase una. Frase dos.\nFrase tres.';
+    expect(tokenizeReading(text).map((t) => t.text)).toEqual(
+      segmentReading(text),
+    );
+  });
+});
+
+describe('normalizeSegment', () => {
+  it('colapsa espacios y recorta', () => {
+    expect(normalizeSegment('  hola   mundo \n ')).toBe('hola mundo');
+  });
+});

--- a/mcm-app/app/(tabs)/contigo/bookmarks.tsx
+++ b/mcm-app/app/(tabs)/contigo/bookmarks.tsx
@@ -1,5 +1,4 @@
-import { logger } from '@/utils/logger';
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import {
   View,
   Text,
@@ -13,18 +12,11 @@ import {
 import { Stack, useRouter, useFocusEffect } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
 import { MaterialIcons } from '@expo/vector-icons';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { warm, formatDateLong } from '@/components/contigo/theme';
-
-interface Bookmark {
-  date: string;
-  readings: any;
-  bookmarkedAt: number;
-}
-
-const STORAGE = '@contigo_bookmarks';
+import { useReaderBookmarks } from '@/hooks/useReaderBookmarks';
+import { countHighlights } from '@/utils/contigoBookmarks';
 
 export default function BookmarksScreen() {
   const router = useRouter();
@@ -42,43 +34,13 @@ export default function BookmarksScreen() {
       }
     : undefined;
 
-  const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const load = useCallback(async () => {
-    try {
-      const str = await AsyncStorage.getItem(STORAGE);
-      if (str) {
-        const parsed = JSON.parse(str);
-        const valid: Bookmark[] = parsed
-          .filter((b: any) => typeof b !== 'string')
-          .sort((a: Bookmark, b: Bookmark) => b.bookmarkedAt - a.bookmarkedAt);
-        setBookmarks(valid);
-      } else {
-        setBookmarks([]);
-      }
-    } catch (e) {
-      logger.error('bookmarks load', e);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const { bookmarks, isLoading, removeBookmark, reload } = useReaderBookmarks();
 
   useFocusEffect(
     useCallback(() => {
-      load();
-    }, [load]),
+      reload();
+    }, [reload]),
   );
-
-  const removeBookmark = async (date: string) => {
-    const next = bookmarks.filter((b) => b.date !== date);
-    setBookmarks(next);
-    try {
-      await AsyncStorage.setItem(STORAGE, JSON.stringify(next));
-    } catch (e) {
-      logger.error(e);
-    }
-  };
 
   return (
     <View style={styles.container}>
@@ -139,6 +101,7 @@ export default function BookmarksScreen() {
               const ev = b.readings?.evangelio;
               const titulo =
                 b.readings?.info?.titulo || ev?.cita || 'Evangelio guardado';
+              const nHighlights = countHighlights(b);
               const firstLine = ev?.texto
                 ? ev.texto
                     .split('\n')
@@ -180,6 +143,21 @@ export default function BookmarksScreen() {
                         >
                           {formatDateLong(b.date)}
                         </Text>
+                        {nHighlights > 0 ? (
+                          <View style={styles.hlChipRow}>
+                            <MaterialIcons
+                              name="border-color"
+                              size={11}
+                              color={W.accent}
+                            />
+                            <Text
+                              style={[styles.hlChipText, { color: W.accent }]}
+                            >
+                              {nHighlights} subrayado
+                              {nHighlights !== 1 ? 's' : ''}
+                            </Text>
+                          </View>
+                        ) : null}
                       </View>
                       <TouchableOpacity
                         onPress={() => removeBookmark(b.date)}
@@ -302,6 +280,13 @@ const styles = StyleSheet.create({
   },
   cita: { fontSize: 13, fontWeight: '700', marginBottom: 2 },
   dateText: { fontSize: 11 },
+  hlChipRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    marginTop: 4,
+  },
+  hlChipText: { fontSize: 11, fontWeight: '700' },
   removeBtn: {
     width: 28,
     height: 28,

--- a/mcm-app/app/(tabs)/contigo/evangelio.tsx
+++ b/mcm-app/app/(tabs)/contigo/evangelio.tsx
@@ -1,5 +1,5 @@
 import { logger } from '@/utils/logger';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   ScrollView,
   View,
@@ -14,13 +14,12 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { Card } from 'heroui-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import useFontScale from '@/hooks/useFontScale';
+import useSectionFontScale from '@/hooks/useSectionFontScale';
 import { useContigoHabits } from '@/hooks/useContigoHabits';
 import { useDailyReadings } from '@/hooks/useDailyReadings';
 import {
@@ -28,14 +27,15 @@ import {
   getLiturgicalInfo,
 } from '@/components/contigo/LiturgicalBadge';
 import { ReadingCard } from '@/components/contigo/ReadingCard';
-import SettingsBottomSheet from '@/components/SettingsBottomSheet';
+import { HighlightableText } from '@/components/contigo/HighlightableText';
+import ReaderSettingsSheet from '@/components/contigo/ReaderSettingsSheet';
 import BottomSheet from '@/components/BottomSheet';
 import { radii, shadows } from '@/constants/uiStyles';
 import { hexAlpha } from '@/utils/colorUtils';
+import { useReaderBookmarks } from '@/hooks/useReaderBookmarks';
+import { segmentReading } from '@/utils/readingSegments';
 
 import { CelebrationAnimation } from '@/components/contigo/CelebrationAnimation';
-import { useAuth } from '@/contexts/AuthContext';
-import { syncContigoBookmark } from '@/utils/authHelpers';
 
 // ── Contigo warm palette (aligned with redesign tokens) ──
 const WARM = {
@@ -102,7 +102,7 @@ export default function EvangelioScreen() {
   const theme = Colors[scheme ?? 'light'];
   const warm = isDark ? WARM.dark : WARM.light;
   const insets = useSafeAreaInsets();
-  const fontScale = useFontScale();
+  const { scale: fontScale } = useSectionFontScale('contigo');
   const { width: windowWidth } = useWindowDimensions();
   // iPad / large tablet / desktop web — cap content width.
   const isWide = windowWidth >= 720;
@@ -115,7 +115,6 @@ export default function EvangelioScreen() {
       }
     : undefined;
 
-  const { user: authUser } = useAuth();
   const { todayStr, getRecord, setReadingDone } = useContigoHabits();
   const params = useLocalSearchParams<{ date?: string }>();
   const initialDate =
@@ -129,63 +128,29 @@ export default function EvangelioScreen() {
   const [showCheck, setShowCheck] = useState(false);
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [creditsVisible, setCreditsVisible] = useState(false);
-  const [isBookmarked, setIsBookmarked] = useState(false);
+  const [highlightMode, setHighlightMode] = useState(false);
 
-  useEffect(() => {
-    AsyncStorage.getItem('@contigo_bookmarks').then((str) => {
-      if (str) {
-        const bookmarks: any[] = JSON.parse(str);
-        if (bookmarks.length > 0 && typeof bookmarks[0] === 'string') {
-          setIsBookmarked(bookmarks.includes(selectedDate));
-        } else {
-          setIsBookmarked(bookmarks.some((b) => b.date === selectedDate));
-        }
-      }
-    });
-  }, [selectedDate]);
+  const {
+    getBookmark,
+    isBookmarked: isBookmarkedFn,
+    toggleBookmark: toggleBm,
+    setHighlights,
+  } = useReaderBookmarks();
+  const isBookmarked = isBookmarkedFn(selectedDate);
+  const bookmark = getBookmark(selectedDate);
+  const evangelioHighlights = bookmark?.highlights?.evangelio ?? [];
+  const salmoHighlights = bookmark?.highlights?.salmo ?? [];
 
   const toggleBookmark = async () => {
     if (Platform.OS !== 'web')
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    try {
-      const str = await AsyncStorage.getItem('@contigo_bookmarks');
-      let bookmarks: any[] = str ? JSON.parse(str) : [];
-      if (isBookmarked) {
-        if (bookmarks.length > 0 && typeof bookmarks[0] === 'string') {
-          bookmarks = bookmarks.filter((d) => d !== selectedDate);
-        } else {
-          bookmarks = bookmarks.filter((b) => b.date !== selectedDate);
-        }
-      } else {
-        // Handle migration if mixing arrays, filter strings out
-        bookmarks = bookmarks.filter((b) => typeof b !== 'string');
-        bookmarks.push({
-          date: selectedDate,
-          readings: readings,
-          bookmarkedAt: Date.now(),
-        });
-      }
-      await AsyncStorage.setItem(
-        '@contigo_bookmarks',
-        JSON.stringify(bookmarks),
-      );
-      const nowBookmarked = !isBookmarked;
-      setIsBookmarked(nowBookmarked);
-      // Sync solo metadatos (sin texto completo) a RTDB si hay sesión
-      if (authUser) {
-        if (nowBookmarked && readings?.evangelio) {
-          syncContigoBookmark(authUser.uid, selectedDate, {
-            bookmarkedAt: Date.now(),
-            cita: readings.evangelio.cita ?? '',
-            diaLiturgico: readings.info?.diaLiturgico,
-          });
-        } else {
-          syncContigoBookmark(authUser.uid, selectedDate, null);
-        }
-      }
-    } catch (e) {
-      logger.error('Failed to save bookmark', e);
-    }
+    await toggleBm(selectedDate, readings);
+  };
+
+  const toggleHighlightMode = () => {
+    if (Platform.OS !== 'web')
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setHighlightMode((v) => !v);
   };
 
   const record = getRecord(selectedDate);
@@ -262,6 +227,19 @@ export default function EvangelioScreen() {
           headerRight: () => (
             <View style={styles.nativeHeaderActions}>
               <TouchableOpacity
+                onPress={toggleHighlightMode}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                style={styles.nativeHeaderBtn}
+                accessibilityLabel="Subrayar texto"
+                accessibilityState={{ selected: highlightMode }}
+              >
+                <MaterialIcons
+                  name="border-color"
+                  size={21}
+                  color={highlightMode ? warm.accent : theme.text}
+                />
+              </TouchableOpacity>
+              <TouchableOpacity
                 onPress={toggleBookmark}
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                 style={styles.nativeHeaderBtn}
@@ -277,7 +255,7 @@ export default function EvangelioScreen() {
                 onPress={() => setSettingsVisible(true)}
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                 style={styles.nativeHeaderBtn}
-                accessibilityLabel="Ajustes de texto"
+                accessibilityLabel="Ajustes de lectura"
               >
                 <MaterialIcons
                   name="text-fields"
@@ -456,6 +434,46 @@ export default function EvangelioScreen() {
             </View>
           ) : (
             <View style={styles.mainContent}>
+              {/* ── Highlight-mode hint ── */}
+              {highlightMode ? (
+                <View
+                  style={[
+                    styles.highlightBanner,
+                    {
+                      backgroundColor: hexAlpha(
+                        warm.accent,
+                        isDark ? '20' : '16',
+                      ),
+                      borderColor: hexAlpha(warm.accent, '33'),
+                    },
+                  ]}
+                >
+                  <MaterialIcons
+                    name="border-color"
+                    size={16}
+                    color={warm.accent}
+                  />
+                  <Text
+                    style={[styles.highlightBannerText, { color: warm.accent }]}
+                  >
+                    Toca una frase para subrayarla. Mantén pulsado para copiar.
+                  </Text>
+                  <TouchableOpacity
+                    onPress={toggleHighlightMode}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <Text
+                      style={[
+                        styles.highlightBannerDone,
+                        { color: warm.accent },
+                      ]}
+                    >
+                      Hecho
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              ) : null}
+
               {/* ── Evangelio Card ── */}
               <Card
                 style={[
@@ -607,21 +625,26 @@ export default function EvangelioScreen() {
                               {readings.evangelio.cita}
                             </Text>
                           </View>
-                          <Text
-                            style={[
-                              styles.bodyText,
-                              {
-                                color: theme.text,
-                                fontSize: 18 * fontScale,
-                                lineHeight: 28 * fontScale,
-                                fontFamily:
-                                  Platform.OS === 'ios' ? 'Palatino' : 'serif',
-                              },
-                            ]}
-                            selectable
-                          >
-                            {readings.evangelio.texto}
-                          </Text>
+                          <HighlightableText
+                            text={readings.evangelio.texto}
+                            highlighted={evangelioHighlights}
+                            highlightMode={highlightMode}
+                            onChange={(next) =>
+                              setHighlights(
+                                selectedDate,
+                                'evangelio',
+                                next,
+                                readings,
+                              )
+                            }
+                            color={theme.text}
+                            fontSize={18 * fontScale}
+                            lineHeight={28 * fontScale}
+                            fontFamily={
+                              Platform.OS === 'ios' ? 'Palatino' : 'serif'
+                            }
+                            isDark={isDark}
+                          />
                         </>
                       ) : (
                         <>
@@ -703,21 +726,19 @@ export default function EvangelioScreen() {
                         {readings.evangelio.cita}
                       </Text>
                     </View>
-                    <Text
-                      style={[
-                        styles.bodyText,
-                        {
-                          color: theme.text,
-                          fontSize: 18 * fontScale,
-                          lineHeight: 28 * fontScale,
-                          fontFamily:
-                            Platform.OS === 'ios' ? 'Palatino' : 'serif',
-                        },
-                      ]}
-                      selectable
-                    >
-                      {readings.evangelio.texto}
-                    </Text>
+                    <HighlightableText
+                      text={readings.evangelio.texto}
+                      highlighted={evangelioHighlights}
+                      highlightMode={highlightMode}
+                      onChange={(next) =>
+                        setHighlights(selectedDate, 'evangelio', next, readings)
+                      }
+                      color={theme.text}
+                      fontSize={18 * fontScale}
+                      lineHeight={28 * fontScale}
+                      fontFamily={Platform.OS === 'ios' ? 'Palatino' : 'serif'}
+                      isDark={isDark}
+                    />
                   </View>
                 )}
               </Card>
@@ -820,6 +841,7 @@ export default function EvangelioScreen() {
                       title="Primera Lectura"
                       cita={readings.lectura1.cita}
                       texto={readings.lectura1.texto}
+                      scale={fontScale}
                     />
                   )}
 
@@ -828,6 +850,13 @@ export default function EvangelioScreen() {
                       title="Salmo"
                       cita={readings.salmo.cita}
                       texto={readings.salmo.texto}
+                      scale={fontScale}
+                      highlightable
+                      highlightMode={highlightMode}
+                      highlighted={salmoHighlights}
+                      onChangeHighlights={(next) =>
+                        setHighlights(selectedDate, 'salmo', next, readings)
+                      }
                     />
                   )}
 
@@ -836,6 +865,7 @@ export default function EvangelioScreen() {
                       title="Segunda Lectura"
                       cita={readings.lectura2.cita}
                       texto={readings.lectura2.texto}
+                      scale={fontScale}
                     />
                   )}
                 </View>
@@ -868,9 +898,15 @@ export default function EvangelioScreen() {
       {/* Celebration burst animation */}
       <CelebrationAnimation visible={showCheck} isDark={isDark} />
 
-      <SettingsBottomSheet
+      <ReaderSettingsSheet
         visible={settingsVisible}
         onClose={() => setSettingsVisible(false)}
+        sectionKey="contigo"
+        previewText={
+          readings?.evangelio?.texto
+            ? segmentReading(readings.evangelio.texto)[0]
+            : undefined
+        }
       />
 
       {/* Credits Sheet */}
@@ -1154,6 +1190,26 @@ const styles = StyleSheet.create({
   mainContent: {
     paddingHorizontal: 16,
     marginTop: 16,
+  },
+  highlightBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+    marginBottom: 14,
+  },
+  highlightBannerText: {
+    flex: 1,
+    fontSize: 12.5,
+    fontWeight: '600',
+    lineHeight: 17,
+  },
+  highlightBannerDone: {
+    fontSize: 13,
+    fontWeight: '800',
   },
   evangelioCard: {
     borderRadius: radii.xl,

--- a/mcm-app/components/contigo/HighlightableText.tsx
+++ b/mcm-app/components/contigo/HighlightableText.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { Text, StyleSheet, type TextStyle } from 'react-native';
+import { h } from '@/utils/haptics';
+import { tokenizeReading, normalizeSegment } from '@/utils/readingSegments';
+
+interface HighlightableTextProps {
+  text: string;
+  /** Frases actualmente subrayadas (texto). */
+  highlighted: string[];
+  /** Si true, tocar una frase la subraya/quita; si false, solo lectura
+   *  (la selección nativa por pulsación larga sigue disponible). */
+  highlightMode: boolean;
+  /** Devuelve la nueva lista de frases subrayadas tras alternar una. */
+  onChange: (nextHighlighted: string[]) => void;
+  color: string;
+  fontSize: number;
+  lineHeight: number;
+  fontFamily?: string;
+  isDark: boolean;
+  style?: TextStyle;
+}
+
+/**
+ * Texto de lectura con subrayado a nivel de frase.
+ *
+ * El `<Text>` contenedor es `selectable`, así que la selección nativa (copiar,
+ * buscar, herramientas de escritura / IA en iOS) funciona con pulsación larga.
+ * En modo subrayar, un toque simple alterna el marcado de la frase.
+ */
+export function HighlightableText({
+  text,
+  highlighted,
+  highlightMode,
+  onChange,
+  color,
+  fontSize,
+  lineHeight,
+  fontFamily,
+  isDark,
+  style,
+}: HighlightableTextProps) {
+  const tokens = useMemo(() => tokenizeReading(text), [text]);
+  const highlightedSet = useMemo(
+    () => new Set(highlighted.map(normalizeSegment)),
+    [highlighted],
+  );
+
+  const markerBg = isDark ? 'rgba(218,165,32,0.32)' : 'rgba(233,171,45,0.34)';
+
+  const toggle = (segment: string) => {
+    const norm = normalizeSegment(segment);
+    const current = highlighted.filter((s) => normalizeSegment(s) !== norm);
+    if (highlightedSet.has(norm)) {
+      h.remove();
+      onChange(current);
+    } else {
+      h.add();
+      onChange([...current, segment]);
+    }
+  };
+
+  return (
+    <Text
+      selectable
+      style={[
+        styles.body,
+        { color, fontSize, lineHeight, ...(fontFamily ? { fontFamily } : {}) },
+        style,
+      ]}
+    >
+      {tokens.map((tok, i) => {
+        const isHl = highlightedSet.has(normalizeSegment(tok.text));
+        return (
+          <Text
+            key={i}
+            onPress={highlightMode ? () => toggle(tok.text) : undefined}
+            suppressHighlighting={!highlightMode}
+            style={isHl ? { backgroundColor: markerBg, color } : undefined}
+          >
+            {tok.text}
+            {tok.breakAfter ? '\n' : i < tokens.length - 1 ? ' ' : ''}
+          </Text>
+        );
+      })}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    fontWeight: '400',
+  },
+});

--- a/mcm-app/components/contigo/ReaderSettingsSheet.tsx
+++ b/mcm-app/components/contigo/ReaderSettingsSheet.tsx
@@ -1,0 +1,345 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Platform,
+  TouchableOpacity,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import BottomSheet from '@/components/BottomSheet';
+import { useAppSettings, ThemeScheme } from '@/contexts/AppSettingsContext';
+import useSectionFontScale from '@/hooks/useSectionFontScale';
+import { warm } from '@/components/contigo/theme';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { radii } from '@/constants/uiStyles';
+import { h } from '@/utils/haptics';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  /** Clave de sección para el tamaño de letra (p.ej. 'contigo'). */
+  sectionKey: string;
+  /** Texto de vista previa (una frase de la lectura actual). */
+  previewText?: string;
+}
+
+const THEME_OPTIONS: { key: ThemeScheme; icon: string; label: string }[] = [
+  { key: 'light', icon: 'light-mode', label: 'Claro' },
+  { key: 'dark', icon: 'dark-mode', label: 'Oscuro' },
+  { key: 'system', icon: 'brightness-auto', label: 'Auto' },
+];
+
+const DEFAULT_PREVIEW =
+  'En aquel tiempo, dijo Jesús a sus discípulos: «Yo soy la luz del mundo».';
+
+/**
+ * Bottom sheet minimalista y bonito solo para la lectura: tamaño de letra
+ * (propio de la sección, con herencia del global) y modo claro/oscuro.
+ * Reutilizable en otras secciones de lectura pasando otra `sectionKey`.
+ */
+export default function ReaderSettingsSheet({
+  visible,
+  onClose,
+  sectionKey,
+  previewText,
+}: Props) {
+  const { settings, setSettings } = useAppSettings();
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const W = warm(isDark);
+  const { scale, hasOverride, globalScale, setScale, reset, min, max, step } =
+    useSectionFontScale(sectionKey);
+
+  const canDecrease = scale > min + 0.001;
+  const canIncrease = scale < max - 0.001;
+
+  const decrease = () => {
+    if (!canDecrease) return;
+    h.tap();
+    setScale(scale - step);
+  };
+  const increase = () => {
+    if (!canIncrease) return;
+    h.tap();
+    setScale(scale + step);
+  };
+
+  const segmentBg = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)';
+  const surfaceBg = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)';
+
+  // Progreso del tamaño dentro del rango, para la barra.
+  const progress = Math.max(0, Math.min(1, (scale - min) / (max - min)));
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} title="Ajustes de lectura">
+      <View style={styles.container}>
+        {/* ── Vista previa en vivo ── */}
+        <View
+          style={[
+            styles.preview,
+            { backgroundColor: surfaceBg, borderColor: W.border },
+          ]}
+        >
+          <Text
+            style={{
+              color: W.text,
+              fontSize: 18 * scale,
+              lineHeight: 28 * scale,
+              fontFamily: Platform.OS === 'ios' ? 'Palatino' : 'serif',
+            }}
+          >
+            {previewText || DEFAULT_PREVIEW}
+          </Text>
+        </View>
+
+        {/* ── Tamaño de letra ── */}
+        <View style={styles.sectionHeaderRow}>
+          <Text style={[styles.sectionLabel, { color: W.textSec }]}>
+            TAMAÑO DE LETRA
+          </Text>
+          {hasOverride ? (
+            <TouchableOpacity
+              onPress={() => {
+                h.tap();
+                reset();
+              }}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Text style={[styles.resetLink, { color: W.accent }]}>
+                Sincronizar con la app
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        <View style={styles.sizeRow}>
+          <TouchableOpacity
+            onPress={decrease}
+            disabled={!canDecrease}
+            style={[
+              styles.sizeBtn,
+              { backgroundColor: segmentBg },
+              !canDecrease && styles.disabled,
+            ]}
+            accessibilityLabel="Reducir tamaño de letra"
+          >
+            <Text style={[styles.sizeGlyphSmall, { color: W.text }]}>A</Text>
+          </TouchableOpacity>
+
+          <View style={styles.trackWrap}>
+            <View style={[styles.track, { backgroundColor: segmentBg }]}>
+              <View
+                style={[
+                  styles.trackFill,
+                  {
+                    backgroundColor: W.accent,
+                    width: `${progress * 100}%`,
+                  },
+                ]}
+              />
+              <View
+                style={[
+                  styles.knob,
+                  {
+                    backgroundColor: W.accent,
+                    left: `${progress * 100}%`,
+                    borderColor: W.bgCard,
+                  },
+                ]}
+              />
+            </View>
+            <Text style={[styles.percentLabel, { color: W.textMuted }]}>
+              {Math.round(scale * 100)}%
+            </Text>
+          </View>
+
+          <TouchableOpacity
+            onPress={increase}
+            disabled={!canIncrease}
+            style={[
+              styles.sizeBtn,
+              { backgroundColor: segmentBg },
+              !canIncrease && styles.disabled,
+            ]}
+            accessibilityLabel="Aumentar tamaño de letra"
+          >
+            <Text style={[styles.sizeGlyphBig, { color: W.text }]}>A</Text>
+          </TouchableOpacity>
+        </View>
+
+        {!hasOverride ? (
+          <View style={styles.syncHint}>
+            <MaterialIcons name="link" size={13} color={W.textMuted} />
+            <Text style={[styles.syncHintText, { color: W.textMuted }]}>
+              Ligado al tamaño general de la app (
+              {Math.round(globalScale * 100)}
+              %). Ajústalo aquí para tener uno propio en la lectura.
+            </Text>
+          </View>
+        ) : null}
+
+        {/* ── Tema ── */}
+        <Text
+          style={[
+            styles.sectionLabel,
+            { color: W.textSec, marginTop: 22, marginBottom: 10 },
+          ]}
+        >
+          APARIENCIA
+        </Text>
+        <View style={[styles.themeSegment, { backgroundColor: segmentBg }]}>
+          {THEME_OPTIONS.map((opt) => {
+            const selected = settings.theme === opt.key;
+            return (
+              <TouchableOpacity
+                key={opt.key}
+                onPress={() => {
+                  h.select();
+                  setSettings({ theme: opt.key });
+                }}
+                style={[
+                  styles.themeOption,
+                  selected && {
+                    backgroundColor: W.accent,
+                    shadowColor: W.accent,
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowOpacity: 0.3,
+                    shadowRadius: 5,
+                    elevation: 3,
+                  },
+                ]}
+                accessibilityRole="radio"
+                accessibilityState={{ selected }}
+                accessibilityLabel={`Tema ${opt.label}`}
+              >
+                <MaterialIcons
+                  name={opt.icon as never}
+                  size={17}
+                  color={selected ? '#fff' : W.textSec}
+                />
+                <Text
+                  style={[
+                    styles.themeOptionText,
+                    { color: selected ? '#fff' : W.textSec },
+                  ]}
+                >
+                  {opt.label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 20,
+    paddingTop: 4,
+    paddingBottom: 36,
+  },
+  preview: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    padding: 18,
+    marginBottom: 22,
+    minHeight: 96,
+    justifyContent: 'center',
+  },
+  sectionHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+  },
+  resetLink: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  sizeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  sizeBtn: {
+    width: 46,
+    height: 46,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  disabled: { opacity: 0.35 },
+  sizeGlyphSmall: { fontSize: 15, fontWeight: '700' },
+  sizeGlyphBig: { fontSize: 26, fontWeight: '700' },
+  trackWrap: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 8,
+  },
+  track: {
+    width: '100%',
+    height: 6,
+    borderRadius: 3,
+    justifyContent: 'center',
+  },
+  trackFill: {
+    height: 6,
+    borderRadius: 3,
+  },
+  knob: {
+    position: 'absolute',
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    borderWidth: 2,
+    marginLeft: -9,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  percentLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  syncHint: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 6,
+    marginTop: 12,
+    paddingHorizontal: 2,
+  },
+  syncHintText: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  themeSegment: {
+    flexDirection: 'row',
+    borderRadius: 12,
+    padding: 4,
+    gap: 4,
+  },
+  themeOption: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 11,
+    borderRadius: 9,
+  },
+  themeOptionText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+});

--- a/mcm-app/components/contigo/ReadingCard.tsx
+++ b/mcm-app/components/contigo/ReadingCard.tsx
@@ -6,6 +6,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { MaterialIcons } from '@expo/vector-icons';
 import { radii, shadows } from '@/constants/uiStyles';
 import { hexAlpha } from '@/utils/colorUtils';
+import { HighlightableText } from '@/components/contigo/HighlightableText';
 
 import useFontScale from '@/hooks/useFontScale';
 
@@ -14,6 +15,13 @@ interface ReadingCardProps {
   cita: string;
   texto: string;
   defaultExpanded?: boolean;
+  /** Escala de letra a aplicar. Si se omite, usa la global de la app. */
+  scale?: number;
+  /** Habilita el subrayado por frase en el cuerpo. */
+  highlightable?: boolean;
+  highlighted?: string[];
+  highlightMode?: boolean;
+  onChangeHighlights?: (next: string[]) => void;
 }
 
 // Warm amber accent for Contigo section
@@ -25,12 +33,18 @@ export function ReadingCard({
   cita,
   texto,
   defaultExpanded = false,
+  scale,
+  highlightable = false,
+  highlighted = [],
+  highlightMode = false,
+  onChangeHighlights,
 }: ReadingCardProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
   const theme = Colors[scheme ?? 'light'];
   const accent = isDark ? WARM_ACCENT_DARK : WARM_ACCENT_LIGHT;
-  const fontScale = useFontScale();
+  const globalScale = useFontScale();
+  const fontScale = scale ?? globalScale;
 
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -91,20 +105,34 @@ export function ReadingCard({
                 },
               ]}
             >
-              <Text
-                style={[
-                  styles.bodyText,
-                  {
-                    color: theme.text,
-                    fontSize: 16 * fontScale,
-                    lineHeight: 24 * fontScale,
-                    fontFamily: Platform.OS === 'ios' ? 'Palatino' : 'serif',
-                  },
-                ]}
-                selectable
-              >
-                {texto}
-              </Text>
+              {highlightable ? (
+                <HighlightableText
+                  text={texto}
+                  highlighted={highlighted}
+                  highlightMode={highlightMode}
+                  onChange={(next) => onChangeHighlights?.(next)}
+                  color={theme.text}
+                  fontSize={17 * fontScale}
+                  lineHeight={26 * fontScale}
+                  fontFamily={Platform.OS === 'ios' ? 'Palatino' : 'serif'}
+                  isDark={isDark}
+                />
+              ) : (
+                <Text
+                  style={[
+                    styles.bodyText,
+                    {
+                      color: theme.text,
+                      fontSize: 17 * fontScale,
+                      lineHeight: 26 * fontScale,
+                      fontFamily: Platform.OS === 'ios' ? 'Palatino' : 'serif',
+                    },
+                  ]}
+                  selectable
+                >
+                  {texto}
+                </Text>
+              )}
             </View>
           )}
         </View>

--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -15,6 +15,14 @@ export type ThemeScheme = 'light' | 'dark' | 'system';
 interface AppSettings {
   fontScale: number;
   theme: ThemeScheme;
+  /**
+   * Overrides de tamaño de letra por sección (p.ej. 'contigo').
+   * Si una sección NO tiene entrada aquí, hereda del `fontScale` global — así
+   * el usuario nota una transición suave. En cuanto configura un tamaño
+   * específico para la sección, esta pasa a ser independiente del global.
+   * Reutilizable para otras secciones de lectura (materiales de eventos…).
+   */
+  sectionFontScales: Record<string, number>;
 }
 
 interface AppSettingsContextType {
@@ -26,6 +34,7 @@ interface AppSettingsContextType {
 const defaultSettings: AppSettings = {
   fontScale: 1,
   theme: 'system',
+  sectionFontScales: {},
 };
 
 const STORAGE_KEY = '@app_settings';

--- a/mcm-app/hooks/useReaderBookmarks.ts
+++ b/mcm-app/hooks/useReaderBookmarks.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  fetchContigoBookmarks,
+  syncContigoBookmark,
+} from '@/utils/authHelpers';
+import {
+  loadLocalBookmarks,
+  upsertLocalBookmark,
+  removeLocalBookmark,
+  mergeRemoteBookmarks,
+  type StoredBookmark,
+  type BookmarkHighlights,
+  type HighlightSource,
+} from '@/utils/contigoBookmarks';
+import type { DailyReadings } from '@/hooks/useDailyReadings';
+
+/**
+ * Gestión centralizada de los bookmarks de evangelio de CONTIGO.
+ *
+ * - Guarda el TEXTO COMPLETO de las lecturas (local + RTDB por usuario) para que
+ *   los guardados sobrevivan al borrado a 30 días del nodo global de lecturas.
+ * - Hidrata desde RTDB al iniciar sesión (multi-dispositivo / reinstalación).
+ * - Soporta subrayados por fuente (evangelio / salmo), que auto-crean bookmark.
+ */
+export function useReaderBookmarks() {
+  const { user: authUser } = useAuth();
+  const [bookmarks, setBookmarks] = useState<StoredBookmark[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    const local = await loadLocalBookmarks();
+    setBookmarks(local);
+    setIsLoading(false);
+    return local;
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const local = await loadLocalBookmarks();
+      if (mounted) {
+        setBookmarks(local);
+        setIsLoading(false);
+      }
+      // Hidratar desde RTDB si hay sesión — funde texto completo remoto.
+      if (authUser) {
+        const remote = await fetchContigoBookmarks(authUser.uid);
+        if (remote.length > 0) {
+          const merged = await mergeRemoteBookmarks(remote);
+          if (mounted) setBookmarks(merged);
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [authUser]);
+
+  const getBookmark = useCallback(
+    (date: string): StoredBookmark | undefined =>
+      bookmarks.find((b) => b.date === date),
+    [bookmarks],
+  );
+
+  const isBookmarked = useCallback(
+    (date: string): boolean => bookmarks.some((b) => b.date === date),
+    [bookmarks],
+  );
+
+  /** Persiste local + RTDB. */
+  const persist = useCallback(
+    async (bookmark: StoredBookmark) => {
+      const next = await upsertLocalBookmark(bookmark);
+      setBookmarks(next);
+      if (authUser) syncContigoBookmark(authUser.uid, bookmark.date, bookmark);
+    },
+    [authUser],
+  );
+
+  /** Marca/desmarca un día. Al marcar guarda el texto completo. Devuelve el
+   *  nuevo estado (true = ahora guardado). */
+  const toggleBookmark = useCallback(
+    async (date: string, readings: DailyReadings | null): Promise<boolean> => {
+      const existing = getBookmark(date);
+      if (existing) {
+        const next = await removeLocalBookmark(date);
+        setBookmarks(next);
+        if (authUser) syncContigoBookmark(authUser.uid, date, null);
+        return false;
+      }
+      await persist({
+        date,
+        bookmarkedAt: Date.now(),
+        readings: readings ?? null,
+      });
+      return true;
+    },
+    [getBookmark, persist, authUser],
+  );
+
+  const removeBookmark = useCallback(
+    async (date: string) => {
+      const next = await removeLocalBookmark(date);
+      setBookmarks(next);
+      if (authUser) syncContigoBookmark(authUser.uid, date, null);
+    },
+    [authUser],
+  );
+
+  /** Fija las frases subrayadas de una fuente. Auto-crea el bookmark si no
+   *  existe (para no perder ni el subrayado ni el texto). */
+  const setHighlights = useCallback(
+    async (
+      date: string,
+      source: HighlightSource,
+      texts: string[],
+      readings: DailyReadings | null,
+    ) => {
+      const existing = getBookmark(date);
+      const prevHighlights: BookmarkHighlights = existing?.highlights ?? {};
+      const highlights: BookmarkHighlights = { ...prevHighlights };
+      if (texts.length > 0) highlights[source] = texts;
+      else delete highlights[source];
+
+      await persist({
+        date,
+        bookmarkedAt: existing?.bookmarkedAt ?? Date.now(),
+        readings: existing?.readings ?? readings ?? null,
+        highlights: Object.keys(highlights).length ? highlights : undefined,
+      });
+    },
+    [getBookmark, persist],
+  );
+
+  return {
+    bookmarks,
+    isLoading,
+    getBookmark,
+    isBookmarked,
+    toggleBookmark,
+    removeBookmark,
+    setHighlights,
+    reload,
+  };
+}

--- a/mcm-app/hooks/useSectionFontScale.ts
+++ b/mcm-app/hooks/useSectionFontScale.ts
@@ -1,0 +1,74 @@
+import { useCallback } from 'react';
+import { useAppSettings } from '@/contexts/AppSettingsContext';
+
+export const SECTION_FONT_MIN = 0.85;
+export const SECTION_FONT_MAX = 2.2;
+export const SECTION_FONT_STEP = 0.1;
+
+const clamp = (n: number) =>
+  Math.min(
+    SECTION_FONT_MAX,
+    Math.max(SECTION_FONT_MIN, Math.round(n * 100) / 100),
+  );
+
+export interface SectionFontScale {
+  /** Escala efectiva a aplicar (override de la sección o, si no hay, el global). */
+  scale: number;
+  /** True si la sección tiene un tamaño propio configurado. */
+  hasOverride: boolean;
+  /** Escala global de la app (fallback cuando no hay override). */
+  globalScale: number;
+  /** Fija un tamaño propio para la sección (independiza del global). */
+  setScale: (value: number) => void;
+  /** Elimina el tamaño propio: la sección vuelve a heredar del global. */
+  reset: () => void;
+  min: number;
+  max: number;
+  step: number;
+}
+
+/**
+ * Tamaño de letra específico por sección con herencia del global.
+ *
+ * Si la sección no tiene un tamaño propio, usa el `fontScale` global (así, al
+ * cambiar el tamaño general, las secciones sin configurar se ajustan solas y la
+ * transición es suave). En cuanto el usuario fija un tamaño para la sección,
+ * esta queda desacoplada del global hasta que se resetee.
+ *
+ * Reutilizable: pasa una `key` distinta por sección (p.ej. `'contigo'`,
+ * `'materiales'`).
+ */
+export default function useSectionFontScale(key: string): SectionFontScale {
+  const { settings, setSettings } = useAppSettings();
+  const overrides = settings.sectionFontScales ?? {};
+  const hasOverride = Object.prototype.hasOwnProperty.call(overrides, key);
+  const globalScale = settings.fontScale;
+  const scale = hasOverride ? overrides[key] : globalScale;
+
+  const setScale = useCallback(
+    (value: number) => {
+      setSettings({
+        sectionFontScales: { ...overrides, [key]: clamp(value) },
+      });
+    },
+    [setSettings, overrides, key],
+  );
+
+  const reset = useCallback(() => {
+    if (!hasOverride) return;
+    const next = { ...overrides };
+    delete next[key];
+    setSettings({ sectionFontScales: next });
+  }, [setSettings, overrides, key, hasOverride]);
+
+  return {
+    scale,
+    hasOverride,
+    globalScale,
+    setScale,
+    reset,
+    min: SECTION_FONT_MIN,
+    max: SECTION_FONT_MAX,
+    step: SECTION_FONT_STEP,
+  };
+}

--- a/mcm-app/utils/authHelpers.ts
+++ b/mcm-app/utils/authHelpers.ts
@@ -2,6 +2,7 @@ import { logger } from '@/utils/logger';
 import { getDatabase, ref, update, get, set, remove } from 'firebase/database';
 import { getFirebaseApp } from '@/utils/firebaseApp';
 import type { DayRecord } from '@/hooks/useContigoHabits';
+import type { StoredBookmark } from '@/utils/contigoBookmarks';
 
 function db() {
   return getDatabase(getFirebaseApp());
@@ -104,16 +105,18 @@ export async function syncContigoHabit(
   }
 }
 
-/** Sincroniza los metadatos de un bookmark de evangelio con RTDB. Solo guarda
- *  la cita y la fecha, NO el texto completo del evangelio. */
+/** Sincroniza un bookmark de evangelio con RTDB.
+ *
+ *  A diferencia del nodo global `seccion_oracion/lecturas/*` (que un Job limpia
+ *  pasados 30 días), este bookmark guarda el TEXTO COMPLETO de las lecturas bajo
+ *  el subárbol del propio usuario. El crecimiento es acotado (solo los días que
+ *  el usuario guarda, y por usuario), así que se conserva para siempre sin
+ *  hinchar la base común: el bookmark sobrevive al borrado a 30 días y se puede
+ *  restaurar en otro dispositivo. Pasa `null` para eliminarlo. */
 export async function syncContigoBookmark(
   uid: string,
   date: string,
-  bookmark: {
-    bookmarkedAt: number;
-    cita: string;
-    diaLiturgico?: string;
-  } | null,
+  bookmark: StoredBookmark | null,
 ): Promise<void> {
   try {
     const bookmarkRef = ref(db(), `users/${uid}/contigo/bookmarks/${date}`);
@@ -124,6 +127,27 @@ export async function syncContigoBookmark(
     }
   } catch (err) {
     logger.error('[authHelpers] syncContigoBookmark:', err);
+  }
+}
+
+/** Descarga todos los bookmarks de CONTIGO del usuario desde RTDB (con texto
+ *  completo). Se usa para hidratar el almacenamiento local tras iniciar sesión
+ *  o cambiar de dispositivo, de forma que los guardados no se pierdan aunque el
+ *  nodo global de lecturas ya se haya limpiado. */
+export async function fetchContigoBookmarks(
+  uid: string,
+): Promise<StoredBookmark[]> {
+  try {
+    const bookmarksRef = ref(db(), `users/${uid}/contigo/bookmarks`);
+    const snap = await get(bookmarksRef);
+    if (!snap.exists()) return [];
+    const val = snap.val() as Record<string, StoredBookmark>;
+    return Object.values(val).filter(
+      (b): b is StoredBookmark => !!b && typeof b === 'object' && !!b.date,
+    );
+  } catch (err) {
+    logger.error('[authHelpers] fetchContigoBookmarks:', err);
+    return [];
   }
 }
 

--- a/mcm-app/utils/contigoBookmarks.ts
+++ b/mcm-app/utils/contigoBookmarks.ts
@@ -1,0 +1,115 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logger } from '@/utils/logger';
+import type { DailyReadings } from '@/hooks/useDailyReadings';
+
+export const BOOKMARKS_KEY = '@contigo_bookmarks';
+
+/** Fuentes de texto que se pueden subrayar dentro de un día. */
+export type HighlightSource = 'evangelio' | 'salmo';
+
+export type BookmarkHighlights = Partial<Record<HighlightSource, string[]>>;
+
+export interface StoredBookmark {
+  date: string;
+  bookmarkedAt: number;
+  /** Texto completo de las lecturas — guardado para que el bookmark sobreviva
+   *  al borrado a 30 días del nodo global de lecturas. */
+  readings: DailyReadings | null;
+  /** Frases subrayadas por el usuario, por fuente. */
+  highlights?: BookmarkHighlights;
+}
+
+/** ¿Tiene el bookmark al menos un subrayado? */
+export function hasHighlights(b: StoredBookmark | undefined | null): boolean {
+  if (!b?.highlights) return false;
+  return Object.values(b.highlights).some((arr) => (arr?.length ?? 0) > 0);
+}
+
+/** Número total de frases subrayadas en un bookmark. */
+export function countHighlights(b: StoredBookmark | undefined | null): number {
+  if (!b?.highlights) return 0;
+  return Object.values(b.highlights).reduce(
+    (acc, arr) => acc + (arr?.length ?? 0),
+    0,
+  );
+}
+
+// ── Almacenamiento local ────────────────────────────────────────────────────
+
+/** Lee los bookmarks locales, migrando el formato antiguo (array de strings de
+ *  fechas) al formato de objeto y descartando entradas inválidas. */
+export async function loadLocalBookmarks(): Promise<StoredBookmark[]> {
+  try {
+    const str = await AsyncStorage.getItem(BOOKMARKS_KEY);
+    if (!str) return [];
+    const parsed = JSON.parse(str);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (b: unknown): b is StoredBookmark =>
+          !!b && typeof b === 'object' && typeof (b as any).date === 'string',
+      )
+      .sort((a, b) => b.bookmarkedAt - a.bookmarkedAt);
+  } catch (e) {
+    logger.error('[contigoBookmarks] loadLocalBookmarks', e);
+    return [];
+  }
+}
+
+async function saveLocalBookmarks(list: StoredBookmark[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BOOKMARKS_KEY, JSON.stringify(list));
+  } catch (e) {
+    logger.error('[contigoBookmarks] saveLocalBookmarks', e);
+  }
+}
+
+/** Inserta o reemplaza un bookmark y persiste. Devuelve la lista resultante. */
+export async function upsertLocalBookmark(
+  bookmark: StoredBookmark,
+): Promise<StoredBookmark[]> {
+  const list = await loadLocalBookmarks();
+  const next = [bookmark, ...list.filter((b) => b.date !== bookmark.date)].sort(
+    (a, b) => b.bookmarkedAt - a.bookmarkedAt,
+  );
+  await saveLocalBookmarks(next);
+  return next;
+}
+
+/** Elimina un bookmark por fecha y persiste. Devuelve la lista resultante. */
+export async function removeLocalBookmark(
+  date: string,
+): Promise<StoredBookmark[]> {
+  const list = await loadLocalBookmarks();
+  const next = list.filter((b) => b.date !== date);
+  await saveLocalBookmarks(next);
+  return next;
+}
+
+/** Funde los bookmarks remotos (RTDB, con texto completo) con los locales.
+ *  Ante conflicto gana el más reciente (`bookmarkedAt` mayor). Persiste el
+ *  resultado y lo devuelve — así los guardados sobreviven a reinstalaciones y
+ *  al borrado a 30 días del nodo global de lecturas. */
+export async function mergeRemoteBookmarks(
+  remote: StoredBookmark[],
+): Promise<StoredBookmark[]> {
+  const local = await loadLocalBookmarks();
+  const byDate = new Map<string, StoredBookmark>();
+  for (const b of local) byDate.set(b.date, b);
+  for (const r of remote) {
+    const existing = byDate.get(r.date);
+    if (!existing || (r.bookmarkedAt ?? 0) >= (existing.bookmarkedAt ?? 0)) {
+      // Preferimos el remoto, pero conservamos las readings locales si el
+      // remoto no las trae (por si un guardado antiguo iba sin texto).
+      byDate.set(r.date, {
+        ...r,
+        readings: r.readings ?? existing?.readings ?? null,
+      });
+    }
+  }
+  const next = Array.from(byDate.values()).sort(
+    (a, b) => b.bookmarkedAt - a.bookmarkedAt,
+  );
+  await saveLocalBookmarks(next);
+  return next;
+}

--- a/mcm-app/utils/readingSegments.ts
+++ b/mcm-app/utils/readingSegments.ts
@@ -1,0 +1,55 @@
+// Segmentación de un texto de lectura en frases "subrayables".
+//
+// El subrayado funciona a nivel de frase (no de carácter): la selección nativa
+// de iOS/Android sigue disponible con pulsación larga (copiar, buscar, IA),
+// mientras que un toque en modo subrayar marca la frase completa. Segmentar por
+// frase da un resultado limpio y estable para guardar y restaurar.
+
+// Divide respetando saltos de línea y puntuación final. Mantiene el signo de
+// puntuación pegado a su frase. Evita cortes en abreviaturas comunes.
+const SENTENCE_SPLIT = /(?<=[.!?…»])\s+(?=[«"¿¡A-ZÁÉÍÓÚÑ0-9])/u;
+
+export interface ReadingToken {
+  /** Texto de la frase (recortado). */
+  text: string;
+  /** True si tras esta frase había un salto de línea/párrafo en el original. */
+  breakAfter: boolean;
+}
+
+/** Trocea un texto en frases conservando la información de salto de párrafo,
+ *  para poder renderizar respetando la estructura original. */
+export function tokenizeReading(text: string): ReadingToken[] {
+  if (!text) return [];
+  const tokens: ReadingToken[] = [];
+  const lines = text.split(/\n+/).map((l) => l.trim());
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    if (!line) continue;
+    const parts = line
+      .split(SENTENCE_SPLIT)
+      .map((p) => p.trim())
+      .filter(Boolean);
+    for (let pi = 0; pi < parts.length; pi++) {
+      const isLastOfLine = pi === parts.length - 1;
+      const moreLines = lines.slice(li + 1).some(Boolean);
+      tokens.push({
+        text: parts[pi],
+        breakAfter: isLastOfLine && moreLines,
+      });
+    }
+  }
+  return tokens;
+}
+
+/** Trocea un texto en frases. Devuelve los segmentos con su texto ya recortado
+ *  (sin espacios sobrantes) preservando el orden. Los segmentos vacíos se
+ *  descartan. */
+export function segmentReading(text: string): string[] {
+  return tokenizeReading(text).map((t) => t.text);
+}
+
+/** Normaliza un fragmento para compararlo de forma robusta (por si cambia el
+ *  espaciado entre guardado y render). */
+export function normalizeSegment(seg: string): string {
+  return seg.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
Cherry-pick a **production** de las mejoras de Contigo (mismo commit que #288, aplicado limpio sobre `production` para lanzar la OTA).

Contenido idéntico a #288:
1. **Bookmarks duraderos**: texto completo en `users/{uid}/contigo/bookmarks/{date}` + hidratación desde RTDB → sobreviven al borrado a 30 días y a reinstalaciones.
2. **Subrayado** de evangelio y salmo (frase a frase), con selección nativa intacta; auto-guarda bookmark.
3. **Tamaño de letra propio de Contigo** + tema en bottom sheet dedicado, con herencia del global (`useSectionFontScale`, reutilizable).

## Verificación
- `typecheck` / `typecheck:tests`: 0 errores (verificado también sobre la base de `production`).
- `lint`: 0 errores. `test`: verde.
- **Sin paquetes nativos** → apto para OTA (no requiere build de tienda).

> Nota: al mergear a `production` se dispara la OTA (`ota-production.yml`). Como no hay código nativo, es seguro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EazmNN34gMru5FfZSLcNBJ)_