### PR TITLE
REVISAR ⚠️ Cambio del NativeTabs - Mirar con calma

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,42 @@
 
 ---
 
+## 2026-07-26 22:15 — Barra de pestañas: píldora flotante glass unificada (expo-glass-tabs)
+
+- **Experimento / prueba en producción**: sustituye la implementación dual del
+  tab bar (`NativeTabs` en iOS / `Tabs` clásico en Android-Web) por una única
+  píldora flotante liquid-glass (librería `expo-glass-tabs`) que se **encoge y
+  oculta las etiquetas al hacer scroll** — igual en las tres plataformas. En
+  iOS esto cambia el tab bar nativo real (Liquid Glass del sistema) por una
+  recreación en JS; a cambio gana la animación de minimizado, que el
+  `NativeTabs` no ofrecía.
+- Nueva dependencia `expo-glass-tabs` (0.1.1) — **sin código nativo propio**:
+  se apoya en `expo-blur`/`expo-glass-effect`/`react-native-reanimated`/
+  `react-native-gesture-handler`, ya instalados. **No requiere build de
+  tienda ni `[skip-ota]`**, se puede publicar por OTA normal.
+  - `app/(tabs)/_layout.tsx`: reescrito sobre las primitivas headless
+    `Tabs`/`TabList`/`TabSlot`/`TabTrigger` de `expo-router/ui`. Sigue
+    limitando la píldora a 5 tabs visibles (`splitTabsForIOS`, reutilizado
+    ahora en todas las plataformas); el resto se registra en un `TabList`
+    oculto para que siga siendo navegable (`router.navigate`) aunque no
+    tenga botón visible. Header propio por tab (color + título) ya que la
+    barra headless no ofrece header nativo como el `Tabs` clásico.
+  - `app/screens/MasHomeScreen.tsx`: la lógica de "tabs que no caben van como
+    tarjetas" ya no es exclusiva de iOS — aplica en todas las plataformas al
+    compartir el mismo límite de 5.
+  - `app/(tabs)/index.tsx`, `calendario.tsx`, `fotos.tsx`: scroll principal
+    enganchado a `useMinimizeOnScroll()` (efecto de encogerse); padding
+    inferior que antes sólo se aplicaba en iOS (barra flotante) ahora es
+    universal (la píldora flota sobre el contenido en todas partes).
+  - Pendiente/no cubierto en esta pasada: el resto de pantallas internas
+    (Contigo, Cantoral, Más y sus subpantallas) no llevan aún el hook de
+    scroll ni el padding ajustado — su contenido puede quedar parcialmente
+    tapado por la píldora en listas largas.
+- Verificado en este entorno: `tsc --noEmit`, `lint` y suite de tests (305)
+  en verde; capturas con Playwright en web confirman el render (fallback
+  sólido, sin liquid glass real ahí) y el minimizado al hacer scroll.
+  **Sin probar en iOS/Android reales todavía.**
+
 ## 2026-07-26 11:20 — Comunica: cápsula atrás/adelante legible en oscuro + tema hacia la web
 
 - **Fix (modo oscuro)**: la cápsula atrás/adelante era ilegible. `GlassSurface`

--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -1,222 +1,193 @@
-// app/(tabs)/_layout.tsx - Hybrid Tabs Implementation
-// iOS: NativeTabs for liquid glass compatibility
-// Android/Web: Traditional Tabs for better functionality
+// app/(tabs)/_layout.tsx - Unified glass tab bar (expo-glass-tabs) for all
+// platforms. Replaces the previous NativeTabs (iOS) / classic Tabs
+// (Android/Web) split with a single floating, liquid-glass pill that
+// minimizes on scroll everywhere.
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import { useRouter, usePathname } from 'expo-router';
+import { Tabs, TabList, TabSlot, TabTrigger } from 'expo-router/ui';
+import {
+  GlassTabBar,
+  GlassTabButton,
+  TabBarMinimizeProvider,
+  renderFadingTabScreen,
+  type GlassTabItem,
+} from 'expo-glass-tabs';
+import { SymbolView } from 'expo-symbols';
+import { MaterialIcons } from '@expo/vector-icons';
+import { StatusBar } from 'expo-status-bar';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
-import { StatusBar } from 'expo-status-bar';
-
-// Import iOS-specific NativeTabs
-import { NativeTabs } from 'expo-router/unstable-native-tabs';
-import { MaterialIcons } from '@expo/vector-icons';
-
-// Import Android/Web-specific Traditional Tabs
-import { Tabs } from 'expo-router';
-import {
-  ThemeProvider,
-  DarkTheme,
-  DefaultTheme,
-} from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Colors } from '@/constants/colors';
 import { hexAlpha } from '@/utils/colorUtils';
-import { HapticTab } from '@/components/HapticTab';
-import { TABS_CONFIG, splitTabsForIOS } from '@/constants/tabsCatalog';
+import {
+  TABS_CONFIG,
+  splitTabsForIOS,
+  type TabConfig,
+} from '@/constants/tabsCatalog';
 import { useCarismochito } from '@/contexts/CarismochitoContext';
 
-/* Verdes del modo carismochito para teñir la barra de pestañas. */
-// Modo OSCURO: fondo verde casi negro + verdes claros para contraste.
-const CARISMO_TABBAR_BG = '#06210F';
-const CARISMO_TABBAR_ACTIVE = '#9DE86B';
-const CARISMO_TABBAR_INACTIVE = '#4E8C5F';
-// Modo CLARO: el fondo se queda blanco (como el tema claro normal) y sólo se
-// tiñen los iconos de verde — un verde vivo para el activo y uno apagado para
-// los inactivos, ambos con buen contraste sobre blanco.
-const CARISMO_TABBAR_BG_LIGHT = '#FFFFFF';
-const CARISMO_TABBAR_ACTIVE_LIGHT = '#1B9E4B';
-const CARISMO_TABBAR_INACTIVE_LIGHT = '#6FA77E';
-// En iOS el tinte va sobre la barra translúcida/clara (liquid glass): usamos
-// un verde más oscuro para que iconos y texto tengan buen contraste.
-const CARISMO_TABBAR_TINT_IOS = '#1B9E4B';
+/* Verdes del modo carismochito para teñir la píldora de pestañas. */
+const CARISMO_ACTIVE_DARK = '#9DE86B';
+const CARISMO_INACTIVE_DARK = '#4E8C5F';
+const CARISMO_BG_DARK = '#06210F';
+const CARISMO_ACTIVE_LIGHT = '#1B9E4B';
+const CARISMO_INACTIVE_LIGHT = '#6FA77E';
+const CARISMO_BG_LIGHT = '#FFFFFF';
 
-// ============================================================================
-// iOS NativeTabs Component
-// ============================================================================
-// iOS sólo muestra 5 tabs antes de generar un "More" automático del sistema.
-// Limitamos a 5 triggers (4 prioritarios + "mas" como último) y los demás se
-// muestran como tarjetas dentro de MasHomeScreen. Las rutas sin trigger siguen
-// siendo navegables programáticamente (expo-router las mantiene en el state).
-function IOSNativeTabsLayout() {
-  const resolved = useResolvedProfileConfig();
-  const visibleTabs = new Set(resolved.tabs);
-  const { mainTabs } = splitTabsForIOS(visibleTabs);
-  // Modo carismochito: tiñe iconos + labels de verde. NOTA: en iOS sólo
-  // tocamos `tintColor`/`labelStyle` (fiables). El `backgroundColor` de la
-  // barra NO es fiable en iOS 26+ (liquid glass adapta el fondo solo y lo
-  // ignora — bug expo#41360), por eso el efecto de fondo verde lo da el
-  // overlay (resplandor + mascota) en `CarismochitoOverlay`.
-  const { isActive: carismoActive } = useCarismochito();
+const HEADER_HEIGHT = 44;
 
-  return (
-    // En iOS ≤18 la barra nativa se vuelve TRANSPARENTE al llegar al final del
-    // scroll o cuando el contenido es una View estática (no scrollea por
-    // debajo). Eso dejaba los iconos flotando sobre el contenido y casi
-    // ilegibles. `disableTransparentOnScrollEdge` desactiva ese comportamiento
-    // (mantiene el fondo en el borde) y `blurEffect="systemChromeMaterial"` le
-    // da el material translúcido del tab bar nativo, adaptado al tema. En
-    // iOS 26+ el sistema usa liquid glass y ambos se ignoran (ahí ya se veía
-    // bien).
-    <NativeTabs
-      disableTransparentOnScrollEdge
-      blurEffect="systemChromeMaterial"
-      {...(carismoActive && {
-        tintColor: CARISMO_TABBAR_TINT_IOS,
-        labelStyle: { color: CARISMO_TABBAR_TINT_IOS },
-      })}
-    >
-      {mainTabs.map((tab) => (
-        // disablePopToTop + disableScrollToTop son CRÍTICOS: sin ellos, en
-        // iOS el UITabBarController nativo llama popToRootViewController
-        // sobre el UINavigationController de `createNativeStackNavigator`
-        // al re-tappear el mismo tab — bypasea React Navigation y deja JS y
-        // nativo desincronizados → la pantalla queda congelada. Con estas
-        // props deshabilitamos el comportamiento nativo y replicamos la UX
-        // (pop a la raíz al re-tap) desde JS de forma segura.
-        <NativeTabs.Trigger
-          key={tab.name}
-          name={tab.name}
-          disablePopToTop
-          disableScrollToTop
-        >
-          <NativeTabs.Trigger.Label>{tab.label}</NativeTabs.Trigger.Label>
-          <NativeTabs.Trigger.Icon sf={tab.iosIcon as any} />
-        </NativeTabs.Trigger>
-      ))}
-    </NativeTabs>
-  );
+type GlassTab = GlassTabItem & { href: string };
+
+function tabHref(name: string): string {
+  return name === 'index' ? '/' : `/${name}`;
 }
 
-// ============================================================================
-// Android/Web Traditional Tabs Component
-// ============================================================================
-function AndroidWebTabsLayout() {
-  const scheme = useColorScheme();
-  const theme = scheme === 'dark' ? DarkTheme : DefaultTheme;
-  // En web (sobre todo en PWA standalone iOS) reservamos espacio para la status bar
-  // del sistema usando el safe-area-inset top. En navegador normal este valor es 0.
+/** SF Symbol en iOS (a través de expo-symbols), MaterialIcons en Android/Web
+ * — `expo-glass-tabs` sólo sabe pintar SF Symbols de fábrica y no existen
+ * fuera de iOS. */
+function toGlassItem(tab: TabConfig): GlassTab {
+  return {
+    name: tab.name,
+    href: tabHref(tab.name),
+    label: tab.label,
+    renderIcon: ({ tint, size }) =>
+      Platform.OS === 'ios' ? (
+        <SymbolView
+          name={tab.iosIcon.selected as any}
+          tintColor={tint}
+          size={size}
+          weight="semibold"
+        />
+      ) : (
+        <MaterialIcons name={tab.androidIcon} color={tint} size={size} />
+      ),
+  };
+}
+
+/** Cabecera propia por tab (color + título) — la píldora flotante es
+ * headless y no ofrece header nativo como el `Tabs` clásico de antes. */
+function TabTopHeader({ tab }: { tab?: TabConfig }) {
   const insets = useSafeAreaInsets();
-  const webStatusBarHeight = Platform.OS === 'web' ? insets.top : undefined;
-  // En Android (Expo 55 va edge-to-edge: la app dibuja DETRÁS de la barra de
-  // navegación del sistema), hay que reservar `insets.bottom` para que la tab
-  // bar no quede tapada por la barra de gestos/3 botones. En móviles que la
-  // ocultan, `insets.bottom` es 0 y no cambia nada; en los que no, vale ~24-48px.
-  const bottomInset = insets.bottom;
-  const bottomPad =
-    Platform.OS === 'web' ? Math.max(bottomInset, 12) : 8 + bottomInset;
-  const resolved = useResolvedProfileConfig();
-  const visibleTabs = new Set(resolved.tabs);
-  // Modo carismochito: tiñe la barra de pestañas de verde mientras está activo.
-  // En modo CLARO el fondo se mantiene blanco y sólo se tiñen los iconos; en
-  // OSCURO usamos el fondo verde casi negro. Antes el fondo verde oscuro se
-  // aplicaba siempre y en claro parecía estar en modo oscuro.
-  const { isActive: carismoActive } = useCarismochito();
-  const isDark = scheme === 'dark';
-  const carismoBg = isDark ? CARISMO_TABBAR_BG : CARISMO_TABBAR_BG_LIGHT;
-  const carismoActiveTint = isDark
-    ? CARISMO_TABBAR_ACTIVE
-    : CARISMO_TABBAR_ACTIVE_LIGHT;
-  const carismoInactiveTint = isDark
-    ? CARISMO_TABBAR_INACTIVE
-    : CARISMO_TABBAR_INACTIVE_LIGHT;
-
+  if (!tab || tab.headerShown === false) return null;
   return (
-    <ThemeProvider value={theme}>
-      <Tabs
-        initialRouteName={resolved.defaultTab}
-        screenOptions={{
-          headerShown: true,
-          headerTintColor: '#fff',
-          headerTitleStyle: {
-            fontWeight: 'bold',
-            fontSize: 18,
-          },
-          headerTitleAlign: 'center',
-          headerStatusBarHeight: webStatusBarHeight,
-          tabBarActiveTintColor: carismoActive
-            ? carismoActiveTint
-            : Colors[scheme ?? 'light'].tint,
-          tabBarInactiveTintColor: carismoActive
-            ? carismoInactiveTint
-            : Colors[scheme ?? 'light'].icon,
-          tabBarStyle: {
-            backgroundColor: carismoActive
-              ? carismoBg
-              : Colors[scheme ?? 'light'].background,
-            borderTopWidth: 1,
-            borderTopColor: carismoActive
-              ? hexAlpha(carismoActiveTint, '55')
-              : hexAlpha(Colors[scheme ?? 'light'].icon, '20'),
-            paddingBottom: bottomPad,
-            paddingTop: 12,
-            height:
-              Platform.OS === 'web'
-                ? 60 + (insets.bottom > 0 ? insets.bottom : 0)
-                : 80 + bottomInset,
-            elevation: 8,
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: -2 },
-            shadowOpacity: 0.1,
-            shadowRadius: 3,
-          },
-          tabBarButton: HapticTab,
-          animation: 'shift',
-        }}
-      >
-        {TABS_CONFIG.map((tab) => {
-          if (!visibleTabs.has(tab.name)) return null;
-
-          return (
-            <Tabs.Screen
-              key={tab.name}
-              name={tab.name}
-              options={{
-                title: tab.label,
-                tabBarIcon: ({ color, size }) => (
-                  <MaterialIcons
-                    name={tab.androidIcon}
-                    color={color}
-                    size={size}
-                  />
-                ),
-                headerShown: tab.headerShown ?? true,
-                ...(tab.headerColor && {
-                  headerStyle: { backgroundColor: tab.headerColor },
-                  headerTransparent: false,
-                }),
-              }}
-            />
-          );
-        })}
-      </Tabs>
-    </ThemeProvider>
+    <View
+      style={[
+        styles.header,
+        {
+          paddingTop: insets.top,
+          height: insets.top + HEADER_HEIGHT,
+          backgroundColor: tab.headerColor ?? tab.tintColor,
+        },
+      ]}
+    >
+      <Text style={styles.headerTitle}>{tab.label}</Text>
+    </View>
   );
 }
 
-// ============================================================================
-// Main TabsLayout Component - Platform-specific rendering
-// ============================================================================
 export default function TabsLayout() {
   const scheme = useColorScheme();
+  const router = useRouter();
+  const pathname = usePathname();
+  const resolved = useResolvedProfileConfig();
+  const { isActive: carismoActive } = useCarismochito();
+  const isDark = scheme === 'dark';
+
+  const visibleTabs = new Set(resolved.tabs);
+  // Mismo tope de 5 que antes forzaba UITabBarController — ya no es una
+  // limitación nativa, pero se mantiene para que la píldora flotante no se
+  // sature: el resto sigue siendo accesible como tarjetas en MasHomeScreen.
+  const { mainTabs, overflowTabs } = splitTabsForIOS(visibleTabs);
+  const items = React.useMemo(() => mainTabs.map(toGlassItem), [mainTabs]);
+
+  const activeName =
+    pathname === '/' ? 'index' : pathname.split('/').filter(Boolean)[0];
+  const activeTab = TABS_CONFIG.find((tab) => tab.name === activeName);
+
+  const carismoBg = isDark ? CARISMO_BG_DARK : CARISMO_BG_LIGHT;
+  const carismoActiveTint = isDark ? CARISMO_ACTIVE_DARK : CARISMO_ACTIVE_LIGHT;
+  const carismoInactiveTint = isDark
+    ? CARISMO_INACTIVE_DARK
+    : CARISMO_INACTIVE_LIGHT;
 
   return (
-    <>
-      {Platform.OS === 'ios' ? (
-        <IOSNativeTabsLayout />
-      ) : (
-        <AndroidWebTabsLayout />
-      )}
-      <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-    </>
+    <TabBarMinimizeProvider>
+      <Tabs options={{ initialRouteName: resolved.defaultTab }}>
+        <View style={styles.screenArea}>
+          <TabTopHeader tab={activeTab} />
+          <TabSlot style={styles.slot} renderFn={renderFadingTabScreen} />
+        </View>
+
+        <TabList asChild>
+          <GlassTabBar
+            onIndexSelected={(index) => {
+              const target = items[index];
+              if (target) router.navigate(target.href as any);
+            }}
+            theme={
+              carismoActive
+                ? {
+                    activeTint: carismoActiveTint,
+                    inactiveTint: carismoInactiveTint,
+                    highlight: hexAlpha(carismoActiveTint, '26'),
+                    glassTint: hexAlpha(carismoBg, 'B3'),
+                    solidFallback: hexAlpha(carismoBg, 'F5'),
+                  }
+                : undefined
+            }
+          >
+            {mainTabs.map((tab, index) => (
+              <TabTrigger
+                key={tab.name}
+                name={tab.name}
+                href={tabHref(tab.name) as any}
+                asChild
+              >
+                <GlassTabButton item={items[index]} index={index} />
+              </TabTrigger>
+            ))}
+          </GlassTabBar>
+        </TabList>
+
+        {/* Tabs que no caben en la píldora: sin trigger visible no quedan
+            registradas como pantalla del navegador y `router.navigate`
+            fallaría al intentar abrirlas desde MasHomeScreen. Este TabList
+            oculto sólo las mantiene navegables. */}
+        {overflowTabs.length > 0 && (
+          <TabList style={styles.hidden}>
+            {overflowTabs.map((tab) => (
+              <TabTrigger
+                key={tab.name}
+                name={tab.name}
+                href={tabHref(tab.name) as any}
+              />
+            ))}
+          </TabList>
+        )}
+      </Tabs>
+      <StatusBar style={isDark ? 'light' : 'dark'} />
+    </TabBarMinimizeProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  screenArea: {
+    flex: 1,
+  },
+  slot: {
+    flex: 1,
+  },
+  header: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  hidden: {
+    display: 'none',
+  },
+});

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -18,6 +18,8 @@ import {
   Text,
 } from 'react-native';
 import { Calendar, CalendarProps, LocaleConfig } from 'react-native-calendars';
+import Animated from 'react-native-reanimated';
+import { useMinimizeOnScroll } from 'expo-glass-tabs';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { radii } from '@/constants/uiStyles';
@@ -82,6 +84,7 @@ LocaleConfig.locales['es'] = {
 LocaleConfig.defaultLocale = 'es';
 
 export function CalendarScreen() {
+  const onScroll = useMinimizeOnScroll();
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
   const isDark = scheme === 'dark';
@@ -512,7 +515,11 @@ export function CalendarScreen() {
         </View>
 
         {viewMode === 'calendar' ? (
-          <ScrollView showsVerticalScrollIndicator={false}>
+          <Animated.ScrollView
+            showsVerticalScrollIndicator={false}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+          >
             <View style={isLandscapeWide ? styles.monthRowTwoPane : undefined}>
               <View style={isLandscapeWide ? styles.monthLeftPane : undefined}>
                 {/* Wrapper para detectar swipes horizontales (cross-platform) */}
@@ -606,7 +613,7 @@ export function CalendarScreen() {
                 </View>
               </View>
             </View>
-          </ScrollView>
+          </Animated.ScrollView>
         ) : (
           <View style={styles.agendaContainer}>
             {/* Agenda view header */}
@@ -949,7 +956,7 @@ const createStyles = (scheme: 'light' | 'dark') => {
     // Event section (calendar view)
     eventSection: {
       paddingHorizontal: 16,
-      paddingBottom: Platform.OS === 'ios' ? 100 : 24,
+      paddingBottom: 100,
     },
     eventSectionHeader: {
       flexDirection: 'row',
@@ -1123,7 +1130,7 @@ const createStyles = (scheme: 'light' | 'dark') => {
     },
     agendaContent: {
       paddingHorizontal: 16,
-      paddingBottom: Platform.OS === 'ios' ? 100 : 24,
+      paddingBottom: 100,
     },
 
     // Section header (agenda)

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -3,14 +3,14 @@ import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import {
   View,
-  FlatList,
   StyleSheet,
   Linking,
   useWindowDimensions,
   ViewStyle,
   Alert,
-  Platform,
 } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { useMinimizeOnScroll } from 'expo-glass-tabs';
 import { Button, Spinner } from 'heroui-native';
 import TabScreenWrapper from '@/components/ui/TabScreenWrapper';
 import AlbumCard from '@/components/AlbumCard';
@@ -60,6 +60,7 @@ interface FotosScreenStyles {
 }
 
 export default function FotosScreen() {
+  const onScroll = useMinimizeOnScroll();
   const { width } = useWindowDimensions();
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
@@ -174,7 +175,7 @@ export default function FotosScreen() {
   return (
     <TabScreenWrapper style={styles.container} edges={['top']}>
       {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
-      <FlatList
+      <Animated.FlatList
         data={displayedAlbums}
         renderItem={({ item }) => (
           <View style={columnContainerStyle}>
@@ -193,11 +194,13 @@ export default function FotosScreen() {
             maxWidth: width > 1200 ? 1600 : 1200,
             alignSelf: 'center',
           },
-          Platform.OS === 'ios' && { paddingBottom: 100 },
+          { paddingBottom: 100 },
         ]}
         onEndReached={loadMoreAlbums}
         onEndReachedThreshold={0.5}
         ListFooterComponent={renderFooter}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
       />
     </TabScreenWrapper>
   );

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -11,7 +11,6 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
   TouchableOpacity,
   Pressable,
   Linking,
@@ -28,6 +27,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import { useMinimizeOnScroll } from 'expo-glass-tabs';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -197,6 +197,7 @@ interface QuickItem {
 
 export default function Home() {
   const navigation = useNavigation();
+  const onScroll = useMinimizeOnScroll();
   const scheme = useColorScheme();
   const theme = Colors[scheme ?? 'light'];
   // Color neutro de los iconos en la cápsula glass (igual que EventActionButtons).
@@ -664,14 +665,16 @@ export default function Home() {
         />
       </View>
 
-      <ScrollView
+      <Animated.ScrollView
         style={{ backgroundColor: theme.background }}
         contentContainerStyle={[
           styles.scrollContent,
           isWide && styles.scrollContentWide,
-          Platform.OS === 'ios' && { paddingBottom: 120 },
+          { paddingBottom: 120 },
         ]}
         showsVerticalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
       >
         {/* ── Two-column wrapper on wide screens ── */}
         <View style={isWide ? styles.wideRow : undefined}>
@@ -1283,7 +1286,7 @@ export default function Home() {
             </Text>
           </SecretMenuTrigger>
         </View>
-      </ScrollView>
+      </Animated.ScrollView>
     </SafeAreaView>
   );
 }

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -115,12 +115,16 @@ export default function MasHomeScreen() {
   const navigationItems = React.useMemo(() => {
     const items: NavigationItem[] = [];
 
-    // En iOS la barra nativa sólo admite 5 triggers; los tabs que no caben
-    // se exponen aquí como tarjetas para evitar el "More" automático del sistema.
-    if (Platform.OS === 'ios') {
+    // La píldora flotante (expo-glass-tabs, todas las plataformas) sólo
+    // admite 5 triggers visibles; los tabs que no caben se exponen aquí como
+    // tarjetas — antes esto era exclusivo de iOS (limitación de
+    // UITabBarController), ahora aplica también a Android/Web al compartir
+    // la misma barra.
+    {
       const visibleSet = new Set(resolved.tabs);
       const { overflowTabs } = splitTabsForIOS(visibleSet);
-      // Tabs cuyo screen está registrado en el stack de Más (no accesibles vía router.navigate en iOS)
+      // Tabs cuyo screen está registrado en el stack de Más (evita depender
+      // de router.navigate hacia una tab sin trigger visible).
       const OVERFLOW_STACK_TARGETS: Partial<
         Record<string, keyof MasStackParamList>
       > = {

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -30,6 +30,7 @@
         "expo-file-system": "~55.0.10",
         "expo-font": "~55.0.4",
         "expo-glass-effect": "~55.0.7",
+        "expo-glass-tabs": "^0.1.1",
         "expo-haptics": "~55.0.8",
         "expo-image": "~55.0.6",
         "expo-insights": "~55.0.10",
@@ -10625,6 +10626,25 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-glass-tabs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/expo-glass-tabs/-/expo-glass-tabs-0.1.1.tgz",
+      "integrity": "sha512-DVtfA+wTXz63LNAgGXXuAPEtCFwciELLTI8J1kq16ER7IcAx+dPZdMwfBpOY9iVkwinPdSz60dSe8QNQGWbBZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-blur": "*",
+        "expo-glass-effect": "*",
+        "expo-haptics": "*",
+        "expo-router": "*",
+        "expo-symbols": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": "*",
+        "react-native-reanimated": "*",
+        "react-native-safe-area-context": "*",
+        "react-native-screens": "*"
       }
     },
     "node_modules/expo-haptics": {

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -39,6 +39,7 @@
     "expo-file-system": "~55.0.10",
     "expo-font": "~55.0.4",
     "expo-glass-effect": "~55.0.7",
+    "expo-glass-tabs": "^0.1.1",
     "expo-haptics": "~55.0.8",
     "expo-image": "~55.0.6",
     "expo-insights": "~55.0.10",


### PR DESCRIPTION
## ⚠️ Experimento — revisar con calma antes de tocarlo

Sustituye la barra de pestañas dual actual (`NativeTabs` en iOS / `Tabs` clásico en Android-Web) por una única píldora flotante *liquid-glass* (librería [`expo-glass-tabs`](https://github.com/davidmokos/expo-glass-tabs)) que se encoge y oculta las etiquetas al hacer scroll, igual en las tres plataformas.

**Trade-off importante**: en iOS esto cambia el tab bar nativo real (Liquid Glass del sistema, `UITabBarController`) por una recreación en JS. A cambio se gana la animación de minimizado al hacer scroll, que `NativeTabs` no ofrece.

## Qué cambia

- `app/(tabs)/_layout.tsx`: reescrito sobre las primitivas headless `Tabs`/`TabList`/`TabSlot`/`TabTrigger` de `expo-router/ui`. Sigue limitando la píldora a 5 tabs visibles (`splitTabsForIOS`, antes solo en iOS, ahora en todas las plataformas); el resto se registra en un `TabList` oculto para que siga siendo navegable (`router.navigate`) desde "Más" aunque no tenga botón visible en la barra. Header propio por tab (color + título) porque la barra headless no trae header nativo.
- `app/screens/MasHomeScreen.tsx`: la lógica de "tabs que no caben van como tarjetas" ya no es exclusiva de iOS.
- `app/(tabs)/index.tsx`, `calendario.tsx`, `fotos.tsx`: scroll principal enganchado a `useMinimizeOnScroll()` (efecto de encogerse); padding inferior que antes solo se aplicaba en iOS ahora es universal (la píldora flota sobre el contenido en todas partes).
- Nueva dependencia `expo-glass-tabs` (0.1.1) — **sin código nativo propio**, se apoya en `expo-blur`/`expo-glass-effect`/`react-native-reanimated`/`react-native-gesture-handler`, ya instalados. No requiere build de tienda ni `[skip-ota]`, se puede publicar por OTA normal y revertir igual de rápido.

## Pendiente / no cubierto en esta pasada

- Contigo, Cantoral, Más y sus subpantallas no llevan aún el hook de scroll ni el padding ajustado — su contenido puede quedar parcialmente tapado por la píldora en listas largas.
- Sin probar en iOS/Android reales todavía (solo simulado en web).

## Test plan

- [x] `npx tsc --noEmit` sin errores
- [x] `npm run lint` sin errores nuevos (solo warnings preexistentes de `max-lines`)
- [x] `npm test` — 305 tests en verde
- [x] Verificado en web con Playwright: renderiza sin crashear (fallback sólido, sin liquid glass real ahí), el minimizado al hacer scroll funciona, y las tabs en overflow (Calendario, Fotos) siguen siendo navegables
- [ ] Probar en dispositivo/simulador iOS real (liquid glass real)
- [ ] Probar en Android real
- [ ] Decidir si se completa el hook de scroll en el resto de pantallas antes de mergear


---
_Generated by [Claude Code](https://claude.ai/code/session_01PUx2LXZQkfWaBj5XzpyHdD)_