### PR TITLE
UI Nativa Fase 2 (cont.): AppTextField error/accentColor + EmptyState

### DIFF
--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -211,9 +211,13 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
 > sueltos NUEVOS.
 
 - [~] Migrar los **~13 `TextInput`** restantes a `AppTextField`. Hechos:
-      SuggestSong (✓), **AppFeedbackModal (✓), ReportBugsModal (✓)** (2026-07-22).
-      Pendientes: CodeInput, PasswordPrompt, Arrangement, Evaluation, Grupos,
-      Reflexiones, Revisión, SelectedSongs, SecretPanel (admin, último).
+      SuggestSong (✓), AppFeedbackModal (✓), ReportBugsModal (✓),
+      **PasswordPromptModal (✓), ArrangementInputModal (✓)** (2026-07-22).
+      `AppTextField` ganó props `error` (borde rojo) y `accentColor` (para
+      respetar paletas propias — Arrangement usa el rojo de marca).
+      Pendientes: CodeInput (solo el campo `name`; el de código es un input
+      OCULTO tipo OTP, NO migrar), Evaluation, Grupos, Reflexiones, Revisión,
+      SelectedSongs, SecretPanel (admin, último).
 - [~] **`AppPrimaryButton`** (CTA "Enviar/Guardar/Aceptar") — **creado**
       (`components/ui/AppPrimaryButton.tsx`, usa `PressableFeedback` + `Scale`,
       prop `color` para paletas propias de Contigo/eventos). Migrados: **SuggestSong,

--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -226,7 +226,11 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
       a uno.
 - [ ] **`SegmentedControl`** — unificar Mes/Agenda (Calendario), toggles de
       ajustes, Evangelio, SongFullscreen (4-5 versiones distintas).
-- [ ] **`EmptyState`** — adoptarlo en los ~20 sitios que reinventan "no hay…".
+- [~] **`EmptyState`** — adoptarlo en los ~20 sitios que reinventan "no hay…".
+      Hechos: Calendario, SelectedSongs, Home (previos) + **ReflexionesScreen,
+      notifications.tsx, NotificationsBottomSheet** (2026-07-22). Pendientes:
+      EventosPasados (texto pelado), ContactosScreen, CommandPalette, evangelio
+      "no se encontraron lecturas", SongList "no se encontraron canciones".
 - [ ] **Chips/pills** — estandarizar (mezcla de heroui `Chip` + pills custom).
 - [ ] **Tokens** (`radii`/`shadows`/`typography`) — migrar números mágicos.
 

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,15 @@
 
 ---
 
+## 2026-07-22 23:45 — UI Nativa Fase 2: más migraciones a `AppTextField`
+
+- `AppTextField` gana dos props: `error` (borde rojo, con prioridad sobre
+  foco/contenido) y `accentColor` (color de acento configurable, por defecto el
+  verde de iOS) — así las pantallas con paleta propia lo respetan.
+- Migrados a `AppTextField`: `PasswordPromptModal` (usa `error` para la
+  contraseña incorrecta) y `ArrangementInputModal` (usa `accentColor` con el
+  rojo de marca `#E15C62`).
+
 ## 2026-07-22 23:15 — UI Nativa Fase 2: `AppPrimaryButton` (CTA unificado)
 
 - Nuevo `components/ui/AppPrimaryButton.tsx`: botón CTA estándar

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,13 @@
 
 ---
 
+## 2026-07-22 23:55 — UI Nativa Fase 2: adoptar `EmptyState` en estados vacíos
+
+- Estados "no hay…" reinventados a mano migrados al componente canónico
+  `EmptyState`: `ReflexionesScreen` ("aún no hay reflexiones"),
+  `app/notifications.tsx` y `NotificationsBottomSheet` ("no hay notificaciones").
+  Mismo look de vacío unificado (icono en círculo tintado + título + subtítulo).
+
 ## 2026-07-22 23:45 — UI Nativa Fase 2: más migraciones a `AppTextField`
 
 - `AppTextField` gana dos props: `error` (borde rojo, con prioridad sobre

--- a/mcm-app/app/notifications.tsx
+++ b/mcm-app/app/notifications.tsx
@@ -21,6 +21,7 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
 import colors, { Colors } from '@/constants/colors';
+import EmptyState from '@/components/ui/EmptyState';
 import { hexAlpha } from '@/utils/colorUtils';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
@@ -610,17 +611,11 @@ export default function NotificationsScreen() {
           <Text style={styles.emptyText}>Cargando...</Text>
         </View>
       ) : allNotifications.length === 0 ? (
-        <View style={styles.emptyState}>
-          <MaterialIcons
-            name="notifications-none"
-            size={64}
-            color={Colors[scheme ?? 'light'].icon}
-          />
-          <Text style={styles.emptyTitle}>No hay notificaciones</Text>
-          <Text style={styles.emptyText}>
-            Aquí aparecerán tus notificaciones cuando las tengas.
-          </Text>
-        </View>
+        <EmptyState
+          icon="notifications-none"
+          title="No hay notificaciones"
+          subtitle="Aquí aparecerán tus notificaciones cuando las tengas."
+        />
       ) : (
         <FlatList
           data={allNotifications}

--- a/mcm-app/app/screens/ComunicaScreen.tsx
+++ b/mcm-app/app/screens/ComunicaScreen.tsx
@@ -152,6 +152,8 @@ export default function ComunicaScreen() {
             right: 0,
             bottom: bottomInset,
           }}
+          // @ts-expect-error `scrollIndicatorInsets` es un passthrough de iOS
+          // válido en runtime pero ausente de los tipos de react-native-webview.
           scrollIndicatorInsets={{ top: insets.top, bottom: bottomInset }}
           onNavigationStateChange={onNavStateChange}
           renderLoading={renderLoading}

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -20,6 +20,7 @@ import { Spinner, BottomSheet } from 'heroui-native';
 import { useToast } from '@/contexts/AppToastContext';
 import ContextMenuSheet from '@/components/ContextMenuSheet';
 import CelebrationBurst from '@/components/ui/CelebrationBurst';
+import EmptyState from '@/components/ui/EmptyState';
 import { useContextMenu } from '@/hooks/useContextMenu';
 import DateTimePicker, {
   DateTimePickerAndroid,
@@ -317,17 +318,12 @@ export default function ReflexionesScreen() {
           ]}
         >
           {sortedList.length === 0 ? (
-            <View style={styles.emptyState}>
-              <MaterialIcons
-                name="auto-stories"
-                size={40}
-                color={colors.success}
-              />
-              <Text style={styles.emptyTitle}>Aún no hay reflexiones</Text>
-              <Text style={styles.emptyText}>
-                Pulsa el botón + de arriba para compartir la primera.
-              </Text>
-            </View>
+            <EmptyState
+              icon="auto-stories"
+              title="Aún no hay reflexiones"
+              subtitle="Pulsa el botón + de arriba para compartir la primera."
+              accentColor={colors.success}
+            />
           ) : (
             sortedList.map((r, i) => {
               const color = pickCardColor(r.id);

--- a/mcm-app/components/ArrangementInputModal.tsx
+++ b/mcm-app/components/ArrangementInputModal.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import BottomSheet from './BottomSheet';
+import AppTextField from '@/components/ui/AppTextField';
 import { Colors } from '@/constants/colors';
 import { radii } from '@/constants/uiStyles';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -75,18 +76,12 @@ export default function ArrangementInputModal({
           </View>
         ) : null}
 
-        <TextInput
+        <AppTextField
           ref={inputRef}
-          style={[
-            styles.input,
-            {
-              backgroundColor: isDark ? '#2C2C2E' : '#F2F2F7',
-              color: theme.text,
-              borderColor: text.trim() ? '#E15C62' : theme.icon,
-            },
-          ]}
+          accentWhenFilled
+          accentColor="#E15C62"
+          style={styles.input}
           placeholder="Ej: Intro: solo guitarra (x2)"
-          placeholderTextColor={theme.icon}
           value={text}
           onChangeText={setText}
           multiline
@@ -169,12 +164,7 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
   },
   input: {
-    borderWidth: 1,
-    borderRadius: radii.sm,
-    padding: 12,
-    fontSize: 16,
     minHeight: 52,
-    textAlignVertical: 'top',
   },
   note: {
     fontSize: 12,

--- a/mcm-app/components/NotificationsBottomSheet.tsx
+++ b/mcm-app/components/NotificationsBottomSheet.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import colors, { Colors } from '@/constants/colors';
+import EmptyState from '@/components/ui/EmptyState';
 import { hexAlpha } from '@/utils/colorUtils';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import spacing from '@/constants/spacing';
@@ -284,19 +285,11 @@ export default function NotificationsBottomSheet({
               </Text>
             </View>
           ) : allNotifications.length === 0 ? (
-            <View style={sheetStyles.empty}>
-              <MaterialIcons
-                name="notifications-none"
-                size={64}
-                color={theme.icon}
-              />
-              <Text style={[sheetStyles.emptyTitle, { color: theme.text }]}>
-                No hay notificaciones
-              </Text>
-              <Text style={[sheetStyles.emptyText, { color: theme.icon }]}>
-                Aquí aparecerán tus notificaciones cuando las tengas.
-              </Text>
-            </View>
+            <EmptyState
+              icon="notifications-none"
+              title="No hay notificaciones"
+              subtitle="Aquí aparecerán tus notificaciones cuando las tengas."
+            />
           ) : (
             <FlatList
               data={allNotifications}

--- a/mcm-app/components/playlist/PasswordPromptModal.tsx
+++ b/mcm-app/components/playlist/PasswordPromptModal.tsx
@@ -11,11 +11,11 @@ import {
   View,
   Text,
   StyleSheet,
-  TextInput,
   TouchableOpacity,
   TouchableWithoutFeedback,
   Platform,
 } from 'react-native';
+import AppTextField from '@/components/ui/AppTextField';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { h } from '@/utils/haptics';
 
@@ -78,15 +78,15 @@ const PasswordPromptModal: React.FC<Props> = ({
               {description ? (
                 <Text style={styles.description}>{description}</Text>
               ) : null}
-              <TextInput
+              <AppTextField
                 value={password}
                 onChangeText={(t) => {
                   setPassword(t);
                   setError(false);
                 }}
                 placeholder="Contraseña"
-                placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
-                style={[styles.input, error && styles.inputError]}
+                error={error}
+                style={styles.input}
                 autoFocus
                 autoCapitalize="none"
                 autoCorrect={false}
@@ -162,18 +162,7 @@ const createStyles = (isDark: boolean) =>
       marginTop: 6,
     },
     input: {
-      borderWidth: 1,
-      borderColor: isDark ? '#3A3A3C' : '#D1D1D6',
-      borderRadius: 10,
-      paddingHorizontal: 12,
-      paddingVertical: Platform.OS === 'ios' ? 12 : 10,
-      fontSize: 15,
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
-      backgroundColor: isDark ? '#2C2C2E' : '#F2F2F7',
       marginTop: 14,
-    },
-    inputError: {
-      borderColor: '#FF453A',
     },
     errorText: {
       color: '#FF453A',

--- a/mcm-app/components/ui/AppTextField.tsx
+++ b/mcm-app/components/ui/AppTextField.tsx
@@ -14,15 +14,31 @@ import { radii } from '@/constants/uiStyles';
  * autoFocus, etc.), así que es un reemplazo directo.
  */
 interface AppTextFieldProps extends TextInputProps {
-  /** Borde verde cuando el campo tiene contenido (además de al enfocar). */
+  /** Borde de acento cuando el campo tiene contenido (además de al enfocar). */
   accentWhenFilled?: boolean;
+  /** Color de acento (foco/contenido). Por defecto verde "completado" de iOS.
+   *  Permite que pantallas con paleta propia (Contigo, eventos) lo respeten. */
+  accentColor?: string;
+  /** Borde rojo de error (tiene prioridad sobre foco/contenido). */
+  error?: boolean;
 }
 
 const ACCENT = '#34C759'; // verde "completado" de iOS
+const ERROR = '#FF453A'; // rojo de error de iOS
 
 const AppTextField = forwardRef<TextInput, AppTextFieldProps>(
   function AppTextField(
-    { style, accentWhenFilled, value, multiline, onFocus, onBlur, ...rest },
+    {
+      style,
+      accentWhenFilled,
+      accentColor = ACCENT,
+      error,
+      value,
+      multiline,
+      onFocus,
+      onBlur,
+      ...rest
+    },
     ref,
   ) {
     const isDark = useColorScheme() === 'dark';
@@ -32,7 +48,11 @@ const AppTextField = forwardRef<TextInput, AppTextFieldProps>(
     const bg = isDark ? '#2C2C2E' : '#F2F2F7';
     const neutralBorder = isDark ? '#3A3A3C' : '#E5E5EA';
     const filled = accentWhenFilled && !!(value && String(value).trim());
-    const borderColor = focused || filled ? ACCENT : neutralBorder;
+    const borderColor = error
+      ? ERROR
+      : focused || filled
+        ? accentColor
+        : neutralBorder;
 
     return (
       <TextInput


### PR DESCRIPTION
Continúa la Fase 2 de UI Nativa (dos lotes más sobre la PR #301).

## Lote 3 — `AppTextField` más capaz + 2 modales
- `AppTextField` gana **`error`** (borde rojo, prioritario) y **`accentColor`** (color de acento configurable, verde por defecto) → respeta paletas propias (decisión #3).
- **PasswordPromptModal** → `AppTextField` con `error` (contraseña incorrecta).
- **ArrangementInputModal** → `AppTextField` con `accentColor` = rojo de marca `#E15C62`.
- `CodeInputModal` se deja fuera a propósito: su campo de código es un **input oculto tipo OTP** que no debe unificarse.

## Lote 4 — Adoptar `EmptyState`
Estados "no hay…" reinventados a mano migrados al componente canónico `EmptyState` (icono en círculo tintado + título + subtítulo):
- **ReflexionesScreen** ("aún no hay reflexiones")
- **app/notifications.tsx** y **NotificationsBottomSheet** ("no hay notificaciones")

## Verificación
`npx tsc --noEmit` + `typecheck:tests` limpios · `npm run lint` (CI) 0 errores · **32 suites / 305 tests** verdes.

## Progreso Fase 2 (acumulado)
- Componentes: `AppPrimaryButton` (nuevo), `AppTextField` (+error/+accentColor).
- Migrados CTA: SuggestSong, AppFeedback, ReportBugs.
- Migrados input: SuggestSong, AppFeedback, ReportBugs, PasswordPrompt, Arrangement.
- Adoptado EmptyState: Reflexiones, notifications, NotificationsBottomSheet.
- Pendiente: `SegmentedControl`, resto de inputs/CTAs, más EmptyState, chips/pills, tokens.

Como antes: cambios visuales — el pulido fino conviene verlo en dispositivo, pero lógica y tests cubiertos y sin tocar providers ni pantallas completas de forma estructural.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9)_