### PR TITLE
Fix: habilitar disableAntiBrickingMeasures para el override OTA preview

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,28 @@
 
 ---
 
+## 2026-07-22 21:00 — Fix: el modo alpha (7 taps) no conectaba al canal OTA preview
+
+- **Causa raíz**: `Updates.setUpdateURLAndRequestHeadersOverride()` exige que el
+  binario esté construido con `updates.disableAntiBrickingMeasures: true` en
+  `app.json`. Sin ese flag, expo-updates lanza un error que el `try/catch` de
+  `PreviewChannelContext` silenciaba — el toggle parecía funcionar pero el
+  dispositivo seguía en el canal `production`.
+- **Fix**: añadido `"disableAntiBrickingMeasures": true` al bloque `updates` de
+  `app.json`, y el `catch` ahora loguea con `logger.warn` para que el fallo sea
+  visible. (`app.json`, `contexts/PreviewChannelContext.tsx`)
+- ⚠️ **Requiere build de tienda**: el flag se hornea en el binario nativo
+  (Expo.plist / AndroidManifest). Los binarios ya instalados seguirán ignorando
+  el toggle hasta que se publique una nueva build de producción con este cambio.
+  Las OTAs no pueden activar el flag — este commit en sí es OTA-safe (no añade
+  módulos nativos nuevos), simplemente el toggle no surtirá efecto hasta la
+  próxima build de tienda.
+- El resto de la cadena ya estaba bien: 7 taps (`SecretMenuTrigger` →
+  `useSecretTap`) → modal Laboratorio Alpha → flag en AsyncStorage → override al
+  arrancar → `useOTAUpdate` hace `checkForUpdateAsync` contra el canal `preview`.
+  El workflow `.github/workflows/ota-preview.yml` publica en la branch EAS
+  `preview` con cada push a la rama git `preview`.
+
 ## 2026-07-19 18:30 — Seguridad cantoral (XSS), bug de fecha UTC, reflexiones atómicas, limpieza de deps
 
 - **Seguridad (cantoral)**: `author`/`title`/el badge de tono se escapan

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -175,7 +175,8 @@
     "updates": {
       "url": "https://u.expo.dev/aa9f2d3a-b74a-4169-bad4-e851015e30c6",
       "fallbackToCacheTimeout": 0,
-      "checkAutomatically": "ON_LOAD"
+      "checkAutomatically": "ON_LOAD",
+      "disableAntiBrickingMeasures": true
     }
   }
 }

--- a/mcm-app/contexts/PreviewChannelContext.tsx
+++ b/mcm-app/contexts/PreviewChannelContext.tsx
@@ -11,6 +11,7 @@ import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
+import { logger } from '@/utils/logger';
 
 /**
  * Activa o desactiva el canal "preview" de EAS Update en tiempo de ejecución,
@@ -79,8 +80,11 @@ function applyPreviewOverride(active: boolean) {
       updateUrl,
       requestHeaders: { 'expo-channel-name': PREVIEW_CHANNEL },
     });
-  } catch {
+  } catch (err) {
     // No bloqueante: si el override falla, la app sigue en su canal nativo.
+    // Requiere `updates.disableAntiBrickingMeasures: true` en app.json — en
+    // binarios construidos sin ese flag, expo-updates lanza aquí.
+    logger.warn('[PreviewChannel] No se pudo aplicar el override OTA:', err);
   }
 }
 


### PR DESCRIPTION
Retoma la PR #261 (abierta desde junio, desactualizada respecto a `main` — cientos de commits de diferencia). Mismo fix, reconstruido limpio sobre `main` actual:

## Qué arregla
`Updates.setUpdateURLAndRequestHeadersOverride()` exige `updates.disableAntiBrickingMeasures: true` en `app.json`. Sin él lanzaba un error silenciado por el `try/catch`, y el toggle de 7 taps (Laboratorio Alpha) parecía funcionar pero el dispositivo seguía en el canal `production`.

## Diferencia con la #261 original
`console.warn` → `logger.warn`: la regla `no-console: error` no existía en junio cuando se escribió el fix original; ahora sí (Plan de Calidad Fase 0), así que el `console.warn` original habría roto el lint.

## Requiere build de tienda
El flag se hornea en el binario nativo. Los binarios ya instalados ignorarán el toggle hasta la próxima build de producción. El commit en sí es **OTA-safe** (sin módulos nativos nuevos) — solo el efecto del toggle necesita el build.

## Verificado
`npx tsc --noEmit`, `npm run lint` (0 errores), `npx jest --ci` (283/283) — todo limpio.

Cierra #261.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9)_