### PR TITLE
Archivar Visita Papa de verdad + Comunica como tab tras Contigo

### DIFF
--- a/docs/funcionalidades/EVENTOS.md
+++ b/docs/funcionalidades/EVENTOS.md
@@ -65,6 +65,23 @@ eventos NO activos siguen tomando `status` del registry (la lista "Eventos
 pasados" no refleja aún un `archived` puesto desde el panel a un evento no
 activo). Ver `docs/planes/PLAN_INTEGRACIONES.md`, Integración B.
 
+**Qué hace `status: 'archived'` en la app** (desde 2026-07-29): archivar el
+evento activo lo saca de todos los sitios donde estaba destacado y lo deja sólo
+en "Más > Eventos pasados":
+
+| Sitio                            | Quién lo filtra                               |
+| -------------------------------- | --------------------------------------------- |
+| Tab propia (`tabId`)             | `hooks/useVisibleTabs.ts` → `(tabs)/_layout`  |
+| Tarjeta de overflow en iOS       | `useVisibleTabs` → `MasHomeScreen`            |
+| Botón del grid de la Home        | `app/(tabs)/index.tsx` (`quickItems`)         |
+| Banner "modo evento" de la Home  | `app/(tabs)/index.tsx` (`showEventBanner`)    |
+| Lista "Eventos pasados"          | `EventosPasadosScreen` (lo AÑADE)             |
+
+Ojo: el `status` es lo único que decide si un evento se destaca. `tabId` puede
+seguir en la lista `tabs` del perfil (`/profileConfig`) sin que el tab aparezca,
+y `ACTIVE_EVENT_ID` puede apuntar a un evento archivado (sigue siendo el evento
+por defecto para routing/caché, simplemente no se destaca).
+
 ### Forma de cada sección
 
 Cada sección (nodo hijo del evento) tiene siempre:

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,42 @@
 
 ---
 
+## 2026-07-29 19:20 — Visita Papa archivada y Comunica como tab (después de Contigo)
+
+- **Archivar un evento ahora hace algo.** El "archivar" del panel MCM
+  (`activities/<id>/_meta.status = 'archived'`) se leía y se mergeaba sobre el
+  registry, pero **ningún sitio de la app consumía el `status`**: la tab del
+  evento dependía sólo de la lista `tabs` del perfil, el botón de la Home de
+  `homeButtons` y el banner de "tener acceso al evento", así que archivar no
+  cambiaba nada visible. Nuevo `hooks/useVisibleTabs.ts` (quita el `tabId` del
+  evento archivado en `(tabs)/_layout.tsx` y en las tarjetas de overflow de
+  `MasHomeScreen`), más el gating del banner y del botón del grid en
+  `app/(tabs)/index.tsx`. `EventosPasadosScreen` ya incluye el evento en curso
+  cuando el panel lo archiva en caliente (antes leía sólo el registry).
+- **Visita Papa León XIV 2026 pasa a `status: 'archived'`** en
+  `constants/events.ts`: sin tab, sin botón en la Home y sin banner; se accede
+  desde **Más > Eventos pasados**. El panel puede devolverla a `active`.
+- **Comunica es tab propia, justo después de Contigo.** Faltaba la ruta:
+  `TABS_CONFIG` y `KNOWN_TABS` ya listaban `comunica`, pero no existía
+  `app/(tabs)/comunica.tsx`, así que ponerla en `tabs` no podía funcionar. Se
+  crea la ruta (envuelve `ComunicaScreen`, `headerShown: false` porque el WebView
+  gestiona su propia zona segura) y se mueve su entrada del catálogo detrás de
+  `contigo`. El botón de la Home apunta a `/comunica` cuando el perfil tiene el
+  tab, en vez de abrir la pantalla dentro del stack de "Más".
+- **`firebase-seed/profileConfig.json`:** los tres perfiles (familia, monitor,
+  miembro) añaden `comunica` a `tabs`, quitan `visitapapa` de `tabs`/
+  `homeButtons` y quitan `comunica` de `masItems` (ya no hace falta duplicarla en
+  "Más"). ⚠️ El mismo cambio hay que aplicarlo en `/profileConfig/data/profiles/*`
+  de Firebase (desde el panel) para que surta efecto sin publicar.
+- Orden resultante de la barra: Inicio · Cantoral · Contigo · Comunica ·
+  Calendario · Fotos · Más (en iOS, Calendario y Fotos siguen cayendo como
+  tarjetas en "Más", igual que antes).
+- Archivos: `constants/events.ts`, `constants/tabsCatalog.ts`,
+  `hooks/useVisibleTabs.ts`, `app/(tabs)/comunica.tsx`, `app/(tabs)/_layout.tsx`,
+  `app/(tabs)/index.tsx`, `app/screens/MasHomeScreen.tsx`,
+  `app/screens/EventosPasadosScreen.tsx`, `firebase-seed/profileConfig.json`,
+  `docs/funcionalidades/EVENTOS.md`.
+
 ## 2026-07-27 23:45 — Comunica: el tema de la web ya no se congela antes de tiempo
 
 - **Tema correcto en la primera petición.** La URL inicial (`?theme=`) se

--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -69,11 +69,12 @@ app/
 │   ├── _layout.tsx             # Tabs: plataforma iOS (NativeTabs) vs Android/Web (Tabs)
 │   ├── index.tsx               # Home: grid de botones de navegación
 │   ├── cancionero.tsx          # Cantoral: stack navigator interno (Categories → Songs → Detail → Fullscreen)
+│   ├── contigo/                # Contigo: acompañamiento y oración (rutas anidadas)
+│   ├── comunica.tsx            # Comunica: WebView del portal (envuelve ComunicaScreen)
+│   ├── visitapapa.tsx          # Tab del evento Visita Papa (oculta: evento archivado)
 │   ├── calendario.tsx          # Calendario: eventos ICS
 │   ├── fotos.tsx               # Galería de fotos
 │   └── mas.tsx                 # Más opciones (JubileoHome, Grupos, Materiales, etc.)
-├── (disabled)/
-│   └── comunica.tsx            # Tab desactivada (movida fuera de tabs activos)
 ├── screens/                    # 20 pantallas individuales
 │   ├── CategoriesScreen.tsx    # Lista de categorías del cantoral
 │   ├── SongListScreen.tsx      # Lista de canciones por categoría
@@ -176,8 +177,11 @@ RootLayout (Stack)
 ├── (tabs) ← Bottom Tabs
 │   ├── index (Home)           ← Grid de botones
 │   ├── cancionero             ← Stack interno: Categories → SongsList → SongDetail → SongFullscreen
+│   ├── contigo                ← Acompañamiento y oración
+│   ├── comunica               ← WebView del portal de comunicación
 │   ├── calendario             ← Eventos ICS
 │   ├── fotos                  ← Galería
+│   ├── visitapapa             ← Stack del evento (oculto mientras esté archivado)
 │   └── mas                    ← Stack interno: MasHome → Jubileo/Grupos/Materiales/etc.
 ├── wordle                     ← Juego
 └── notifications              ← Lista de notificaciones
@@ -187,7 +191,12 @@ RootLayout (Stack)
 
 - **iOS**: `NativeTabs` (expo-router/unstable-native-tabs) para liquid glass
 - **Android/Web**: `Tabs` tradicionales (expo-router)
-- Config centralizada en `TABS_CONFIG` array en `app/(tabs)/_layout.tsx`
+- Config centralizada en `TABS_CONFIG` (`constants/tabsCatalog.ts`); el **orden
+  de la barra** lo da ese array, NO la lista `tabs` del perfil
+- Qué tabs se ven: `hooks/useVisibleTabs.ts` = `tabs` del perfil resuelto menos
+  el tab del evento en curso si está archivado (`status: 'archived'`)
+- En iOS sólo caben 5 triggers: `splitTabsForIOS` deja los 4 primeros + "Más", y
+  el resto se ve como tarjetas en `MasHomeScreen`
 
 ## Sistema de Perfiles (reemplaza a los feature flags)
 
@@ -294,8 +303,10 @@ danger: '#9D1E74'; // Morado LC
 
 ### Añadir nuevo tab
 
-1. Crear archivo en `app/(tabs)/nuevoTab.tsx`
-2. Añadir objeto a `TABS_CONFIG` en `app/(tabs)/_layout.tsx`
+1. Crear archivo en `app/(tabs)/nuevoTab.tsx` — **imprescindible**: sin la ruta,
+   meter el ID en `TABS_CONFIG`/`tabs` no muestra nada (le pasaba a `comunica`)
+2. Añadir objeto a `TABS_CONFIG` en `constants/tabsCatalog.ts`, en la posición
+   que deba ocupar en la barra (ese array define el orden)
 3. Añadir el ID a `KNOWN_TABS` en `constants/profileCatalog.ts`
 4. Añadir el ID a `profiles.*.tabs` en `firebase-seed/profileConfig.json` y en `/profileConfig` en Firebase
 5. Definir color en `TabHeaderColors` si aplica (en `constants/colors.ts`)

--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Platform } from 'react-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
+import { useVisibleTabs } from '@/hooks/useVisibleTabs';
 import { StatusBar } from 'expo-status-bar';
 
 // Import iOS-specific NativeTabs
@@ -48,8 +49,7 @@ const CARISMO_TABBAR_TINT_IOS = '#1B9E4B';
 // muestran como tarjetas dentro de MasHomeScreen. Las rutas sin trigger siguen
 // siendo navegables programáticamente (expo-router las mantiene en el state).
 function IOSNativeTabsLayout() {
-  const resolved = useResolvedProfileConfig();
-  const visibleTabs = new Set(resolved.tabs);
+  const visibleTabs = useVisibleTabs();
   const { mainTabs } = splitTabsForIOS(visibleTabs);
   // Modo carismochito: tiñe iconos + labels de verde. NOTA: en iOS sólo
   // tocamos `tintColor`/`labelStyle` (fiables). El `backgroundColor` de la
@@ -115,7 +115,7 @@ function AndroidWebTabsLayout() {
   const bottomPad =
     Platform.OS === 'web' ? Math.max(bottomInset, 12) : 8 + bottomInset;
   const resolved = useResolvedProfileConfig();
-  const visibleTabs = new Set(resolved.tabs);
+  const visibleTabs = useVisibleTabs();
   // Modo carismochito: tiñe la barra de pestañas de verde mientras está activo.
   // En modo CLARO el fondo se mantiene blanco y sólo se tiñen los iconos; en
   // OSCURO usamos el fondo verde casi negro. Antes el fondo verde oscuro se

--- a/mcm-app/app/(tabs)/comunica.tsx
+++ b/mcm-app/app/(tabs)/comunica.tsx
@@ -1,0 +1,17 @@
+// app/(tabs)/comunica.tsx
+//
+// Tab "Comunica": portal de comunicación (WebView a
+// comunica.movimientoconsolacion.com). Hasta ahora Comunica sólo existía como
+// pantalla dentro del stack de "Más"; el catálogo de tabs ya la contemplaba
+// pero la ruta no existía, así que ponerla en `tabs` no funcionaba.
+//
+// La pantalla se pinta a pantalla completa y se gestiona su propia zona segura
+// (barra glass en el notch en iOS, franja lisa en Android), por eso el tab va
+// con `headerShown: false` en `TABS_CONFIG`.
+
+import React from 'react';
+import ComunicaScreen from '../screens/ComunicaScreen';
+
+export default function ComunicaTab() {
+  return <ComunicaScreen />;
+}

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -68,7 +68,11 @@ import {
 import { useFirebaseData } from '@/hooks/useFirebaseData';
 import { useActiveSurveys } from '@/hooks/useActiveSurveys';
 import SurveyBanner from '@/components/SurveyBanner';
-import { getEventCacheKey, getEventFirebasePath } from '@/constants/events';
+import {
+  getEventCacheKey,
+  getEventFirebasePath,
+  isEventArchived,
+} from '@/constants/events';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import {
   getLocalNotificationsHistory,
@@ -238,7 +242,13 @@ export default function Home() {
   // valor hardcoded en `constants/events.ts`.
   const { activeEvent } = useActiveMeta();
   const activeTabId = activeEvent.tabId ?? '';
+  // Un evento archivado (`status: 'archived'`, ya sea en el registry o puesto
+  // desde el panel MCM) deja de destacarse: sin banner, sin botón en la Home y
+  // sin tab (esto último lo filtra `useVisibleTabs`). Se sigue viendo en
+  // "Más > Eventos pasados".
+  const eventArchived = isEventArchived(activeEvent);
   const hasEventAccess =
+    !eventArchived &&
     activeTabId !== '' &&
     (resolved.tabs.includes(activeTabId) ||
       resolved.homeButtons.includes(activeTabId));
@@ -390,6 +400,10 @@ export default function Home() {
     (g) => g.events.length > 0,
   );
 
+  // ¿El perfil tiene Comunica como tab propia? Cambia a dónde apunta el botón
+  // de la Home (tab vs. pantalla dentro del stack de "Más").
+  const comunicaIsTab = resolved.tabs.includes('comunica');
+
   // Quick grid items — filtrados por la config del perfil resuelto
   const quickItems = useMemo<QuickItem[]>(() => {
     const visible = new Set(resolved.homeButtons);
@@ -400,7 +414,9 @@ export default function Home() {
         icon: 'forum',
         iconBg: scheme === 'dark' ? '#3A2200' : '#FFF0E0',
         iconColor: '#E08A3C',
-        href: '/mas',
+        // Con Comunica como tab propia vamos directos a la tab; si el perfil no
+        // la tiene, se sigue abriendo la pantalla dentro del stack de "Más".
+        href: comunicaIsTab ? '/comunica' : '/mas',
       },
       cancionero: {
         key: 'cancionero',
@@ -444,10 +460,19 @@ export default function Home() {
         dashed: true,
       },
     };
+    // El botón del evento en curso desaparece cuando el evento se archiva.
     return resolved.homeButtons
       .filter((id) => visible.has(id) && catalog[id])
+      .filter((id) => !(eventArchived && id === activeTabId))
       .map((id) => catalog[id]);
-  }, [resolved.homeButtons, scheme, theme.icon]);
+  }, [
+    resolved.homeButtons,
+    scheme,
+    theme.icon,
+    comunicaIsTab,
+    eventArchived,
+    activeTabId,
+  ]);
 
   // Hide the tab navigator header — we render our own
   useLayoutEffect(() => {
@@ -1033,7 +1058,7 @@ export default function Home() {
                     accessibilityRole="button"
                     onPress={() => {
                       h.tap();
-                      if (item.key === 'comunica') {
+                      if (item.key === 'comunica' && !comunicaIsTab) {
                         setPendingMasScreen('Comunica');
                       } else if (item.key === 'fotos') {
                         setPendingMasScreen('Fotos');

--- a/mcm-app/app/screens/EventosPasadosScreen.tsx
+++ b/mcm-app/app/screens/EventosPasadosScreen.tsx
@@ -19,13 +19,15 @@ import EmptyState from '@/components/ui/EmptyState';
 import { hexAlpha } from '@/utils/colorUtils';
 import spacing from '@/constants/spacing';
 import { radii } from '@/constants/uiStyles';
-import { getArchivedEvents } from '@/constants/events';
+import { getArchivedEvents, isEventArchived } from '@/constants/events';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
 import { MasStackParamList } from '../(tabs)/mas';
 
 /**
- * "Eventos pasados": lista los eventos archivados (`status: 'archived'` en
- * `constants/events.ts`) como tarjetas que abren su hub. Hoy muestra Jubileo;
- * cuando un evento activo se archive aparecerá aquí automáticamente.
+ * "Eventos pasados": lista los eventos archivados como tarjetas que abren su
+ * hub. Son archivados los que tienen `status: 'archived'` en
+ * `constants/events.ts` y también el evento en curso cuando el panel MCM lo
+ * archiva en caliente (`activities/<id>/_meta.status`), sin publicar la app.
  */
 export default function EventosPasadosScreen() {
   const navigation =
@@ -34,7 +36,21 @@ export default function EventosPasadosScreen() {
   const isDark = scheme === 'dark';
   const styles = React.useMemo(() => createStyles(isDark), [isDark]);
 
-  const events = React.useMemo(() => getArchivedEvents(), []);
+  const { activeEvent } = useActiveMeta();
+  const events = React.useMemo(() => {
+    const list = getArchivedEvents();
+    // El evento en curso puede estar archivado sólo en remoto: en ese caso el
+    // registry aún lo da como activo y hay que añadirlo (o sustituirlo, para
+    // quedarnos con el título/color que trae el panel).
+    if (!isEventArchived(activeEvent)) {
+      return list.filter((e) => e.id !== activeEvent.id);
+    }
+    const i = list.findIndex((e) => e.id === activeEvent.id);
+    if (i === -1) return [...list, activeEvent];
+    const merged = [...list];
+    merged[i] = activeEvent;
+    return merged;
+  }, [activeEvent]);
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -22,6 +22,7 @@ import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import AppFeedbackModal from '@/components/AppFeedbackModal';
 import { MasStackParamList } from '../(tabs)/mas';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
+import { useVisibleTabs } from '@/hooks/useVisibleTabs';
 import { useAdminStatus } from '@/hooks/useAdminStatus';
 import { takePendingMasScreen } from '@/utils/masNavigation';
 import PageContainer from '@/components/ui/PageContainer';
@@ -111,6 +112,7 @@ export default function MasHomeScreen() {
   const layout = useResponsiveLayout();
   const useTwoColumns = layout.isWide;
   const resolved = useResolvedProfileConfig();
+  const visibleTabs = useVisibleTabs();
   const { isAdmin } = useAdminStatus();
   const navigationItems = React.useMemo(() => {
     const items: NavigationItem[] = [];
@@ -118,8 +120,7 @@ export default function MasHomeScreen() {
     // En iOS la barra nativa sólo admite 5 triggers; los tabs que no caben
     // se exponen aquí como tarjetas para evitar el "More" automático del sistema.
     if (Platform.OS === 'ios') {
-      const visibleSet = new Set(resolved.tabs);
-      const { overflowTabs } = splitTabsForIOS(visibleSet);
+      const { overflowTabs } = splitTabsForIOS(visibleTabs);
       // Tabs cuyo screen está registrado en el stack de Más (no accesibles vía router.navigate en iOS)
       const OVERFLOW_STACK_TARGETS: Partial<
         Record<string, keyof MasStackParamList>
@@ -155,7 +156,7 @@ export default function MasHomeScreen() {
     }
 
     return items;
-  }, [resolved.masItems, resolved.tabs, isAdmin]);
+  }, [resolved.masItems, visibleTabs, isAdmin]);
 
   // Deep-link desde la Home: si hay una pantalla pendiente, navegar a ella
   useFocusEffect(

--- a/mcm-app/constants/events.ts
+++ b/mcm-app/constants/events.ts
@@ -192,7 +192,10 @@ export const VISITAPAPA: EventConfig = {
   tintColor: '#FCD200',
   heroImage: require('@/assets/alzalamirada.png'),
   firebasePrefix: 'activities/visitapapa26',
-  status: 'active',
+  // Archivado tras la visita: ya no tiene tab propia, ni botón en la Home, ni
+  // banner. Se accede desde "Más > Eventos pasados". El panel MCM puede
+  // devolverlo a `active` desde `activities/visitapapa26/_meta.status`.
+  status: 'archived',
   bannerText: 'Horarios, materiales y todo para vivir un momento histórico',
   tabId: 'visitapapa',
   hiddenGroupCategories: ['Alojamiento'],
@@ -289,11 +292,14 @@ export const EVENTS: Record<string, EventConfig> = {
 };
 
 /**
- * Evento activo / destacado ("modo evento"): la app lo resalta con tab propia,
- * botón en la Home y banner. También es el evento por defecto.
+ * Evento "en curso" por defecto: el que la app usa cuando no se le pasa un
+ * `eventId` explícito y el que consulta en `activities/<id>/_meta`.
  *
- * TODO (mcmpanel/Firebase): mover esta decisión al nodo `activities/` para
- * poder activar/archivar eventos sin desplegar.
+ * OJO: que este evento esté DESTACADO ("modo evento": tab propia, botón en la
+ * Home y banner) NO depende de esta constante, sino de su `status`. Con
+ * `status: 'archived'` la app lo trata como evento pasado aunque siga siendo el
+ * `ACTIVE_EVENT_ID`. El panel MCM puede cambiar ese `status` en
+ * `activities/<id>/_meta` sin publicar una versión nueva de la app.
  */
 export const ACTIVE_EVENT_ID = VISITAPAPA.id;
 
@@ -305,9 +311,14 @@ export function getEvent(id?: string | null): EventConfig {
   return EVENTS[id] ?? EVENTS[DEFAULT_EVENT_ID];
 }
 
+/** True si el evento es pasado: no se destaca en la app (tab/botón/banner). */
+export function isEventArchived(event: EventConfig): boolean {
+  return event.status === 'archived';
+}
+
 /** Eventos archivados (pasados), para "Más > Eventos pasados". */
 export function getArchivedEvents(): EventConfig[] {
-  return Object.values(EVENTS).filter((e) => e.status === 'archived');
+  return Object.values(EVENTS).filter(isEventArchived);
 }
 
 /** Path de Firebase de una sección: `<firebasePrefix>/<key>`. */

--- a/mcm-app/constants/tabsCatalog.ts
+++ b/mcm-app/constants/tabsCatalog.ts
@@ -65,6 +65,19 @@ export const TABS_CONFIG: TabConfig[] = [
     headerShown: false,
   },
   {
+    name: 'comunica',
+    label: 'Comunica',
+    subtitle: 'Portal de comunicación',
+    emoji: '📣',
+    iosIcon: { default: 'globe', selected: 'globe' },
+    androidIcon: 'public',
+    tintColor: TabHeaderColors.comunica,
+    headerColor: TabHeaderColors.comunica,
+    // La pantalla es un WebView a pantalla completa que gestiona su propia zona
+    // segura (barra glass en el notch); un header encima la partiría.
+    headerShown: false,
+  },
+  {
     name: 'visitapapa',
     label: 'Visita Papa',
     subtitle: 'Visita del Papa León XIV 2026',
@@ -95,17 +108,6 @@ export const TABS_CONFIG: TabConfig[] = [
     androidIcon: 'photo-library',
     tintColor: TabHeaderColors.fotos,
     headerColor: TabHeaderColors.fotos,
-    headerShown: true,
-  },
-  {
-    name: 'comunica',
-    label: 'Comunica',
-    subtitle: 'Portal de comunicación',
-    emoji: '📣',
-    iosIcon: { default: 'globe', selected: 'globe' },
-    androidIcon: 'public',
-    tintColor: TabHeaderColors.comunica,
-    headerColor: TabHeaderColors.comunica,
     headerShown: true,
   },
   {

--- a/mcm-app/firebase-seed/profileConfig.json
+++ b/mcm-app/firebase-seed/profileConfig.json
@@ -16,14 +16,14 @@
       "tabs": [
         "index",
         "contigo",
+        "comunica",
         "calendario",
         "fotos",
         "cancionero",
-        "mas",
-        "visitapapa"
+        "mas"
       ],
-      "homeButtons": ["fotos", "evangelio", "cancionero", "visitapapa"],
-      "masItems": ["comunica", "eventos-pasados"],
+      "homeButtons": ["fotos", "evangelio", "cancionero"],
+      "masItems": ["eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "familias"]
@@ -34,20 +34,14 @@
       "tabs": [
         "index",
         "contigo",
+        "comunica",
         "calendario",
         "fotos",
         "cancionero",
-        "mas",
-        "visitapapa"
+        "mas"
       ],
-      "homeButtons": [
-        "fotos",
-        "evangelio",
-        "comunica",
-        "cancionero",
-        "visitapapa"
-      ],
-      "masItems": ["comunica", "comunica-gestion", "eventos-pasados"],
+      "homeButtons": ["fotos", "evangelio", "comunica", "cancionero"],
+      "masItems": ["comunica-gestion", "eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "monitores"]
@@ -58,14 +52,14 @@
       "tabs": [
         "index",
         "contigo",
+        "comunica",
         "calendario",
         "fotos",
         "cancionero",
-        "mas",
-        "visitapapa"
+        "mas"
       ],
-      "homeButtons": ["fotos", "evangelio", "cancionero", "visitapapa"],
-      "masItems": ["comunica", "comunica-gestion", "eventos-pasados"],
+      "homeButtons": ["fotos", "evangelio", "cancionero"],
+      "masItems": ["comunica-gestion", "eventos-pasados"],
       "defaultCalendars": ["mcm-europa"],
       "albumTags": ["all"],
       "notificationTopics": ["general", "eventos", "miembros"]

--- a/mcm-app/hooks/useVisibleTabs.ts
+++ b/mcm-app/hooks/useVisibleTabs.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
+import { isEventArchived } from '@/constants/events';
+
+/**
+ * Tabs que el usuario debe ver realmente: los `tabs` del perfil resuelto
+ * (`/profileConfig` en Firebase) MENOS el tab del evento en curso si ese
+ * evento está archivado.
+ *
+ * El "archivar" del panel MCM escribe `activities/<id>/_meta.status =
+ * 'archived'`; sin este filtro el tab del evento seguía en la barra porque su
+ * visibilidad dependía sólo de la lista `tabs` del perfil, y archivar no hacía
+ * nada visible en la app.
+ *
+ * Lo consumen `app/(tabs)/_layout.tsx` (barra de tabs) y `MasHomeScreen`
+ * (tarjetas de overflow en iOS), para que el tab no reaparezca como tarjeta.
+ */
+export function useVisibleTabs(): Set<string> {
+  const resolved = useResolvedProfileConfig();
+  const { activeEvent } = useActiveMeta();
+
+  const archivedTabId =
+    isEventArchived(activeEvent) && activeEvent.tabId
+      ? activeEvent.tabId
+      : undefined;
+
+  return useMemo(() => {
+    const visible = new Set(resolved.tabs);
+    if (archivedTabId) visible.delete(archivedTabId);
+    return visible;
+  }, [resolved.tabs, archivedTabId]);
+}


### PR DESCRIPTION
## Por qué

Dar a "archivar" en el panel MCM no archivaba la Visita Papa. No era el panel: el panel escribe `activities/<id>/_meta.status = 'archived'`, la app lo leía y lo mergeaba sobre el registry (`useEventMeta` + `mergeEventMeta`)… y **ningún sitio de la app consumía ese `status`**. La visibilidad del evento salía por otras vías:

| Sitio | De qué dependía antes |
| --- | --- |
| Tab del evento | sólo la lista `tabs` del perfil (`/profileConfig`) |
| Botón del grid de la Home | sólo `homeButtons` |
| Banner "modo evento" | sólo "el perfil tiene acceso al evento" |
| "Más > Eventos pasados" | sólo el registry hardcodeado → un `archived` remoto no aparecía ahí |

Es decir, el botón de archivar no podía funcionar por diseño.

De paso, `comunica` estaba en `TABS_CONFIG` y en `KNOWN_TABS` pero **no existía `app/(tabs)/comunica.tsx`**: ponerla en `tabs` desde el panel habría apuntado a una ruta inexistente.

## Qué cambia

- **`status: 'archived'` ahora manda.** Nuevo `hooks/useVisibleTabs.ts` (= `tabs` del perfil menos el `tabId` del evento en curso si está archivado), aplicado en `(tabs)/_layout.tsx` y en las tarjetas de overflow de `MasHomeScreen`. Gating del banner y del botón del grid en `(tabs)/index.tsx`. `EventosPasadosScreen` incluye el evento en curso cuando el panel lo archiva en caliente.
- **Visita Papa León XIV 2026 → `status: 'archived'`** en `constants/events.ts`: sin tab, sin botón en la Home, sin banner; accesible desde **Más > Eventos pasados**. El panel puede devolverla a `active` sin publicar.
- **Comunica pasa a tab propia, justo después de Contigo.** Se crea `app/(tabs)/comunica.tsx` (envuelve `ComunicaScreen`, `headerShown: false` porque el WebView gestiona su propia zona segura) y su entrada de `TABS_CONFIG` se mueve detrás de `contigo`. El botón de Comunica de la Home apunta a `/comunica` cuando el perfil tiene el tab, en vez de abrir la pantalla dentro del stack de "Más".
- **Seed `firebase-seed/profileConfig.json`** (familia, monitor, miembro): `+comunica` en `tabs`, `-visitapapa` en `tabs`/`homeButtons`, `-comunica` en `masItems`.
- Docs: `docs/funcionalidades/EVENTOS.md` (tabla de qué filtra cada sitio) y `mcm-app/CLAUDE.md` (el árbol de `(tabs)` seguía citando un `app/(disabled)/comunica.tsx` inexistente y `TABS_CONFIG` en `_layout.tsx` en vez de `constants/tabsCatalog.ts`).

Orden resultante de la barra: **Inicio · Cantoral · Contigo · Comunica · Calendario · Fotos · Más**. En iOS, Calendario y Fotos siguen cayendo como tarjetas en "Más" igual que antes: Comunica ocupa el hueco que deja Visita Papa, no desplaza al Cantoral.

## Acción manual pendiente en Firebase

El seed es sólo el fallback offline; manda `/profileConfig` en Firebase. En los tres perfiles hay que aplicar el mismo cambio (`+comunica` en `tabs`, `-visitapapa` en `tabs`/`homeButtons`, `-comunica` en `masItems`) y tocar `updatedAt`. Sin eso, la Visita Papa desaparece igualmente (lo decide el `status`), pero Comunica **no** saldrá como tab.

## Verificación

- `npx tsc --noEmit` limpio
- `npm run lint` → 0 errores (quedan 31 warnings `max-lines` preexistentes)
- `npm test` → 32 suites / 305 tests en verde

Sin paquetes nativos nuevos: apto para OTA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ8QQ1ygCdfPQDpiX4N5fM)_