### PR TITLE
UI Nativa Fase 2: AppPrimaryButton + migraciones (feedback family)

### DIFF
--- a/docs/planes/BACKLOG.md
+++ b/docs/planes/BACKLOG.md
@@ -28,7 +28,7 @@
 
 | | |
 |---|---|
-| **Ahora mismo (en curso / siguiente)** | UI Nativa 🔒 (preguntar las 3 decisiones antes) |
+| **Ahora mismo (en curso / siguiente)** | UI Nativa — **Fase 2** (componentes); las 3 decisiones ya están tomadas (ver §4) |
 | **Después** | Integración D 🔒 → Widget de Contigo 🔒 → Carismochito + Panel Pañuelo |
 | **Bloqueado, no tocar sin preguntar** | Integración D, Widget de Contigo, Panel Pañuelo |
 | **Oportunista (solo si piden hueco)** | Calidad Fase 1, Integraciones resto, bolsa nativa |
@@ -73,7 +73,7 @@
 |---|---|---|---|---|---|
 | 1 | **Plan 004** — Contigo: sync bidireccional de hábitos/revisiones + tests `authHelpers` | Sonnet | No | ✅ **DONE** (2026-07-22) | `plans/004-contigo-sync-bidireccional.md` |
 | 2 | **Plan 005** — Scraper: vacío=error, fecha vetada, pytest en CI, workflow sin inyección | Sonnet | No | ✅ **DONE** (2026-07-22) | `plans/005-scraper-fiabilidad-y-ci.md` |
-| 3 | **Plan 008** — Caché compartida `useFirebaseData` + calendario stale-while-revalidate | **Opus** | No | ✅ **DONE** (2026-07-22) — pendiente validar rendimiento real en dispositivo | `plans/008-cache-compartida-firebase-calendario.md` |
+| 3 | **Plan 008** — Caché compartida `useFirebaseData` + calendario stale-while-revalidate | **Opus** | No | ✅ **DONE** en `main` (2026-07-22). **NO cherry-pickeado a producción a propósito**: toca el hook central y cambia comportamiento visible del calendario; validar en dispositivo (vía `preview`, con la próxima build de tienda) antes de producción. No corre prisa (es perf, no bug). | `plans/008-cache-compartida-firebase-calendario.md` |
 | 4 | **UI Nativa** — headers nativos + componentes unificados | Sonnet (Fable en la cola mecánica de Fase 2) | Parcial — 3 decisiones bloquean partes concretas, no todo (ver §4) | 🟡 En curso (Fase 1 casi hecha) | `docs/planes/PLAN_UI_NATIVA.md` |
 | 5 | **Integración D** — Seguridad Firebase | Opus | **Sí** — D2 + repo `mcmpanel` (ver §4) | ⏳ Pendiente, importante pero no urgente | `docs/planes/PLAN_INTEGRACIONES.md` §"Integración D" |
 | 6 | **Widget de Contigo** | Opus | **Sí** — ¿release de tienda ya? (ver §4) | ⏳ Al final | `docs/planes/PLAN_WIDGET_CONTIGO.md` |
@@ -171,7 +171,7 @@ reabrir este plan tal cual, su premisa ya no aplica.
 | Decisión | Bloquea | Dónde consultar el contexto | Qué preguntar |
 |---|---|---|---|
 | **D2** — modelo de auth del panel (Firebase Auth + `/admins` vs mover escrituras a `api/`) | Integración D | `docs/planes/PLAN_INTEGRACIONES.md` §"Integración D" | "¿Qué modelo de auth para el panel — Firebase Auth+`/admins` o mover escrituras a funciones `api/`? Y ¿añado el repo `mcmpanel` a la sesión para poder tocarlo?" |
-| **3 decisiones de UI** — qué pantallas van a header nativo plano vs floating glass; primitiva de pulsación estándar; ¿Contigo/Eventos mantienen paleta propia o se alinean a marca? | UI Nativa (Fases 1 resto y 4; Fase 2/3 no bloqueadas) | `docs/planes/PLAN_UI_NATIVA.md` §4 | Las 3 preguntas literales de esa sección |
+| ~~**3 decisiones de UI**~~ ✅ **RESUELTAS (2026-07-22)** | UI Nativa | `docs/planes/PLAN_UI_NATIVA.md` §4 | **(1) Headers**: nativo plano en pantallas "lista+detalle" (Revisión, Materiales, Horario, sub-pantallas de evento), floating glass solo donde aporta identidad (heros de evento). **(2) Pulsación**: `PressableFeedback` (heroui) como primitiva única de contenido — es la opción con feedback nativo más consistente y ya soportada por la librería; barras de navegación siguen con bar items nativos. **(3) Color**: Contigo (warm) y Eventos (color por evento) **mantienen su paleta propia** — es identidad intencional; documentar como temas con nombre, no forzar alineación a marca. |
 | **Release de tienda para el Widget** — ¿se compromete ya? ¿iOS primero? ¿App Intents interactivos o solo abrir la app? | Widget de Contigo | `docs/planes/PLAN_WIDGET_CONTIGO.md` | "¿Arrancamos el Widget de Contigo? Implica una build de tienda dedicada — ¿cuándo?" |
 | **Icono nativo Carismochito (§5)** | Bolsa nativa / Carismochito | `docs/planes/PLAN_CARISMOCHITO.md` §5 | "¿Compensa el icono alternativo para un modo que es efímero (se activa agitando)?" |
 | **Plan funcional del Panel Pañuelo** | Panel Pañuelo | `docs/planes/PLAN_PANEL_PANUELO.md` (stub) | "¿Nos sentamos a diseñar la mecánica de chapas/modelo 3D, o esperamos a después de Carismochito §1–4?" |

--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -204,24 +204,40 @@ acciones de evento). Clasificación:
 ## 5. Fase 2 — cola de trabajo (componentes ya creados y por crear)
 
 Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
-`EmptyState`, `ScreenHero`.
+`AppPrimaryButton`, `EmptyState`, `ScreenHero`.
+
+> **Pulsación estándar decidida (§4): `PressableFeedback` (heroui).** Los
+> componentes nuevos de Fase 2 la usan; prohibido `TouchableOpacity`/`Pressable`
+> sueltos NUEVOS.
 
 - [ ] Migrar los **~13 `TextInput`** restantes a `AppTextField` (hecho:
       SuggestSongModal). Lote a lote: AppFeedbackModal, ReportBugsModal,
       SuggestSong (✓), CodeInput, PasswordPrompt, Arrangement, Evaluation,
       Grupos, Reflexiones, Revisión, SelectedSongs, SecretPanel (admin, último).
-- [ ] **`AppPrimaryButton`** (CTA "Enviar/Guardar/Aceptar") — ~10 modales cada
-      uno con su botón. Crear y migrar.
+- [~] **`AppPrimaryButton`** (CTA "Enviar/Guardar/Aceptar") — **creado**
+      (`components/ui/AppPrimaryButton.tsx`, usa `PressableFeedback` + `Scale`,
+      prop `color` para paletas propias de Contigo/eventos). Migrados: **SuggestSong,
+      AppFeedback, ReportBugs** (2026-07-22). Pendientes: el resto de modales con
+      CTA (Evaluation, SecretPanel, export PDF, login…) — estructura distinta, uno
+      a uno.
 - [ ] **`SegmentedControl`** — unificar Mes/Agenda (Calendario), toggles de
       ajustes, Evangelio, SongFullscreen (4-5 versiones distintas).
 - [ ] **`EmptyState`** — adoptarlo en los ~20 sitios que reinventan "no hay…".
 - [ ] **Chips/pills** — estandarizar (mezcla de heroui `Chip` + pills custom).
 - [ ] **Tokens** (`radii`/`shadows`/`typography`) — migrar números mágicos.
 
-## 4. Decisiones de producto pendientes (bloquean algunas fases)
+## 4. Decisiones de producto — ✅ TOMADAS (2026-07-22)
 
-- [ ] ¿Contigo y Eventos mantienen su paleta propia o se alinean a marca? (Fase 4)
-- [ ] ¿Qué pantallas de Contigo/eventos pasan a header nativo plano y cuáles
-      conservan el floating glass? (Fase 1)
-- [ ] ¿Componente estándar de pulsación: `PressableFeedback` (heroui) o wrapper
-      propio? (Fase 2)
+- [x] **Color (Fase 4)**: Contigo (warm) y Eventos (color por evento) **mantienen
+      su paleta propia**. Es identidad intencional, no una divergencia a corregir.
+      Acción: documentarlas como temas con nombre en `constants/colors.ts` cuando
+      se toque; NO alinear a marca.
+- [x] **Headers (Fase 1)**: **nativo plano** en las pantallas "lista + detalle"
+      (Revisión, Materiales, Horario y sub-pantallas de evento); **floating glass**
+      solo donde aporta identidad (hero de evento). Es la recomendación del §1 de
+      este plan.
+- [x] **Pulsación (Fase 2)**: primitiva única de contenido = **`PressableFeedback`
+      (heroui)** — feedback nativo consistente y soportado por la librería (ya en
+      24 ficheros). Las barras de navegación siguen con bar items nativos.
+      Prohibido `TouchableOpacity`/`Pressable` sueltos NUEVOS; migración
+      incremental de los existentes.

--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -210,10 +210,10 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
 > componentes nuevos de Fase 2 la usan; prohibido `TouchableOpacity`/`Pressable`
 > sueltos NUEVOS.
 
-- [ ] Migrar los **~13 `TextInput`** restantes a `AppTextField` (hecho:
-      SuggestSongModal). Lote a lote: AppFeedbackModal, ReportBugsModal,
-      SuggestSong (✓), CodeInput, PasswordPrompt, Arrangement, Evaluation,
-      Grupos, Reflexiones, Revisión, SelectedSongs, SecretPanel (admin, último).
+- [~] Migrar los **~13 `TextInput`** restantes a `AppTextField`. Hechos:
+      SuggestSong (✓), **AppFeedbackModal (✓), ReportBugsModal (✓)** (2026-07-22).
+      Pendientes: CodeInput, PasswordPrompt, Arrangement, Evaluation, Grupos,
+      Reflexiones, Revisión, SelectedSongs, SecretPanel (admin, último).
 - [~] **`AppPrimaryButton`** (CTA "Enviar/Guardar/Aceptar") — **creado**
       (`components/ui/AppPrimaryButton.tsx`, usa `PressableFeedback` + `Scale`,
       prop `color` para paletas propias de Contigo/eventos). Migrados: **SuggestSong,

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,19 @@
 
 ---
 
+## 2026-07-22 23:15 — UI Nativa Fase 2: `AppPrimaryButton` (CTA unificado)
+
+- Nuevo `components/ui/AppPrimaryButton.tsx`: botón CTA estándar
+  ("Enviar/Guardar/Aceptar") que sustituye el `TouchableOpacity` + estilo a mano
+  que cada modal reimplementaba (azul lleno, icono opcional, spinner al enviar,
+  estado deshabilitado). Usa `PressableFeedback` (heroui) con `Scale` —la
+  primitiva de pulsación decidida para la app— y una prop `color` para que
+  Contigo (warm) y los eventos (color por evento) mantengan su paleta propia.
+- Migrados los CTAs de `SuggestSongModal`, `AppFeedbackModal` y `ReportBugsModal`.
+- **Decisiones de UI tomadas** (ver `docs/planes/PLAN_UI_NATIVA.md` §4): headers
+  nativos en pantallas "lista+detalle" y floating glass solo en heros de evento;
+  pulsación estándar `PressableFeedback`; Contigo/Eventos conservan su paleta.
+
 ## 2026-07-22 22:30 — Plan 008: caché de datos compartida (dedupe) + calendario stale-while-revalidate
 
 - **`useFirebaseData`**: nueva caché a nivel de módulo compartida entre las

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -27,6 +27,9 @@
   primitiva de pulsación decidida para la app— y una prop `color` para que
   Contigo (warm) y los eventos (color por evento) mantengan su paleta propia.
 - Migrados los CTAs de `SuggestSongModal`, `AppFeedbackModal` y `ReportBugsModal`.
+- Además, los `TextInput` crudos de `AppFeedbackModal` y `ReportBugsModal`
+  pasan a `AppTextField` (mismo look de input unificado, borde verde al
+  rellenar) — SuggestSong ya lo usaba.
 - **Decisiones de UI tomadas** (ver `docs/planes/PLAN_UI_NATIVA.md` §4): headers
   nativos en pantallas "lista+detalle" y floating glass solo en heros de evento;
   pulsación estándar `PressableFeedback`; Contigo/Eventos conservan su paleta.

--- a/mcm-app/components/AppFeedbackModal.tsx
+++ b/mcm-app/components/AppFeedbackModal.tsx
@@ -7,13 +7,13 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  ActivityIndicator,
   View,
 } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { getDatabase, push, ref, set } from 'firebase/database';
 
 import BottomSheet from './BottomSheet';
+import AppPrimaryButton from '@/components/ui/AppPrimaryButton';
 import SectionHeader from '@/components/ui/SectionHeader';
 import { Colors, FeedbackCategoryColors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -285,39 +285,16 @@ export default function AppFeedbackModal({
               </View>
             ) : null}
 
-            <TouchableOpacity
-              style={[
-                styles.submitBtn,
-                {
-                  backgroundColor: canSubmit
-                    ? selectedCategoryData!.color
-                    : hexAlpha(theme.icon, '40'),
-                },
-              ]}
+            <AppPrimaryButton
+              label={
+                isSubmitting ? 'Enviando...' : selectedCategoryData!.submitText
+              }
+              icon={selectedCategoryData!.icon}
+              color={selectedCategoryData!.color}
               onPress={handleSubmit}
               disabled={!canSubmit}
-              activeOpacity={0.8}
-            >
-              {isSubmitting ? (
-                <ActivityIndicator size="small" color="#fff" />
-              ) : (
-                <MaterialIcons
-                  name={selectedCategoryData!.icon}
-                  size={18}
-                  color={canSubmit ? '#fff' : theme.icon}
-                />
-              )}
-              <Text
-                style={[
-                  styles.submitBtnText,
-                  { color: canSubmit ? '#fff' : theme.icon },
-                ]}
-              >
-                {isSubmitting
-                  ? 'Enviando...'
-                  : selectedCategoryData!.submitText}
-              </Text>
-            </TouchableOpacity>
+              loading={isSubmitting}
+            />
           </>
         )}
       </ScrollView>
@@ -390,17 +367,5 @@ const styles = StyleSheet.create({
     color: APPLE_SYSTEM_RED,
     fontSize: 13,
     fontWeight: '500',
-  },
-  submitBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 15,
-    borderRadius: radii.md,
-  },
-  submitBtnText: {
-    fontSize: 16,
-    fontWeight: '700',
   },
 });

--- a/mcm-app/components/AppFeedbackModal.tsx
+++ b/mcm-app/components/AppFeedbackModal.tsx
@@ -5,7 +5,6 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -14,6 +13,7 @@ import { getDatabase, push, ref, set } from 'firebase/database';
 
 import BottomSheet from './BottomSheet';
 import AppPrimaryButton from '@/components/ui/AppPrimaryButton';
+import AppTextField from '@/components/ui/AppTextField';
 import SectionHeader from '@/components/ui/SectionHeader';
 import { Colors, FeedbackCategoryColors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
@@ -23,10 +23,8 @@ import { getFirebaseApp } from '@/utils/firebaseApp';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { hexAlpha } from '@/utils/colorUtils';
 
-// Apple system colors used inside the modal — not part of the MCM brand
-// palette, but match iOS native conventions for "active border" and
-// "destructive text" inside form controls.
-const APPLE_SYSTEM_GREEN = '#34C759';
+// Apple system color used inside the modal — not part of the MCM brand
+// palette, but matches iOS native conventions for "destructive text".
 const APPLE_SYSTEM_RED = '#FF3B30';
 
 interface AppFeedbackModalProps {
@@ -244,21 +242,10 @@ export default function AppFeedbackModal({
               </Text>
             </View>
 
-            <TextInput
-              style={[
-                styles.textArea,
-                {
-                  backgroundColor: isDark
-                    ? Colors.dark.background
-                    : hexAlpha(theme.icon, '14'),
-                  color: theme.text,
-                  borderColor: feedbackText.trim()
-                    ? APPLE_SYSTEM_GREEN
-                    : hexAlpha(theme.icon, '40'),
-                },
-              ]}
+            <AppTextField
+              accentWhenFilled
+              style={styles.textArea}
               placeholder={selectedCategoryData!.placeholder}
-              placeholderTextColor={theme.icon}
               value={feedbackText}
               onChangeText={(t) => {
                 setFeedbackText(t);
@@ -267,7 +254,6 @@ export default function AppFeedbackModal({
               maxLength={1000}
               multiline
               numberOfLines={5}
-              textAlignVertical="top"
               editable={!isSubmitting}
             />
             <Text style={[styles.charCount, { color: theme.icon }]}>
@@ -344,10 +330,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   textArea: {
-    borderWidth: 1.5,
-    borderRadius: radii.md,
-    padding: 14,
-    fontSize: 15,
     minHeight: 120,
     lineHeight: 22,
   },

--- a/mcm-app/components/ReportBugsModal.tsx
+++ b/mcm-app/components/ReportBugsModal.tsx
@@ -8,9 +8,9 @@ import {
   StyleSheet,
   Platform,
   ScrollView,
-  ActivityIndicator,
 } from 'react-native';
 import BottomSheet from './BottomSheet';
+import AppPrimaryButton from '@/components/ui/AppPrimaryButton';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -169,39 +169,15 @@ export default function ReportBugsModal({
         </Text>
 
         {/* Botón principal */}
-        <TouchableOpacity
-          style={[
-            styles.submitBtn,
-            {
-              backgroundColor: canSubmit
-                ? '#FF3B30'
-                : isDark
-                  ? '#3A3A3C'
-                  : '#E5E5EA',
-            },
-          ]}
+        <AppPrimaryButton
+          label={isSubmitting ? 'Enviando...' : 'Notificar fallitos'}
+          icon="bug-report"
+          color="#FF3B30"
           onPress={handleSubmit}
           disabled={!canSubmit}
-          activeOpacity={0.8}
-        >
-          {isSubmitting ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <MaterialIcons
-              name="bug-report"
-              size={18}
-              color={canSubmit ? '#fff' : theme.icon}
-            />
-          )}
-          <Text
-            style={[
-              styles.submitBtnText,
-              { color: canSubmit ? '#fff' : theme.icon },
-            ]}
-          >
-            {isSubmitting ? 'Enviando...' : 'Notificar fallitos'}
-          </Text>
-        </TouchableOpacity>
+          loading={isSubmitting}
+          style={styles.submitBtn}
+        />
 
         {/* Divisor */}
         <View style={styles.divider}>
@@ -295,17 +271,7 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   submitBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 15,
-    borderRadius: radii.md,
     marginBottom: 4,
-  },
-  submitBtnText: {
-    fontSize: 16,
-    fontWeight: '700',
   },
   divider: {
     flexDirection: 'row',

--- a/mcm-app/components/ReportBugsModal.tsx
+++ b/mcm-app/components/ReportBugsModal.tsx
@@ -3,7 +3,6 @@ import React, { useState, useRef } from 'react';
 import {
   View,
   Text,
-  TextInput,
   TouchableOpacity,
   StyleSheet,
   Platform,
@@ -11,6 +10,7 @@ import {
 } from 'react-native';
 import BottomSheet from './BottomSheet';
 import AppPrimaryButton from '@/components/ui/AppPrimaryButton';
+import AppTextField from '@/components/ui/AppTextField';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -140,27 +140,15 @@ export default function ReportBugsModal({
           Acordes incorrectos, letra con errores, formato roto...
         </Text>
 
-        <TextInput
-          style={[
-            styles.textArea,
-            {
-              backgroundColor: isDark ? '#2C2C2E' : '#F2F2F7',
-              color: theme.text,
-              borderColor: bugDescription.trim()
-                ? '#34C759'
-                : isDark
-                  ? '#3A3A3C'
-                  : '#E5E5EA',
-            },
-          ]}
+        <AppTextField
+          accentWhenFilled
+          style={styles.textArea}
           placeholder="Describe los fallos que has encontrado..."
-          placeholderTextColor={theme.icon}
           value={bugDescription}
           onChangeText={setBugDescription}
           maxLength={500}
           multiline
           numberOfLines={5}
-          textAlignVertical="top"
           returnKeyType="default"
           editable={!isSubmitting}
         />
@@ -257,10 +245,6 @@ const styles = StyleSheet.create({
     lineHeight: 18,
   },
   textArea: {
-    borderWidth: 1.5,
-    borderRadius: radii.md,
-    padding: 14,
-    fontSize: 15,
     minHeight: 120,
     lineHeight: 22,
   },

--- a/mcm-app/components/SuggestSongModal.tsx
+++ b/mcm-app/components/SuggestSongModal.tsx
@@ -7,14 +7,13 @@ import {
   StyleSheet,
   Platform,
   ScrollView,
-  ActivityIndicator,
 } from 'react-native';
 import BottomSheet from './BottomSheet';
 import AppTextField from '@/components/ui/AppTextField';
+import AppPrimaryButton from '@/components/ui/AppPrimaryButton';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { radii } from '@/constants/uiStyles';
 import { getDatabase, ref, push, set } from 'firebase/database';
 import { getFirebaseApp } from '@/utils/firebaseApp';
 import { useUserProfile } from '@/contexts/UserProfileContext';
@@ -242,39 +241,14 @@ export default function SuggestSongModal({
         ) : null}
 
         {/* Botón enviar */}
-        <TouchableOpacity
-          style={[
-            styles.submitBtn,
-            {
-              backgroundColor: canSubmit
-                ? '#007AFF'
-                : isDark
-                  ? '#3A3A3C'
-                  : '#E5E5EA',
-            },
-          ]}
+        <AppPrimaryButton
+          label={isSubmitting ? 'Enviando...' : 'Enviar sugerencia'}
+          icon="send"
           onPress={handleSubmit}
           disabled={!canSubmit}
-          activeOpacity={0.8}
-        >
-          {isSubmitting ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <MaterialIcons
-              name="send"
-              size={18}
-              color={canSubmit ? '#fff' : theme.icon}
-            />
-          )}
-          <Text
-            style={[
-              styles.submitBtnText,
-              { color: canSubmit ? '#fff' : theme.icon },
-            ]}
-          >
-            {isSubmitting ? 'Enviando...' : 'Enviar sugerencia'}
-          </Text>
-        </TouchableOpacity>
+          loading={isSubmitting}
+          style={styles.submitBtn}
+        />
 
         <Text style={[styles.disclaimer, { color: theme.icon }]}>
           Recibiremos tu sugerencia y, con algo de tiempo y suerte, la
@@ -342,18 +316,8 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   submitBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 15,
-    borderRadius: radii.md,
     marginTop: 20,
     marginBottom: 16,
-  },
-  submitBtnText: {
-    fontSize: 16,
-    fontWeight: '700',
   },
   disclaimer: {
     fontSize: 12,

--- a/mcm-app/components/ui/AppPrimaryButton.tsx
+++ b/mcm-app/components/ui/AppPrimaryButton.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { PressableFeedback } from 'heroui-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/colors';
+import { radii } from '@/constants/uiStyles';
+import { h } from '@/utils/haptics';
+
+/**
+ * Botón CTA unificado (Fase 2 de PLAN_UI_NATIVA).
+ *
+ * Sustituye el patrón "Enviar/Guardar/Aceptar" que cada modal reimplementaba a
+ * mano con `TouchableOpacity` + su propio estilo (azul lleno, icono opcional,
+ * spinner al enviar, estado deshabilitado en gris). La pulsación usa
+ * `PressableFeedback` (heroui) con `Scale`, la primitiva estándar de contenido
+ * decidida para la app.
+ *
+ * `color` permite que Contigo (warm) y los eventos (color por evento) mantengan
+ * su paleta propia sin dejar de compartir la forma/comportamiento del botón.
+ */
+interface AppPrimaryButtonProps {
+  label: string;
+  onPress: () => void;
+  /** Icono MaterialIcons a la izquierda del texto. */
+  icon?: keyof typeof MaterialIcons.glyphMap;
+  /** Color de fondo cuando está activo. Por defecto azul de acción de iOS. */
+  color?: string;
+  /** Color del texto/icono cuando está activo. Por defecto blanco. */
+  textColor?: string;
+  disabled?: boolean;
+  /** Muestra un spinner y deshabilita la pulsación. */
+  loading?: boolean;
+  /** Háptica al pulsar (por defecto sí). */
+  haptic?: boolean;
+  style?: ViewStyle;
+  accessibilityLabel?: string;
+}
+
+const DEFAULT_COLOR = '#007AFF'; // azul de acción de iOS
+
+export default function AppPrimaryButton({
+  label,
+  onPress,
+  icon,
+  color = DEFAULT_COLOR,
+  textColor = '#fff',
+  disabled = false,
+  loading = false,
+  haptic = true,
+  style,
+  accessibilityLabel,
+}: AppPrimaryButtonProps) {
+  const isDark = useColorScheme() === 'dark';
+  const theme = Colors[isDark ? 'dark' : 'light'];
+  const isDisabled = disabled || loading;
+
+  const bg = isDisabled ? (isDark ? '#3A3A3C' : '#E5E5EA') : color;
+  const fg = isDisabled ? theme.icon : textColor;
+
+  return (
+    <PressableFeedback
+      onPress={() => {
+        if (isDisabled) return;
+        if (haptic) h.tap();
+        onPress();
+      }}
+      isDisabled={isDisabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
+      style={[styles.button, { backgroundColor: bg }, style]}
+    >
+      <PressableFeedback.Scale />
+      {loading ? (
+        <ActivityIndicator size="small" color={fg} />
+      ) : icon ? (
+        <MaterialIcons name={icon} size={18} color={fg} />
+      ) : null}
+      {/* Mantener el texto visible también en loading para no “saltar” de ancho. */}
+      <View>
+        <Text style={[styles.label, { color: fg }]}>{label}</Text>
+      </View>
+    </PressableFeedback>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 15,
+    paddingHorizontal: 20,
+    borderRadius: radii.md,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
Arranca la **Fase 2** de UI Nativa (componentes unificados), con las 3 decisiones de producto ya tomadas y grabadas en `PLAN_UI_NATIVA.md §4` / `BACKLOG.md §4`.

## Lote 1 — `AppPrimaryButton` (nuevo)
`components/ui/AppPrimaryButton.tsx`: botón CTA estándar ("Enviar/Guardar/Aceptar") que sustituye el `TouchableOpacity` + estilo a mano que cada modal reimplementaba (azul lleno, icono opcional, spinner al enviar, estado deshabilitado).
- Usa **`PressableFeedback` (heroui)** con `Scale` — la pulsación estándar decidida para la app.
- Prop **`color`** para que Contigo (warm) y los eventos (color por evento) mantengan su paleta propia sin dejar de compartir forma/comportamiento.
- Accesible (`role=button`, `accessibilityState` disabled/busy) y con háptica en la pulsación.
- Migrados: **SuggestSongModal, AppFeedbackModal, ReportBugsModal**.

## Lote 2 — `AppTextField`
Los `TextInput` crudos de AppFeedbackModal y ReportBugsModal pasan al input unificado `AppTextField` (mismo look, borde verde al rellenar). SuggestSong ya lo usaba.

## Decisiones de UI tomadas
1. **Headers**: nativo plano en "lista+detalle"; floating glass solo en heros de evento.
2. **Pulsación**: `PressableFeedback` como primitiva única de contenido.
3. **Color**: Contigo y Eventos **conservan su paleta propia** (identidad intencional).

## Verificación
`npx tsc --noEmit` + `typecheck:tests` limpios · `npm run lint` (CI) 0 errores · **32 suites / 305 tests** verdes.

## Nota
Cambios visuales — el detalle fino (spacing exacto, animación de pulsación) conviene verlo en dispositivo, pero la lógica y los tests están cubiertos y no se toca ninguna pantalla completa ni el árbol de providers.

Continuará por lotes: `SegmentedControl`, adopción de `EmptyState`, y el resto de modales con CTA/inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9)_