### PR TITLE
UI Nativa Fase 2: EmptyState en Eventos pasados y Contactos

### DIFF
--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -227,10 +227,12 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
 - [ ] **`SegmentedControl`** — unificar Mes/Agenda (Calendario), toggles de
       ajustes, Evangelio, SongFullscreen (4-5 versiones distintas).
 - [~] **`EmptyState`** — adoptarlo en los ~20 sitios que reinventan "no hay…".
-      Hechos: Calendario, SelectedSongs, Home (previos) + **ReflexionesScreen,
-      notifications.tsx, NotificationsBottomSheet** (2026-07-22). Pendientes:
-      EventosPasados (texto pelado), ContactosScreen, CommandPalette, evangelio
-      "no se encontraron lecturas", SongList "no se encontraron canciones".
+      Hechos: Calendario, SelectedSongs, Home (previos) + ReflexionesScreen,
+      notifications.tsx, NotificationsBottomSheet, **EventosPasadosScreen,
+      ContactosScreen** (2026-07-22/23). Pendientes: evangelio "no se
+      encontraron lecturas", SongList "no se encontraron canciones". **NO** en
+      `CommandPalette` (dropdown compacto — el padding de EmptyState lo
+      desbordaría).
 - [ ] **Chips/pills** — estandarizar (mezcla de heroui `Chip` + pills custom).
 - [ ] **Tokens** (`radii`/`shadows`/`typography`) — migrar números mágicos.
 

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,14 @@
 
 ---
 
+## 2026-07-24 04:10 — UI Nativa Fase 2: más `EmptyState` (Eventos pasados, Contactos)
+
+- `EventosPasadosScreen` (texto pelado "todavía no hay eventos pasados") y el
+  vacío de búsqueda de `ContactosScreen` pasan al componente canónico
+  `EmptyState` (icono + título + subtítulo unificados). `CommandPalette` se
+  deja fuera a propósito: es un dropdown compacto y el padding de `EmptyState`
+  lo desbordaría.
+
 ## 2026-07-23 06:51 — Comunica (familias): navegación atrás/adelante en la web
 
 - Nuevo `components/ui/WebViewNavControls.tsx`: cápsula **glass flotante**

--- a/mcm-app/app/screens/ContactosScreen.tsx
+++ b/mcm-app/app/screens/ContactosScreen.tsx
@@ -21,6 +21,7 @@ import ContextMenuSheet from '@/components/ContextMenuSheet';
 import { useContextMenu } from '@/hooks/useContextMenu';
 import ScreenHero from '@/components/ui/ScreenHero';
 import ComingSoon from '@/components/ui/ComingSoon';
+import EmptyState from '@/components/ui/EmptyState';
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useCurrentEvent } from '@/hooks/useCurrentEvent';
 import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
@@ -291,12 +292,11 @@ export default function ContactosScreen() {
           renderItem={renderItem}
           ListEmptyComponent={
             query.trim().length >= 2 ? (
-              <View style={styles.emptyContainer}>
-                <MaterialIcons name="search-off" size={40} color="#999" />
-                <Text style={styles.emptyText}>
-                  No hay contactos que coincidan con &quot;{query}&quot;.
-                </Text>
-              </View>
+              <EmptyState
+                icon="search-off"
+                title="Sin coincidencias"
+                subtitle={`No hay contactos que coincidan con "${query}".`}
+              />
             ) : null
           }
           contentContainerStyle={styles.content}
@@ -446,16 +446,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       height: StyleSheet.hairlineWidth,
       backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)',
       marginLeft: 70,
-    },
-    emptyContainer: {
-      padding: 32,
-      alignItems: 'center',
-      gap: 8,
-    },
-    emptyText: {
-      fontSize: 15,
-      color: isDark ? '#A0A0A8' : '#6B6B70',
-      textAlign: 'center',
     },
   });
 };

--- a/mcm-app/app/screens/EventosPasadosScreen.tsx
+++ b/mcm-app/app/screens/EventosPasadosScreen.tsx
@@ -15,6 +15,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import EmptyState from '@/components/ui/EmptyState';
 import { hexAlpha } from '@/utils/colorUtils';
 import spacing from '@/constants/spacing';
 import { radii } from '@/constants/uiStyles';
@@ -50,7 +51,7 @@ export default function EventosPasadosScreen() {
         showsVerticalScrollIndicator={false}
       >
         {events.length === 0 ? (
-          <Text style={styles.empty}>Todavía no hay eventos pasados.</Text>
+          <EmptyState icon="history" title="Todavía no hay eventos pasados" />
         ) : (
           events.map((event) => (
             <PressableFeedback
@@ -126,7 +127,6 @@ export default function EventosPasadosScreen() {
 interface Styles {
   safeArea: ViewStyle;
   container: ViewStyle;
-  empty: TextStyle;
   card: ViewStyle;
   accentBar: ViewStyle;
   cardBody: ViewStyle;
@@ -143,12 +143,6 @@ const createStyles = (isDark: boolean) =>
     },
     container: {
       flex: 1,
-    },
-    empty: {
-      textAlign: 'center',
-      marginTop: spacing.xl,
-      color: isDark ? '#8E8E93' : '#6B7280',
-      fontSize: 15,
     },
     card: {
       borderRadius: radii.xl,


### PR DESCRIPTION
Sigue la Fase 2 de UI Nativa (adopción de `EmptyState`).

- **EventosPasadosScreen**: el texto pelado "Todavía no hay eventos pasados" pasa a `EmptyState` con icono `history`.
- **ContactosScreen**: el vacío de búsqueda ("no hay contactos que coincidan…") pasa a `EmptyState` con icono `search-off`.
- Se eliminan los estilos huérfanos que quedaban (`empty`, `emptyContainer`, `emptyText`).
- **CommandPalette** se deja fuera a propósito: es un dropdown compacto y el padding de `EmptyState` lo desbordaría.

## Verificación
`npx tsc --noEmit` + `typecheck:tests` limpios · `npm run lint` (CI) 0 errores · **32 suites / 305 tests** verdes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9)_