### PR TITLE
UI Nativa Fase 2: AppTextField en más formularios, EmptyState en Calendario

### DIFF
--- a/docs/planes/PLAN_UI_NATIVA.md
+++ b/docs/planes/PLAN_UI_NATIVA.md
@@ -212,12 +212,18 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
 
 - [~] Migrar los **~13 `TextInput`** restantes a `AppTextField`. Hechos:
       SuggestSong (✓), AppFeedbackModal (✓), ReportBugsModal (✓),
-      **PasswordPromptModal (✓), ArrangementInputModal (✓)** (2026-07-22).
-      `AppTextField` ganó props `error` (borde rojo) y `accentColor` (para
-      respetar paletas propias — Arrangement usa el rojo de marca).
-      Pendientes: CodeInput (solo el campo `name`; el de código es un input
-      OCULTO tipo OTP, NO migrar), Evaluation, Grupos, Reflexiones, Revisión,
-      SelectedSongs, SecretPanel (admin, último).
+      PasswordPromptModal (✓), ArrangementInputModal (✓) (2026-07-22),
+      **Evaluation (QuestionInput, texto libre), SelectedSongs (nombre de
+      fichero al exportar), Reflexiones (título/contenido/autor),
+      CodeInputModal (campo `name`), ExportPdfModal (título/fecha)**
+      (2026-07-24). `AppTextField` ganó props `error` (borde rojo) y
+      `accentColor` (para respetar paletas propias — Arrangement usa el rojo
+      de marca, PDF el rojo, Reflexiones el verde).
+      Pendientes: Revisión de Contigo (paleta warm propia — como Evangelio,
+      requiere verificación en dispositivo antes de tocar el color de fondo),
+      Grupos (`SearchBar` es un compound component deliberadamente custom, no
+      un `TextInput` simple — descartado), SecretPanel (panel admin, 16
+      campos, superficie grande — último).
 - [~] **`AppPrimaryButton`** (CTA "Enviar/Guardar/Aceptar") — **creado**
       (`components/ui/AppPrimaryButton.tsx`, usa `PressableFeedback` + `Scale`,
       prop `color` para paletas propias de Contigo/eventos). Migrados: **SuggestSong,
@@ -227,10 +233,14 @@ Ya creados (reutilizar): `GlassActionGroup`, `AppIconButton`, `AppTextField`,
 - [ ] **`SegmentedControl`** — unificar Mes/Agenda (Calendario), toggles de
       ajustes, Evangelio, SongFullscreen (4-5 versiones distintas).
 - [~] **`EmptyState`** — adoptarlo en los ~20 sitios que reinventan "no hay…".
-      Hechos: Calendario, SelectedSongs, Home (previos) + ReflexionesScreen,
-      notifications.tsx, NotificationsBottomSheet, **EventosPasadosScreen,
-      ContactosScreen** (2026-07-22/23). Pendientes: evangelio "no se
-      encontraron lecturas", SongList "no se encontraron canciones". **NO** en
+      Hechos: SelectedSongs, Home (previos) + ReflexionesScreen,
+      notifications.tsx, NotificationsBottomSheet, EventosPasadosScreen,
+      ContactosScreen (2026-07-22/23), **Calendario (día seleccionado +
+      vista agenda, con icono dinámico según filtros)** (2026-07-24).
+      Pendientes: evangelio "no se encontraron lecturas" (paleta warm de
+      Contigo — requiere verificación en dispositivo), SongList "no se
+      encontraron canciones" (es un estado de ERROR en rojo con diagnóstico,
+      no un vacío neutro — descartado, no migrar). **NO** en
       `CommandPalette` (dropdown compacto — el padding de EmptyState lo
       desbordaría).
 - [ ] **Chips/pills** — estandarizar (mezcla de heroui `Chip` + pills custom).

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,28 @@
 
 ---
 
+## 2026-07-24 18:42 — UI Nativa Fase 2: `AppTextField` en más formularios + `EmptyState` en Calendario
+
+- Migrados a `AppTextField`: pregunta de texto libre del wizard de encuestas
+  (`QuestionInput`), nombre de fichero al exportar playlist
+  (`SelectedSongsScreen`), formulario de "Compartiendo" en Reflexiones
+  (título/contenido/autor), nombre de sesión al subir/cambiar código
+  (`CodeInputModal`) y título/fecha del modal de exportar PDF
+  (`ExportPdfModal`). Cada campo respeta su acento existente (verde de
+  Reflexiones, azul de playlists, rojo de PDF) vía `accentColor`.
+- Descartados a propósito en esta pasada: el input oculto de dígitos de
+  `CodeInputModal` (hack de opacidad casi nula para el UI de celdas — no es
+  un campo visible), el `TextInput` de solo-selección de
+  `HighlightableReading` (no es un formulario, es un truco de
+  selección/resaltado de texto de lectura) y los formularios de Contigo
+  (`revision.tsx`) que usan la paleta cálida propia — se dejan para cuando
+  se pueda verificar en dispositivo, igual que `evangelio.tsx` en el lote
+  anterior. `SecretPanelModal` (panel de depuración, 16 campos) se deja
+  fuera por ser una superficie grande sin verificar en dispositivo.
+- `EmptyState` adoptado en el tab Calendario: "Sin eventos" del día
+  seleccionado y "Sin eventos este mes" / "Todos los calendarios ocultos"
+  de la vista agenda.
+
 ## 2026-07-24 04:10 — UI Nativa Fase 2: más `EmptyState` (Eventos pasados, Contactos)
 
 - `EventosPasadosScreen` (texto pelado "todavía no hay eventos pasados") y el

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -36,6 +36,7 @@ import { h } from '@/utils/haptics';
 import { localISO } from '@/utils/localDate';
 import CalendarSubscribeBottomSheet from '@/components/CalendarSubscribeBottomSheet';
 import EventDetailsBottomSheet from '@/components/EventDetailsBottomSheet';
+import EmptyState from '@/components/ui/EmptyState';
 
 LocaleConfig.locales['es'] = {
   monthNames: [
@@ -596,17 +597,11 @@ export function CalendarScreen() {
                       renderEventCard(ev, i, selectedDate < todayStr),
                     )
                   ) : (
-                    <View style={styles.emptyState}>
-                      <MaterialIcons
-                        name="event-available"
-                        size={40}
-                        color={isDark ? Colors.dark.card : '#D1D1D6'}
-                      />
-                      <Text style={styles.emptyText}>Sin eventos</Text>
-                      <Text style={styles.emptySubtext}>
-                        No hay eventos programados para este día
-                      </Text>
-                    </View>
+                    <EmptyState
+                      icon="event-available"
+                      title="Sin eventos"
+                      subtitle="No hay eventos programados para este día"
+                    />
                   )}
                 </View>
               </View>
@@ -713,28 +708,19 @@ export function CalendarScreen() {
                 return renderEventCard(item, 0, isPast);
               }}
               ListEmptyComponent={
-                <View style={styles.agendaEmptyState}>
-                  <MaterialIcons
-                    name={allCalendarsHidden ? 'visibility-off' : 'event-busy'}
-                    size={44}
-                    color={isDark ? '#48484A' : '#C7C7CC'}
-                  />
-                  <Text style={[styles.emptyText, { marginTop: 12 }]}>
-                    {allCalendarsHidden
+                <EmptyState
+                  icon={allCalendarsHidden ? 'visibility-off' : 'event-busy'}
+                  title={
+                    allCalendarsHidden
                       ? 'Todos los calendarios ocultos'
-                      : 'Sin eventos este mes'}
-                  </Text>
-                  <Text
-                    style={[
-                      styles.emptySubtext,
-                      { textAlign: 'center', marginTop: 4 },
-                    ]}
-                  >
-                    {allCalendarsHidden
+                      : 'Sin eventos este mes'
+                  }
+                  subtitle={
+                    allCalendarsHidden
                       ? 'Activa algún calendario desde los filtros de arriba'
-                      : 'No hay eventos programados para ' + monthLabel}
-                  </Text>
-                </View>
+                      : 'No hay eventos programados para ' + monthLabel
+                  }
+                />
               }
             />
           </View>
@@ -1104,36 +1090,12 @@ const createStyles = (scheme: 'light' | 'dark') => {
       color: '#8E8E93',
     },
 
-    // Empty state
-    emptyState: {
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingVertical: 40,
-      gap: 8,
-    },
-    emptyText: {
-      fontSize: 17,
-      fontWeight: '600',
-      color: isDark ? '#636366' : '#AEAEB2',
-    },
-    emptySubtext: {
-      fontSize: 14,
-      color: isDark ? '#48484A' : '#C7C7CC',
-    },
-
     // Agenda container — flex: 1 para que el SectionList crezca y los chips no
     agendaContainer: {
       flex: 1,
     },
     agendaList: {
       flex: 1,
-    },
-    agendaEmptyState: {
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingVertical: 60,
-      paddingHorizontal: 32,
-      gap: 4,
     },
 
     // Agenda view

--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -8,7 +8,6 @@ import {
   Share,
   Text,
   Pressable,
-  TextInput,
   Modal,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
@@ -21,6 +20,7 @@ import { useToast } from '@/contexts/AppToastContext';
 import ContextMenuSheet from '@/components/ContextMenuSheet';
 import CelebrationBurst from '@/components/ui/CelebrationBurst';
 import EmptyState from '@/components/ui/EmptyState';
+import AppTextField from '@/components/ui/AppTextField';
 import { useContextMenu } from '@/hooks/useContextMenu';
 import DateTimePicker, {
   DateTimePickerAndroid,
@@ -444,25 +444,24 @@ export default function ReflexionesScreen() {
 
               <View style={styles.field}>
                 <Text style={styles.inputLabel}>Título (opcional)</Text>
-                <TextInput
+                <AppTextField
                   value={titulo}
                   onChangeText={setTitulo}
                   placeholder="Un título breve"
-                  placeholderTextColor={theme.icon}
-                  style={styles.input}
+                  accentColor={colors.success}
+                  accentWhenFilled
                 />
               </View>
 
               <View style={styles.field}>
                 <Text style={styles.inputLabel}>Compartiendo…</Text>
-                <TextInput
+                <AppTextField
                   value={contenido}
                   onChangeText={setContenido}
                   placeholder="Escribe aquí lo que quieras"
-                  placeholderTextColor={theme.icon}
                   multiline
-                  textAlignVertical="top"
-                  style={[styles.input, styles.textArea]}
+                  accentColor={colors.success}
+                  accentWhenFilled
                 />
               </View>
 
@@ -489,12 +488,12 @@ export default function ReflexionesScreen() {
                 <Text style={styles.inputLabel}>
                   ¿Quién la envía? (opcional)
                 </Text>
-                <TextInput
+                <AppTextField
                   value={autor}
                   onChangeText={setAutor}
                   placeholder="Cómo quieres firmar"
-                  placeholderTextColor={theme.icon}
-                  style={styles.input}
+                  accentColor={colors.success}
+                  accentWhenFilled
                 />
               </View>
 
@@ -709,17 +708,6 @@ const createStyles = (scheme: 'light' | 'dark' | null) => {
       letterSpacing: 0.2,
       marginBottom: 6,
     },
-    input: {
-      borderWidth: 1,
-      borderColor: scheme === 'dark' ? '#48484A' : '#D8DCC8',
-      borderRadius: 12,
-      paddingHorizontal: 14,
-      paddingVertical: 12,
-      fontSize: 16,
-      color: theme.text,
-      backgroundColor: scheme === 'dark' ? '#2C2C2E' : '#fff',
-    },
-    textArea: { minHeight: 120, paddingTop: 12 },
     dateField: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -15,11 +15,11 @@ import {
   Platform,
   Share,
   Modal,
-  TextInput,
   TouchableOpacity,
   TouchableWithoutFeedback,
 } from 'react-native';
 import { PressableFeedback } from 'heroui-native';
+import AppTextField from '@/components/ui/AppTextField';
 import { useToast } from '@/contexts/AppToastContext';
 import { extractSongMedia } from '@/types/songMedia';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -1692,11 +1692,10 @@ const SelectedSongsScreen: React.FC = () => {
                 <Text style={styles.modalDescription}>
                   Elige un nombre para tu archivo
                 </Text>
-                <TextInput
+                <AppTextField
                   value={exportFileName}
                   onChangeText={setExportFileName}
                   placeholder="Playlist 7-ago"
-                  placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
                   autoFocus
                   selectTextOnFocus
                   style={styles.modalInput}
@@ -1959,15 +1958,7 @@ const createStyles = (
       marginBottom: 14,
     },
     modalInput: {
-      borderWidth: 1,
-      borderColor: isDark ? '#3A3A3C' : '#D1D1D6',
-      borderRadius: radii.md,
-      paddingVertical: 12,
-      paddingHorizontal: 14,
-      fontSize: 16,
       marginBottom: 8,
-      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
     },
     modalNote: {
       fontSize: 12,

--- a/mcm-app/components/evaluation/QuestionInput.tsx
+++ b/mcm-app/components/evaluation/QuestionInput.tsx
@@ -1,5 +1,6 @@
-import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
+import AppTextField from '@/components/ui/AppTextField';
 import StarRating from '@/components/StarRating';
 import { Colors } from '@/constants/colors';
 import { hexAlpha } from '@/utils/colorUtils';
@@ -47,25 +48,16 @@ export default function QuestionInput({
       )}
 
       {question.type === 'text' && (
-        <TextInput
+        <AppTextField
           value={typeof value === 'string' ? value : ''}
           onChangeText={(t) => onAnswer(question.id, t)}
           placeholder={question.placeholder}
-          placeholderTextColor={theme.icon}
           multiline
-          textAlignVertical="top"
           maxLength={1000}
           autoFocus
-          style={[
-            qStyles.input,
-            {
-              color: theme.text,
-              backgroundColor: isDark ? '#2C2C2E' : '#fff',
-              borderColor: String(value ?? '').trim()
-                ? hexAlpha(accent, '90')
-                : hexAlpha(theme.icon, '35'),
-            },
-          ]}
+          accentWhenFilled
+          accentColor={accent}
+          style={qStyles.input}
         />
       )}
 

--- a/mcm-app/components/playlist/CodeInputModal.tsx
+++ b/mcm-app/components/playlist/CodeInputModal.tsx
@@ -23,6 +23,7 @@ import {
   TextInput,
 } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import AppTextField from '@/components/ui/AppTextField';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import {
   CODE_LENGTH,
@@ -189,13 +190,13 @@ const CodeInputModal: React.FC<Props> = ({
         {copy.askForName && (
           <View style={styles.nameRow}>
             <Text style={styles.inputLabel}>Nombre</Text>
-            <TextInput
+            <AppTextField
               value={name}
               onChangeText={setName}
               placeholder="Ej. Eucaristía domingo 7 abril 2031"
-              placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
-              style={styles.nameInput}
               editable={!submitting}
+              accentColor={isDark ? '#7AB3FF' : '#253883'}
+              accentWhenFilled
             />
           </View>
         )}
@@ -328,16 +329,6 @@ const createStyles = (isDark: boolean) =>
       marginBottom: 6,
       textTransform: 'uppercase',
       letterSpacing: 0.5,
-    },
-    nameInput: {
-      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
-      borderRadius: radii.md,
-      paddingHorizontal: 16,
-      paddingVertical: 14,
-      fontSize: 16,
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
-      borderWidth: 1.5,
-      borderColor: isDark ? '#48484A' : '#D1D1D6',
     },
     hiddenInput: {
       position: 'absolute',

--- a/mcm-app/components/playlist/ExportPdfModal.tsx
+++ b/mcm-app/components/playlist/ExportPdfModal.tsx
@@ -24,13 +24,13 @@ import {
   View,
   Text,
   StyleSheet,
-  TextInput,
   TouchableOpacity,
   TouchableWithoutFeedback,
   Platform,
   ActivityIndicator,
 } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import AppTextField from '@/components/ui/AppTextField';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { h } from '@/utils/haptics';
 
@@ -185,25 +185,27 @@ const ExportPdfModal: React.FC<Props> = ({
               </Text>
 
               <Text style={styles.label}>Título del PDF</Text>
-              <TextInput
+              <AppTextField
                 value={name}
                 onChangeText={setName}
                 placeholder="Mi playlist"
-                placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
                 style={styles.input}
                 selectTextOnFocus
                 returnKeyType="done"
+                accentColor={isDark ? '#FF8A80' : '#C62828'}
+                accentWhenFilled
               />
 
               <Text style={styles.label}>Fecha en la portada</Text>
-              <TextInput
+              <AppTextField
                 value={printedDate}
                 onChangeText={setPrintedDate}
                 placeholder="Déjalo vacío para no imprimir fecha"
-                placeholderTextColor={isDark ? '#636366' : '#A0A0A8'}
                 style={styles.input}
                 selectTextOnFocus
                 returnKeyType="done"
+                accentColor={isDark ? '#FF8A80' : '#C62828'}
+                accentWhenFilled
               />
 
               <View style={styles.row}>
@@ -348,14 +350,6 @@ const createStyles = (isDark: boolean) =>
       marginTop: 4,
     },
     input: {
-      borderWidth: 1,
-      borderColor: isDark ? '#3A3A3C' : '#D1D1D6',
-      borderRadius: 10,
-      paddingHorizontal: 12,
-      paddingVertical: Platform.OS === 'ios' ? 12 : 10,
-      fontSize: 15,
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
-      backgroundColor: isDark ? '#2C2C2E' : '#F2F2F7',
       marginBottom: 14,
     },
     row: {


### PR DESCRIPTION
## Summary
- Migra a `AppTextField`: `QuestionInput` (texto libre de encuestas), nombre de fichero al exportar playlist (`SelectedSongsScreen`), formulario "Compartiendo" de Reflexiones (título/contenido/autor), campo `name` de `CodeInputModal` y título/fecha de `ExportPdfModal` — cada uno con su `accentColor` propio (verde Reflexiones, azul playlists, rojo PDF).
- Adopta `EmptyState` en el tab Calendario: "Sin eventos" del día seleccionado y "Sin eventos este mes" / "Todos los calendarios ocultos" de la vista agenda (icono dinámico según filtros).
- Descarta a propósito en esta pasada: el input oculto tipo OTP de `CodeInputModal`, el `TextInput` de solo-selección de `HighlightableReading`, los formularios de Contigo (`revision.tsx`, paleta warm propia — pendiente de verificación en dispositivo, igual que `evangelio.tsx`) y `SecretPanelModal` (panel admin de 16 campos, superficie grande sin verificar).
- Actualiza `docs/planes/PLAN_UI_NATIVA.md` §5 con el estado de la cola de Fase 2.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run typecheck:tests`
- [x] `npx jest --ci` (305/305 tests)
- [x] `npm run lint` (0 errores, solo warnings `max-lines` preexistentes)

Claude-Session: https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVqvN3Pyfx56f1XJ9nXQA9)_