### PR TITLE
fix(comunica): el tema de la web ya no se congela antes de leer el guardado

### DIFF
--- a/docs/contratos/COMUNICA_WEBVIEW.md
+++ b/docs/contratos/COMUNICA_WEBVIEW.md
@@ -69,6 +69,44 @@ recarga** la página (perdería lo escrito en formularios): reinyecta el JS que
 actualiza la clase de `<html>` y la cookie. Por eso conviene que el CSS reaccione
 a la clase — el cambio se ve al instante sin recargar.
 
+Esto aplica tanto si el cambio viene del selector de la app como del sistema
+operativo cuando el selector está en **Sistema** (la app escucha `Appearance` y
+reinyecta igual).
+
+> **Excepción — versión web de la app.** Ahí Comunica va en un `<iframe>`
+> cross-origin: no se le puede inyectar JS, así que un cambio de tema **sí**
+> recarga el iframe con el nuevo `?theme=`. No hay alternativa y en web el caso
+> es marginal.
+
+### Quién resuelve «Sistema»
+
+**La app.** El selector tiene tres valores (Sistema / Claro / Oscuro) pero a la
+web solo le llega `light` o `dark` ya resueltos; la web nunca ve `system`. Si
+algún día se quisiera delegar, bastaría con omitir `theme` y no escribir
+`mcm_theme` para que la web cayera en «Automático» (`prefers-color-scheme` +
+`matchMedia`) — **hoy no es el caso: la app manda siempre**.
+
+### Color de fondo de página (costura de overscroll)
+
+La app pinta un fondo sólido por detrás del WebView para evitar el flash blanco
+al cargar; se ve además en el rebote del scroll. Tiene que ser **el mismo** que
+el fondo de página de la web, o aparece una costura de color:
+
+| Tema | Color |
+| ---- | ----- |
+| Oscuro | `#121316` |
+| Claro | `#FFFFFF` |
+
+Si la web cambia su fondo de página, avisad para actualizar `PAGE_BG_DARK` /
+`PAGE_BG_LIGHT` en `ComunicaScreen.tsx`.
+
+### Momento de la primera carga
+
+La app no monta la web hasta haber leído de disco el tema guardado. Sin eso, en
+un arranque en frío el primer render usaría el tema del sistema operativo y
+alguien con la app en Claro y el móvil en oscuro recibiría `?theme=dark` en la
+primera petición (parpadeo, corregido acto seguido por la inyección).
+
 ## 3. Zona segura (notch y tab bar)
 
 La app dibuja la web **a pantalla completa**, por detrás de la barra superior

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,24 @@
 
 ---
 
+## 2026-07-27 23:45 — Comunica: el tema de la web ya no se congela antes de tiempo
+
+- **Tema correcto en la primera petición.** La URL inicial (`?theme=`) se
+  congelaba en el primer render, antes de que `AppSettingsContext` terminara de
+  leer el tema guardado de AsyncStorage. En arranque en frío eso mandaba el tema
+  del **sistema operativo**, no el elegido en la app: alguien con la app en Claro
+  y el móvil en oscuro veía Comunica cargar en oscuro y corregirse después. Ahora
+  la pantalla espera a tener el tema guardado (muestra el loader) y solo entonces
+  monta la web.
+- **Web (iframe):** al ser cross-origin no admite inyección de JS, así que el
+  cambio de tema en caliente no le llegaba nunca y se quedaba siempre en claro.
+  Ahora el `src` del iframe lleva el tema actual y se recarga al cambiarlo.
+- **Costura de color al hacer overscroll:** el fondo bajo el WebView pasa de
+  `#1C1C1E` a `#121316` para coincidir con el fondo de página de la web.
+- Archivos: `app/screens/ComunicaScreen.tsx`,
+  `docs/contratos/COMUNICA_WEBVIEW.md` (contrato al día: quién resuelve
+  «Sistema», colores de fondo, excepción de la web).
+
 ## 2026-07-26 18:05 — Contigo: revisión a fondo del sistema de subrayado
 
 - **Copiar/pegar y menú nativo de verdad**: `HighlightableReading` renderiza el

--- a/mcm-app/app/screens/ComunicaScreen.tsx
+++ b/mcm-app/app/screens/ComunicaScreen.tsx
@@ -27,6 +27,7 @@ import { WebView, WebViewNavigation } from 'react-native-webview';
 import { useToast } from '@/contexts/AppToastContext';
 import { Colors as ThemeColors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useAppSettings } from '@/contexts/AppSettingsContext';
 import GlassSurface from '@/components/ui/GlassSurface';
 import WebViewNavControls from '@/components/ui/WebViewNavControls';
 
@@ -69,8 +70,15 @@ const themeBridgeJS = (theme: 'light' | 'dark') => `(function(){try{
 const IOS_TAB_BAR_HEIGHT = 49;
 const IOS_BOTTOM_EXTRA = 32;
 
+// Fondo bajo el WebView. Debe coincidir con el fondo de página de la web:
+// si no, se ve una costura de color en el rebote del overscroll y durante la
+// carga. `#121316` es el fondo oscuro que usa comunica (acordado con la web).
+const PAGE_BG_DARK = '#121316';
+const PAGE_BG_LIGHT = '#FFFFFF';
+
 export default function ComunicaScreen() {
   const scheme = useColorScheme() ?? 'light';
+  const { loading: settingsLoading } = useAppSettings();
   const insets = useSafeAreaInsets();
   const tintColor = ThemeColors[scheme].tint;
   const [isLoading, setIsLoading] = useState(true);
@@ -86,12 +94,21 @@ export default function ComunicaScreen() {
   const goForward = useCallback(() => webViewRef.current?.goForward(), []);
 
   // ── Tema (claro/oscuro) hacia la web ──────────────────────────────────────
-  // La URL se congela con el tema del montaje: si dependiera de `scheme`, un
+  // La URL se congela con el PRIMER tema válido: si dependiera de `scheme`, un
   // cambio de tema mutaría `source.uri` y RECARGARÍA la web, perdiendo lo que
   // el usuario tuviera escrito. Los cambios en caliente van por injectJavaScript.
-  const initialTheme = useRef(scheme).current;
+  //
+  // «Válido» = después de que AppSettings haya leído AsyncStorage. Antes de eso
+  // el tema guardado todavía no se conoce y `scheme` cae al del sistema
+  // operativo; congelarlo ahí mandaría `?theme=dark` a alguien que tiene la app
+  // en Claro con el móvil en oscuro (parpadeo del tema equivocado al entrar).
+  const latchedTheme = useRef<'light' | 'dark' | null>(null);
+  if (latchedTheme.current === null && !settingsLoading) {
+    latchedTheme.current = scheme;
+  }
+  const initialTheme = latchedTheme.current;
   const sourceUri = useMemo(
-    () => `${COMUNICA_URL}&theme=${initialTheme}`,
+    () => (initialTheme ? `${COMUNICA_URL}&theme=${initialTheme}` : null),
     [initialTheme],
   );
   const themeJS = useMemo(() => themeBridgeJS(scheme), [scheme]);
@@ -153,14 +170,30 @@ export default function ComunicaScreen() {
   // Texto de la status bar: oscuro sobre glass claro, claro sobre glass oscuro.
   const barStyle = scheme === 'dark' ? 'light-content' : 'dark-content';
   // Fondo bajo el WebView: evita el flash blanco al cargar en modo oscuro.
-  const pageBg = scheme === 'dark' ? '#1C1C1E' : '#FFFFFF';
+  const pageBg = scheme === 'dark' ? PAGE_BG_DARK : PAGE_BG_LIGHT;
+
+  // Todavía no se sabe el tema guardado: no montamos la web para no cargarla
+  // con el tema equivocado (dura lo que tarda un read de AsyncStorage).
+  if (!sourceUri) {
+    return (
+      <View style={[styles.container, { backgroundColor: pageBg }]}>
+        <View style={dynamicStyles.loadingContainer}>
+          <ActivityIndicator size="large" color={tintColor} />
+        </View>
+      </View>
+    );
+  }
 
   // ── Web: iframe ──────────────────────────────────────────────────────────
+  // En web el iframe es cross-origin: no se le puede inyectar JS, así que el
+  // único modo de propagar un cambio de tema en caliente es recargarlo con el
+  // nuevo `?theme=` (de ahí que aquí sí dependa de `scheme` y no de la URL
+  // congelada). Cambiar de tema es raro y en web no hay WebView que preservar.
   if (Platform.OS === 'web') {
     return (
       <View style={styles.container}>
         <iframe
-          src={sourceUri}
+          src={`${COMUNICA_URL}&theme=${scheme}`}
           title="Comunica"
           className={iframeStyles?.iframe}
           style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}


### PR DESCRIPTION
Repaso del puente de tema app ↔ Comunica tras el feedback del lado web. El contrato estaba entero (`?theme=`, cookie `mcm_theme`, `data-mcm-theme` reinyectado), pero había tres agujeros reales.

## Qué cambia

**1. El tema se congelaba antes de tiempo.** La URL inicial fijaba `?theme=` en el primer render, antes de que `AppSettingsContext` terminara de leer el tema guardado de AsyncStorage. En arranque en frío eso mandaba el tema del **sistema operativo** en vez del elegido en la app: con la app en Claro y el móvil en oscuro, Comunica cargaba oscuro y se corregía después por inyección. Ahora la pantalla espera a tener el tema guardado (muestra el loader) y solo entonces monta la web.

**2. En la versión web el tema nunca cambiaba.** El iframe es cross-origin: no admite inyección de JS, así que el cambio en caliente no le llegaba, y además el `src` quedaba congelado con el `light` de prehidratación. Ahora el `src` lleva el tema actual y se recarga al cambiarlo — única opción posible ahí, y en web no hay WebView con formularios que preservar.

**3. Costura de color en el overscroll.** El fondo bajo el WebView pasa de `#1C1C1E` a `#121316` para igualar el fondo de página de la web. Se arreglaba por cualquiera de los dos lados; este es el barato (el lado web no tiene que subir un escalón sus superficies).

## Lo que se queda como estaba

- **La app sigue resolviendo «Sistema»**: a la web solo le llegan `light`/`dark`. Dentro del WebView `prefers-color-scheme` sigue al SO, no al selector de la app, así que delegarlo rompería a quien tenga app y móvil en temas distintos.
- El cambio en caliente responde a los dos orígenes: el selector de la app y el del sistema operativo cuando el selector está en «Sistema» (`useColorScheme` escucha `Appearance`).

## Documentación

`docs/contratos/COMUNICA_WEBVIEW.md`: quién resuelve «Sistema», los colores de fondo acordados, la excepción del iframe en web y el porqué de esperar al tema guardado antes de la primera carga.

## Verificación

- `npx tsc --noEmit` limpio
- `npx eslint app/screens/ComunicaScreen.tsx` limpio
- Sin dependencias nuevas ni código nativo → apto para OTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PynTJEPEQ9xetVxk6rrzXx)_