### PR TITLE
OTA producción: Comunica oscuro arriba/abajo + carga con marca (cherry-pick)

### DIFF
--- a/docs/contratos/COMUNICA_WEBVIEW.md
+++ b/docs/contratos/COMUNICA_WEBVIEW.md
@@ -3,8 +3,12 @@
 > Qué le manda la app MCM a la web de Comunica cuando la carga embebida, y qué
 > tiene que hacer la web (PHP) para responder bien.
 >
-> Lado app: `mcm-app/app/screens/ComunicaScreen.tsx`.
-> Lado web: repo de `comunica.movimientoconsolacion.com` (PHP).
+> Lado app: `mcm-app/app/screens/ComunicaScreen.tsx` (layout) +
+> `mcm-app/hooks/useComunicaWebView.ts` (tema, historial, progreso, errores).
+> Lado web: repo de `comunica.movimientoconsolacion.com` (PHP). Los formularios
+> del CRM (alta de laicos, monitores, participantes) viven en el repo
+> `comunicaFormularios`, y su hoja `crm_comunica_estilos.css` ya implementa este
+> contrato — sirve de **referencia** de cómo hacerlo en el portal PHP.
 
 ## 1. Detectar que se está dentro de la app
 
@@ -62,6 +66,33 @@ html.light { --bg: #ffffff; --fg: #1a1a1a; }
 > `@media (prefers-color-scheme: dark)`. Si la web solo usa el media query, el
 > modo oscuro elegido a mano en la app no se verá reflejado.
 
+La app actualiza además el `<meta name="theme-color">` de la página con el color
+de fondo del tema, y conviene que el `<head>` declare
+`<meta name="color-scheme" content="light dark">` para que los controles nativos
+(inputs, scrollbars) se pinten acordes.
+
+Receta usada en `comunicaFormularios` (recomendada para el portal): declarar la
+paleta en variables CSS con los valores CLAROS por defecto y sobrescribir solo
+las variables en los dos escenarios oscuros — así las reglas se escriben una vez
+y el tema claro no se toca:
+
+```css
+:root { --bg: #ffffff; --fg: #1a1a1a; /* … */ }
+
+/* Oscuro pedido explícitamente por la app */
+html.dark, html[data-mcm-theme="dark"] { --bg: #121316; --fg: #edf0f5; }
+
+/* Fuera de la app: preferencia del sistema, salvo que se haya pedido claro */
+@media (prefers-color-scheme: dark) {
+  html:not(.light):not([data-mcm-theme="light"]) { --bg: #121316; --fg: #edf0f5; }
+}
+```
+
+Ojo con dos detalles que muerden: las variables CSS **no** funcionan dentro de un
+`url()` (para un SVG embebido, como la flecha de los `<select>`, hay que guardar
+el `url()` entero en la variable), y los logos azul oscuro sobre transparente
+necesitan una tarjeta clara detrás en oscuro para seguir legibles.
+
 ### Cambio de tema en caliente
 
 Si el usuario cambia el tema mientras tiene Comunica abierto, la app **no
@@ -77,6 +108,15 @@ reinyecta igual).
 > cross-origin: no se le puede inyectar JS, así que un cambio de tema **sí**
 > recarga el iframe con el nuevo `?theme=`. No hay alternativa y en web el caso
 > es marginal.
+
+### Apariencia nativa de la app
+
+La app llama a `Appearance.setColorScheme()` con el tema elegido, así que todo lo
+que pinta el sistema operativo (barra glass del notch, tab bar, teclado, fondo por
+defecto del propio WebView) sigue el selector de la app y no el modo del
+dispositivo. Antes se quedaba en claro con la app en oscuro. La web no tiene que
+hacer nada con esto, pero explica por qué el marco de la pantalla cambia a la vez
+que el contenido.
 
 ### Quién resuelve «Sistema»
 
@@ -99,6 +139,10 @@ el fondo de página de la web, o aparece una costura de color:
 
 Si la web cambia su fondo de página, avisad para actualizar `PAGE_BG_DARK` /
 `PAGE_BG_LIGHT` en `ComunicaScreen.tsx`.
+
+Ese color se aplica también al propio WebView (`opaque={false}` en iOS): sin eso,
+WKWebView pinta las zonas del `contentInset` —la franja del notch y el hueco del
+tab bar— con su blanco por defecto, que no cambia nunca de tema.
 
 ### Momento de la primera carga
 
@@ -131,14 +175,24 @@ Y conviene que el `<head>` lleve:
 
 sin el cual `env(safe-area-inset-*)` vale siempre 0.
 
-## 4. Navegación
+## 4. Mientras carga
+
+La app tapa la pantalla con una portada de marca propia (onda del logo animada,
+barra de progreso alimentada por `onLoadProgress`, esqueleto de formulario) y la
+desvanece cuando la web termina de cargar. **La web no tiene que poner ningún
+loader propio para la primera carga**; si falla, la app ofrece «Reintentar».
+
+En las navegaciones siguientes dentro del portal no se tapa nada: solo aparece un
+hilo de progreso arriba, como en un navegador.
+
+## 5. Navegación
 
 La app pone su propia cápsula flotante **atrás/adelante** (abajo a la izquierda)
 sobre el historial del WebView, y en Android el botón atrás del sistema navega
 primero por el historial de la web. La web **no** necesita añadir botones de
 volver propios; si los tiene y `app=1`, mejor ocultarlos.
 
-## 5. Notas de seguridad
+## 6. Notas de seguridad
 
 - Sanea siempre `$_GET['theme']` / `$_COOKIE['mcm_theme']` antes de volcarlos al
   HTML (arriba se hace con la comparación a `'dark'`). Son entrada de usuario:

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,45 @@
 
 ---
 
+## 2026-07-30 01:15 — Comunica: modo oscuro completo + pantalla de carga de marca
+
+- **Franjas de arriba y de abajo en claro con la app en oscuro (bug).** Las zonas
+  del `contentInset` (notch arriba, hueco del tab bar abajo) y el rebote del
+  scroll las pintaba **WKWebView con su blanco por defecto**, no la pantalla: se
+  veían dos bandas claras sobre contenido oscuro y no cambiaban nunca de color.
+  El WebView ahora lleva el fondo del tema (`opaque={false}` en iOS + `style`).
+- **El tema del sistema mandaba sobre el de la app en todo lo nativo.** La barra
+  glass del notch, la tab bar nativa de iOS, el teclado y el fondo por defecto de
+  los WebView seguían la apariencia del **sistema operativo**, así que con la app
+  en Oscuro y el móvil en Claro se quedaban claros (y al cambiar el modo del
+  dispositivo con Comunica abierto la parte de arriba no reaccionaba).
+  `AppSettingsContext` ahora llama a `Appearance.setColorScheme()` con el tema
+  elegido — afecta a TODA la app, no solo a Comunica.
+- **Barra glass del notch teñida con el tema** (antes usaba el material del
+  sistema sin tinte) y hairline visible también en oscuro
+  (`GlassSurface` acepta `bottomBorderColor`).
+- **Pantalla de carga de marca** (`ComunicaLoader`): onda del logo animada,
+  barra de progreso real (`onLoadProgress`), esqueleto de formulario y salida en
+  fade. Comunica tarda en responder y antes no se mostraba nada: `renderLoading`
+  no se aplicaba porque faltaba `startInLoadingState`. En error se ofrece
+  **Reintentar** en la propia pantalla; los fallos de navegaciones posteriores
+  siguen siendo un toast y muestran un hilo de progreso arriba
+  (`ComunicaTopProgress`) en vez de tapar la web.
+- La mecánica del WebView (tema hacia la web, historial, progreso, errores) se
+  extrae a `hooks/useComunicaWebView.ts`; la pantalla se queda con el layout.
+- **Lado web** (repo `comunicaFormularios`): `crm_comunica_estilos.css` gana una
+  capa de modo oscuro por variables, colgada de `html.dark` /
+  `data-mcm-theme="dark"` (y de `prefers-color-scheme` fuera de la app), con el
+  fondo de página `#121316` que espera la app; los formularios añaden
+  `viewport-fit=cover` y `<meta name="color-scheme">`, y los elementos fijos
+  reservan `env(safe-area-inset-bottom)`. El tema claro queda igual (verificado
+  pixel a pixel; solo cambian los iconos de enlace externo de los botones
+  legales, que eran oscuros sobre fondo de color).
+- Archivos: `app/screens/ComunicaScreen.tsx`, `hooks/useComunicaWebView.ts`,
+  `components/ui/ComunicaLoader.tsx`, `components/ui/ComunicaTopProgress.tsx`,
+  `components/ui/GlassSurface{,.ios}.tsx`, `contexts/AppSettingsContext.tsx`,
+  `__tests__/comunicaThemeBridge.test.ts`,
+  `docs/contratos/COMUNICA_WEBVIEW.md`.
 ## 2026-07-29 19:20 — Visita Papa archivada y Comunica como tab (después de Contigo)
 
 - **Archivar un evento ahora hace algo.** El "archivar" del panel MCM

--- a/mcm-app/__tests__/comunicaThemeBridge.test.ts
+++ b/mcm-app/__tests__/comunicaThemeBridge.test.ts
@@ -1,0 +1,33 @@
+// Contrato App ↔ Comunica: lo que el WebView inyecta en la web embebida.
+// Documentado en docs/contratos/COMUNICA_WEBVIEW.md — si esto cambia, hay que
+// avisar al lado web (PHP) antes de mergear.
+
+import { themeBridgeJS, COMUNICA_URL } from '@/hooks/useComunicaWebView';
+
+describe('themeBridgeJS', () => {
+  it('marca <html> con el tema y escribe la cookie mcm_theme', () => {
+    const js = themeBridgeJS('dark', '#121316');
+    expect(js).toContain('"dark"');
+    expect(js).toContain('r.dataset.mcmTheme=t');
+    expect(js).toContain("r.classList.toggle('dark', t==='dark')");
+    expect(js).toContain('r.style.colorScheme=t');
+    expect(js).toContain("document.cookie='mcm_theme='+t");
+    expect(js).toContain('path=/');
+    expect(js).toContain('samesite=Lax');
+  });
+
+  it('propaga el color de fondo al meta theme-color', () => {
+    expect(themeBridgeJS('dark', '#121316')).toContain('"#121316"');
+    expect(themeBridgeJS('light', '#FFFFFF')).toContain('"#FFFFFF"');
+  });
+
+  it('no rompe si la web no tiene head accesible (todo en try/catch)', () => {
+    const js = themeBridgeJS('light', '#FFFFFF');
+    expect(js.startsWith('(function(){try{')).toBe(true);
+    expect(js.endsWith('}catch(e){}})();true;')).toBe(true);
+  });
+
+  it('la URL base marca que se está dentro de la app', () => {
+    expect(COMUNICA_URL).toContain('?app=1');
+  });
+});

--- a/mcm-app/app/screens/ComunicaScreen.tsx
+++ b/mcm-app/app/screens/ComunicaScreen.tsx
@@ -5,64 +5,27 @@
 //            de una barra glass nativa (systemChromeMaterial) al hacer scroll.
 //            Extra de scroll al fondo para no dejar el botón bajo el tab bar.
 //   · Android → franja lisa (blanca/oscura) en el notch; la web arranca debajo.
+//
+// La mecánica (tema hacia la web, historial, progreso, errores) vive en
+// `hooks/useComunicaWebView.ts`; aquí solo queda el layout de cada plataforma.
 
-import React, {
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-  useEffect,
-} from 'react';
-import {
-  Platform,
-  View,
-  StyleSheet,
-  StatusBar,
-  ActivityIndicator,
-  BackHandler,
-} from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Platform, View, StyleSheet, StatusBar, Animated } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useFocusEffect } from '@react-navigation/native';
-import { WebView, WebViewNavigation } from 'react-native-webview';
-import { useToast } from '@/contexts/AppToastContext';
-import { Colors as ThemeColors } from '@/constants/colors';
+import { WebView } from 'react-native-webview';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { useAppSettings } from '@/contexts/AppSettingsContext';
+import { durations, easings } from '@/constants/animations';
 import GlassSurface from '@/components/ui/GlassSurface';
 import WebViewNavControls from '@/components/ui/WebViewNavControls';
+import ComunicaLoader from '@/components/ui/ComunicaLoader';
+import ComunicaTopProgress from '@/components/ui/ComunicaTopProgress';
+import { COMUNICA_URL, useComunicaWebView } from '@/hooks/useComunicaWebView';
 
 // CSS module reutilizado del iframe (solo aplica en web)
 /* eslint-disable @typescript-eslint/no-require-imports */
 const iframeStyles =
   Platform.OS === 'web' ? require('../../styles/comunica.module.css') : null;
 /* eslint-enable @typescript-eslint/no-require-imports */
-
-const COMUNICA_URL = 'https://comunica.movimientoconsolacion.com/aptest/?app=1';
-
-/**
- * Propaga el tema de la app (claro/oscuro) a la web embebida. Se manda por
- * TRES vías complementarias, todas inofensivas si la web todavía las ignora:
- *
- *   1. `?theme=` en la URL inicial → PHP puede renderizar ya en oscuro en la
- *      primerísima petición, sin parpadeo.
- *   2. Cookie `mcm_theme` (1 año, path=/) → viaja en TODAS las peticiones
- *      siguientes, así que PHP la lee aunque el usuario navegue por el portal.
- *   3. Atributo/clase en `<html>` + `color-scheme` → sirve a webs que resuelven
- *      el tema solo con CSS, sin tocar el servidor.
- *
- * Se reinyecta en cada carga de página y también en caliente si el usuario
- * cambia el tema mientras está en la pantalla (sin recargar, para no perder
- * lo que tenga escrito en un formulario).
- */
-const themeBridgeJS = (theme: 'light' | 'dark') => `(function(){try{
-  var t=${JSON.stringify(theme)};
-  var r=document.documentElement;
-  r.dataset.mcmTheme=t;
-  r.classList.toggle('dark', t==='dark');
-  r.classList.toggle('light', t!=='dark');
-  r.style.colorScheme=t;
-  document.cookie='mcm_theme='+t+';path=/;max-age=31536000;samesite=Lax';
-}catch(e){}})();true;`;
 
 // Altura aproximada del tab bar iOS (sin la safe-area inferior) + margen cómodo.
 // Se suma como contentInset inferior para que el contenido pueda arrastrarse por
@@ -76,110 +39,113 @@ const IOS_BOTTOM_EXTRA = 32;
 const PAGE_BG_DARK = '#121316';
 const PAGE_BG_LIGHT = '#FFFFFF';
 
+// Hairline bajo la barra glass del notch. La de por defecto (negro al 10%) no
+// se ve sobre fondo oscuro.
+const HAIRLINE_DARK = 'rgba(255,255,255,0.12)';
+const HAIRLINE_LIGHT = 'rgba(0,0,0,0.10)';
+
 export default function ComunicaScreen() {
   const scheme = useColorScheme() ?? 'light';
-  const { loading: settingsLoading } = useAppSettings();
   const insets = useSafeAreaInsets();
-  const tintColor = ThemeColors[scheme].tint;
-  const [isLoading, setIsLoading] = useState(true);
-  const { toast } = useToast();
 
-  // ── Navegación dentro de la web (atrás/adelante) ──────────────────────────
-  const webViewRef = useRef<WebView>(null);
-  const [nav, setNav] = useState({ canGoBack: false, canGoForward: false });
-  const onNavStateChange = useCallback((s: WebViewNavigation) => {
-    setNav({ canGoBack: s.canGoBack, canGoForward: s.canGoForward });
-  }, []);
-  const goBack = useCallback(() => webViewRef.current?.goBack(), []);
-  const goForward = useCallback(() => webViewRef.current?.goForward(), []);
-
-  // ── Tema (claro/oscuro) hacia la web ──────────────────────────────────────
-  // La URL se congela con el PRIMER tema válido: si dependiera de `scheme`, un
-  // cambio de tema mutaría `source.uri` y RECARGARÍA la web, perdiendo lo que
-  // el usuario tuviera escrito. Los cambios en caliente van por injectJavaScript.
-  //
-  // «Válido» = después de que AppSettings haya leído AsyncStorage. Antes de eso
-  // el tema guardado todavía no se conoce y `scheme` cae al del sistema
-  // operativo; congelarlo ahí mandaría `?theme=dark` a alguien que tiene la app
-  // en Claro con el móvil en oscuro (parpadeo del tema equivocado al entrar).
-  const latchedTheme = useRef<'light' | 'dark' | null>(null);
-  if (latchedTheme.current === null && !settingsLoading) {
-    latchedTheme.current = scheme;
-  }
-  const initialTheme = latchedTheme.current;
-  const sourceUri = useMemo(
-    () => (initialTheme ? `${COMUNICA_URL}&theme=${initialTheme}` : null),
-    [initialTheme],
-  );
-  const themeJS = useMemo(() => themeBridgeJS(scheme), [scheme]);
-
-  useEffect(() => {
-    webViewRef.current?.injectJavaScript(themeJS);
-  }, [themeJS]);
-
-  // Android: el botón/gesto atrás del sistema navega primero por el historial
-  // de la web; solo sale de la pantalla cuando ya no hay a dónde volver.
-  useFocusEffect(
-    useCallback(() => {
-      if (Platform.OS !== 'android') return;
-      const sub = BackHandler.addEventListener('hardwareBackPress', () => {
-        if (nav.canGoBack) {
-          webViewRef.current?.goBack();
-          return true;
-        }
-        return false;
-      });
-      return () => sub.remove();
-    }, [nav.canGoBack]),
-  );
-
-  const dynamicStyles = useMemo(
-    () =>
-      StyleSheet.create({
-        loadingContainer: {
-          ...StyleSheet.absoluteFillObject,
-          justifyContent: 'center' as const,
-          alignItems: 'center' as const,
-          backgroundColor:
-            scheme === 'dark' ? 'rgba(0,0,0,0.7)' : 'rgba(255,255,255,0.85)',
-        },
-      }),
-    [scheme],
-  );
-
-  const onLoadEnd = useCallback(() => setIsLoading(false), []);
-  const onError = useCallback(() => {
-    toast.show({
-      variant: 'danger',
-      label: 'Error al cargar el contenido. Verifica tu conexión a internet.',
-      actionLabel: 'Cerrar',
-      onActionPress: ({ hide }) => hide(),
-    });
-    setIsLoading(false);
-  }, [toast]);
-
-  const renderLoading = useCallback(
-    () => (
-      <View style={dynamicStyles.loadingContainer}>
-        <ActivityIndicator size="large" color={tintColor} />
-      </View>
-    ),
-    [dynamicStyles.loadingContainer, tintColor],
-  );
-
-  // Texto de la status bar: oscuro sobre glass claro, claro sobre glass oscuro.
-  const barStyle = scheme === 'dark' ? 'light-content' : 'dark-content';
-  // Fondo bajo el WebView: evita el flash blanco al cargar en modo oscuro.
+  // Fondo de la pantalla Y del propio WebView: sin esto, las zonas del
+  // `contentInset` (notch arriba, hueco del tab bar abajo) y el rebote del
+  // scroll los pinta WKWebView con su blanco por defecto — se veían dos
+  // franjas claras en modo oscuro que además nunca cambiaban de color.
   const pageBg = scheme === 'dark' ? PAGE_BG_DARK : PAGE_BG_LIGHT;
+  const hairline = scheme === 'dark' ? HAIRLINE_DARK : HAIRLINE_LIGHT;
+
+  const {
+    webViewRef,
+    sourceUri,
+    themeJS,
+    nav,
+    onNavigationStateChange,
+    goBack,
+    goForward,
+    status,
+    progress,
+    pageLoading,
+    onLoadStart,
+    onLoadProgress,
+    onLoadEnd,
+    onError,
+    retry,
+  } = useComunicaWebView(pageBg);
+
+  // La portada de carga se desvanece cuando la web ya está lista (y se
+  // desmonta al acabar la transición, para no dejar una capa invisible encima).
+  const loaderOpacity = useRef(new Animated.Value(1)).current;
+  const [loaderMounted, setLoaderMounted] = useState(true);
+  useEffect(() => {
+    if (status === 'ready') {
+      Animated.timing(loaderOpacity, {
+        toValue: 0,
+        duration: durations.slow,
+        easing: easings.exit,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) setLoaderMounted(false);
+      });
+    } else {
+      setLoaderMounted(true);
+      loaderOpacity.setValue(1);
+    }
+  }, [status, loaderOpacity]);
+
+  // Texto de la status bar: oscuro sobre fondo claro, claro sobre fondo oscuro.
+  const barStyle = scheme === 'dark' ? 'light-content' : 'dark-content';
+
+  // Props comunes a iOS/Android del WebView.
+  const commonWebViewProps = useMemo(
+    () => ({
+      // Rendimiento y persistencia
+      javaScriptEnabled: true,
+      domStorageEnabled: true,
+      sharedCookiesEnabled: true,
+      thirdPartyCookiesEnabled: true,
+      // Reaplica el tema en cada carga de página (también tras navegar)
+      injectedJavaScript: themeJS,
+      onNavigationStateChange,
+      onLoadStart,
+      onLoadProgress,
+      onLoadEnd,
+      onError,
+      onHttpError: onError,
+    }),
+    [
+      themeJS,
+      onNavigationStateChange,
+      onLoadStart,
+      onLoadProgress,
+      onLoadEnd,
+      onError,
+    ],
+  );
+
+  const loaderOverlay = (insetTop: number, insetBottom: number) =>
+    loaderMounted || status === 'error' ? (
+      <Animated.View
+        style={[StyleSheet.absoluteFill, { opacity: loaderOpacity }]}
+        pointerEvents={status === 'ready' ? 'none' : 'auto'}
+      >
+        <ComunicaLoader
+          scheme={scheme}
+          progress={progress}
+          error={status === 'error'}
+          onRetry={retry}
+          insetTop={insetTop}
+          insetBottom={insetBottom}
+        />
+      </Animated.View>
+    ) : null;
 
   // Todavía no se sabe el tema guardado: no montamos la web para no cargarla
   // con el tema equivocado (dura lo que tarda un read de AsyncStorage).
   if (!sourceUri) {
     return (
       <View style={[styles.container, { backgroundColor: pageBg }]}>
-        <View style={dynamicStyles.loadingContainer}>
-          <ActivityIndicator size="large" color={tintColor} />
-        </View>
+        {loaderOverlay(insets.top, insets.bottom)}
       </View>
     );
   }
@@ -191,19 +157,21 @@ export default function ComunicaScreen() {
   // congelada). Cambiar de tema es raro y en web no hay WebView que preservar.
   if (Platform.OS === 'web') {
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: pageBg }]}>
         <iframe
           src={`${COMUNICA_URL}&theme=${scheme}`}
           title="Comunica"
           className={iframeStyles?.iframe}
-          style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}
+          style={{
+            flex: 1,
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            backgroundColor: pageBg,
+          }}
           onLoad={onLoadEnd}
         />
-        {isLoading && (
-          <View style={dynamicStyles.loadingContainer}>
-            <ActivityIndicator size="large" color={tintColor} />
-          </View>
-        )}
+        {loaderOverlay(0, 0)}
       </View>
     );
   }
@@ -217,14 +185,12 @@ export default function ComunicaScreen() {
         <WebView
           ref={webViewRef}
           source={{ uri: sourceUri }}
-          style={styles.webview}
-          // Rendimiento y persistencia
-          javaScriptEnabled={true}
-          domStorageEnabled={true}
-          sharedCookiesEnabled={true}
-          thirdPartyCookiesEnabled={true}
-          // Reaplica el tema en cada carga de página (también tras navegar)
-          injectedJavaScript={themeJS}
+          style={[styles.webview, { backgroundColor: pageBg }]}
+          // `opaque={false}` quita el fondo blanco propio de WKWebView: sin
+          // esto el color de arriba lo pintaba él y ni salía oscuro ni cambiaba
+          // al cambiar de tema.
+          opaque={false}
+          {...commonWebViewProps}
           // La web arranca en zona segura y se desliza bajo el glass al scrollear;
           // el inset inferior da margen para subir el contenido sobre el tab bar.
           automaticallyAdjustContentInsets={false}
@@ -238,20 +204,29 @@ export default function ComunicaScreen() {
           // @ts-expect-error `scrollIndicatorInsets` es un passthrough de iOS
           // válido en runtime pero ausente de los tipos de react-native-webview.
           scrollIndicatorInsets={{ top: insets.top, bottom: bottomInset }}
-          onNavigationStateChange={onNavStateChange}
-          renderLoading={renderLoading}
-          onLoadEnd={onLoadEnd}
-          onError={onError}
-          onHttpError={onError}
         />
         {insets.top > 0 && (
           <View
             style={[styles.notchGlass, { height: insets.top }]}
             pointerEvents="none"
           >
-            <GlassSurface variant="regular" bottomBorder />
+            {/* El tinte explícito es lo que garantiza que la franja siga al
+                tema de la APP: el material del sistema sin teñir se resolvía
+                con la apariencia del dispositivo. */}
+            <GlassSurface
+              variant="regular"
+              tintColor={pageBg}
+              bottomBorder
+              bottomBorderColor={hairline}
+            />
           </View>
         )}
+        <ComunicaTopProgress
+          scheme={scheme}
+          progress={progress}
+          visible={pageLoading && status === 'ready'}
+          top={insets.top}
+        />
         <WebViewNavControls
           canGoBack={nav.canGoBack}
           canGoForward={nav.canGoForward}
@@ -262,37 +237,34 @@ export default function ComunicaScreen() {
             { bottom: insets.bottom + IOS_TAB_BAR_HEIGHT + 12 },
           ]}
         />
+        {loaderOverlay(insets.top, bottomInset)}
       </View>
     );
   }
 
   // ── Android: franja lisa en el notch, la web arranca debajo ────────────────
-  const stripColor = pageBg;
   return (
-    <View style={[styles.container, { backgroundColor: stripColor }]}>
-      <StatusBar barStyle={barStyle} backgroundColor={stripColor} translucent />
+    <View style={[styles.container, { backgroundColor: pageBg }]}>
+      <StatusBar barStyle={barStyle} backgroundColor={pageBg} translucent />
       {insets.top > 0 && (
         <View
           style={[
             styles.notchBar,
-            { backgroundColor: stripColor, height: insets.top },
+            { backgroundColor: pageBg, height: insets.top },
           ]}
         />
       )}
       <WebView
         ref={webViewRef}
         source={{ uri: sourceUri }}
-        style={styles.webview}
-        javaScriptEnabled={true}
-        domStorageEnabled={true}
-        sharedCookiesEnabled={true}
-        thirdPartyCookiesEnabled={true}
-        injectedJavaScript={themeJS}
-        onNavigationStateChange={onNavStateChange}
-        renderLoading={renderLoading}
-        onLoadEnd={onLoadEnd}
-        onError={onError}
-        onHttpError={onError}
+        style={[styles.webview, { backgroundColor: pageBg }]}
+        {...commonWebViewProps}
+      />
+      <ComunicaTopProgress
+        scheme={scheme}
+        progress={progress}
+        visible={pageLoading && status === 'ready'}
+        top={insets.top}
       />
       <WebViewNavControls
         canGoBack={nav.canGoBack}
@@ -301,6 +273,7 @@ export default function ComunicaScreen() {
         onForward={goForward}
         style={[styles.navControls, { bottom: insets.bottom + 16 }]}
       />
+      {loaderOverlay(insets.top, insets.bottom)}
     </View>
   );
 }

--- a/mcm-app/components/ui/ComunicaLoader.tsx
+++ b/mcm-app/components/ui/ComunicaLoader.tsx
@@ -1,0 +1,445 @@
+// components/ui/ComunicaLoader.tsx
+// Pantalla de carga de marca para el WebView de Comunica.
+//
+// Comunica tarda en responder (el CRM va lento), así que en vez de dejar un
+// hueco vacío o un spinner suelto se muestra una portada animada con la onda
+// del logo, una barra de progreso real (`onLoadProgress`) y un esqueleto de
+// formulario que anticipa lo que va a aparecer. Al terminar se desvanece.
+//
+// Solo RN Animated (native driver) + expo-linear-gradient: nada de SVG ni
+// dependencias nuevas. Todo el color sale de tokens y respeta claro/oscuro.
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  Animated,
+  Easing,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialIcons } from '@expo/vector-icons';
+import brand from '@/constants/colors';
+import spacing from '@/constants/spacing';
+import { radii } from '@/constants/uiStyles';
+import { durations, easings } from '@/constants/animations';
+
+interface ComunicaLoaderProps {
+  /** Tema resuelto por la app (no el del sistema). */
+  scheme: 'light' | 'dark';
+  /** Progreso de carga del WebView (0–1). */
+  progress: number;
+  /** Cuando es true, en vez del progreso se ofrece reintentar. */
+  error?: boolean;
+  /** Reintento tras error. */
+  onRetry?: () => void;
+  /** Espacio superior (notch) e inferior (tab bar) a respetar. */
+  insetTop?: number;
+  insetBottom?: number;
+}
+
+// Barras de la onda del logo (alturas relativas en reposo) y desfase del loop.
+const WAVE_BARS = [
+  { h: 18, delay: 0 },
+  { h: 34, delay: 120 },
+  { h: 52, delay: 240 },
+  { h: 34, delay: 360 },
+  { h: 22, delay: 480 },
+];
+
+export default function ComunicaLoader({
+  scheme,
+  progress,
+  error = false,
+  onRetry,
+  insetTop = 0,
+  insetBottom = 0,
+}: ComunicaLoaderProps) {
+  const isDark = scheme === 'dark';
+
+  // Paleta: azules del logo de Comunica. En oscuro se aclaran para mantener
+  // contraste sobre el fondo casi negro de la web.
+  const palette = useMemo(
+    () =>
+      isDark
+        ? {
+            gradient: ['#121316', '#171B24', '#121316'] as const,
+            accent: brand.info, // celeste
+            accentSoft: brand.secondary, // azul letras
+            title: '#F2F4F8',
+            subtitle: 'rgba(242,244,248,0.62)',
+            skeleton: 'rgba(255,255,255,0.07)',
+            skeletonHi: 'rgba(255,255,255,0.16)',
+            track: 'rgba(255,255,255,0.12)',
+            markBg: 'rgba(49,170,223,0.12)',
+            markRing: 'rgba(49,170,223,0.35)',
+          }
+        : {
+            gradient: ['#FFFFFF', '#F3F7FD', '#FFFFFF'] as const,
+            accent: brand.primary, // azul fondo MCM
+            accentSoft: brand.info,
+            title: brand.text,
+            subtitle: 'rgba(0,43,129,0.55)',
+            skeleton: 'rgba(37,56,131,0.07)',
+            skeletonHi: 'rgba(37,56,131,0.14)',
+            track: 'rgba(37,56,131,0.12)',
+            markBg: 'rgba(37,56,131,0.07)',
+            markRing: 'rgba(37,56,131,0.18)',
+          },
+    [isDark],
+  );
+
+  // ── Animaciones en loop: onda + anillo que respira ────────────────────────
+  const bars = useRef(WAVE_BARS.map(() => new Animated.Value(0.45))).current;
+  const ring = useRef(new Animated.Value(0)).current;
+  const entry = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loops = bars.map((v, i) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(WAVE_BARS[i].delay),
+          Animated.timing(v, {
+            toValue: 1,
+            duration: 480,
+            easing: easings.cubic,
+            useNativeDriver: true,
+          }),
+          Animated.timing(v, {
+            toValue: 0.4,
+            duration: 480,
+            easing: easings.cubic,
+            useNativeDriver: true,
+          }),
+        ]),
+      ),
+    );
+    const ringLoop = Animated.loop(
+      Animated.timing(ring, {
+        toValue: 1,
+        duration: 2200,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }),
+    );
+    const enter = Animated.timing(entry, {
+      toValue: 1,
+      duration: durations.slow,
+      easing: easings.bouncy,
+      useNativeDriver: true,
+    });
+
+    enter.start();
+    loops.forEach((l) => l.start());
+    ringLoop.start();
+    return () => {
+      enter.stop();
+      loops.forEach((l) => l.stop());
+      ringLoop.stop();
+    };
+  }, [bars, ring, entry]);
+
+  // ── Barra de progreso ─────────────────────────────────────────────────────
+  // `onLoadProgress` llega a saltos (y en Android a veces se queda en 0.1 un
+  // rato), así que se anima hacia el valor recibido con un mínimo visible para
+  // que la barra nunca parezca congelada del todo.
+  const bar = useRef(new Animated.Value(0.06)).current;
+  useEffect(() => {
+    Animated.timing(bar, {
+      toValue: Math.max(0.06, Math.min(progress, 1)),
+      duration: 420,
+      easing: easings.standard,
+      useNativeDriver: true,
+    }).start();
+  }, [bar, progress]);
+
+  // ── Shimmer del esqueleto ─────────────────────────────────────────────────
+  const shimmer = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(shimmer, {
+        toValue: 1,
+        duration: 1400,
+        easing: Easing.inOut(Easing.ease),
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shimmer]);
+
+  const shimmerStyle = {
+    opacity: shimmer.interpolate({
+      inputRange: [0, 0.5, 1],
+      outputRange: [0.45, 1, 0.45],
+    }),
+  };
+
+  const skeletonRow = (width: `${number}%`, height = 14) => (
+    <Animated.View
+      style={[
+        { width, height, borderRadius: radii.sm },
+        { backgroundColor: palette.skeleton },
+        shimmerStyle,
+      ]}
+    />
+  );
+
+  return (
+    <View
+      style={[StyleSheet.absoluteFill, styles.root]}
+      // El overlay tapa la web mientras carga; los toques no deben llegar
+      // abajo salvo al botón de reintentar (que sí es un hijo pulsable).
+      accessibilityRole="progressbar"
+      accessibilityLabel={
+        error ? 'Error al cargar Comunica' : 'Cargando Comunica'
+      }
+    >
+      <LinearGradient
+        colors={palette.gradient}
+        style={StyleSheet.absoluteFill}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0.6, y: 1 }}
+      />
+
+      <View
+        style={[
+          styles.content,
+          { paddingTop: insetTop + spacing.xl, paddingBottom: insetBottom },
+        ]}
+      >
+        <Animated.View
+          style={{
+            opacity: entry,
+            transform: [
+              {
+                translateY: entry.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [12, 0],
+                }),
+              },
+            ],
+            alignItems: 'center',
+          }}
+        >
+          {/* Marca: burbuja con la onda de audio del logo + anillo que respira */}
+          <View style={styles.markWrapper}>
+            <Animated.View
+              style={[
+                styles.markRing,
+                {
+                  borderColor: palette.markRing,
+                  opacity: ring.interpolate({
+                    inputRange: [0, 0.15, 1],
+                    outputRange: [0, 0.9, 0],
+                  }),
+                  transform: [
+                    {
+                      scale: ring.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [0.85, 1.45],
+                      }),
+                    },
+                  ],
+                },
+              ]}
+            />
+            <View style={[styles.mark, { backgroundColor: palette.markBg }]}>
+              <View style={styles.wave}>
+                {WAVE_BARS.map((b, i) => (
+                  <Animated.View
+                    key={i}
+                    style={{
+                      width: 6,
+                      height: b.h,
+                      borderRadius: 3,
+                      backgroundColor:
+                        i % 2 === 0 ? palette.accent : palette.accentSoft,
+                      transform: [{ scaleY: bars[i] }],
+                    }}
+                  />
+                ))}
+              </View>
+              {/* Pico de la burbuja de diálogo del logo */}
+              <View
+                style={[styles.markTail, { borderTopColor: palette.markBg }]}
+              />
+            </View>
+          </View>
+
+          <Text style={[styles.title, { color: palette.title }]}>Comunica</Text>
+          <Text style={[styles.subtitle, { color: palette.subtitle }]}>
+            {error
+              ? 'No hemos podido conectar con el portal'
+              : 'Preparando el portal…'}
+          </Text>
+
+          {error ? (
+            <Pressable
+              onPress={onRetry}
+              accessibilityRole="button"
+              accessibilityLabel="Reintentar"
+              style={({ pressed }) => [
+                styles.retry,
+                {
+                  backgroundColor: palette.accent,
+                  opacity: pressed ? 0.85 : 1,
+                },
+              ]}
+            >
+              <MaterialIcons name="refresh" size={18} color="#FFFFFF" />
+              <Text style={styles.retryLabel}>Reintentar</Text>
+            </Pressable>
+          ) : (
+            <View style={[styles.track, { backgroundColor: palette.track }]}>
+              <Animated.View
+                style={[
+                  styles.fill,
+                  {
+                    backgroundColor: palette.accent,
+                    // scaleX sobre el ancho completo: animable en el hilo
+                    // nativo (a diferencia de `width`, que va por JS).
+                    transform: [{ scaleX: bar }],
+                  },
+                ]}
+              />
+            </View>
+          )}
+        </Animated.View>
+
+        {/* Esqueleto: insinúa el formulario que está a punto de aparecer */}
+        {!error && (
+          <View style={styles.skeleton} pointerEvents="none">
+            {[0, 1, 2].map((i) => (
+              <View key={i} style={styles.skeletonGroup}>
+                {skeletonRow(i === 0 ? '42%' : '34%', 10)}
+                <Animated.View
+                  style={[
+                    styles.skeletonField,
+                    { backgroundColor: palette.skeleton },
+                    shimmerStyle,
+                  ]}
+                />
+              </View>
+            ))}
+            <Animated.View
+              style={[
+                styles.skeletonButton,
+                { backgroundColor: palette.skeletonHi },
+                shimmerStyle,
+              ]}
+            />
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    zIndex: 20,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    justifyContent: 'center',
+    gap: spacing.xl,
+  },
+  markWrapper: {
+    width: 108,
+    height: 108,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  markRing: {
+    position: 'absolute',
+    width: 108,
+    height: 108,
+    borderRadius: 54,
+    borderWidth: 2,
+  },
+  mark: {
+    width: 84,
+    height: 84,
+    borderRadius: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Triángulo (pico de la burbuja) hecho con bordes: alto 14, ancho 16.
+  markTail: {
+    position: 'absolute',
+    bottom: -9,
+    left: 18,
+    width: 0,
+    height: 0,
+    borderRightWidth: 16,
+    borderTopWidth: 14,
+    borderRightColor: 'transparent',
+  },
+  wave: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    height: 56,
+  },
+  title: {
+    marginTop: spacing.md,
+    fontSize: 26,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  subtitle: {
+    marginTop: spacing.xs,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  track: {
+    marginTop: spacing.lg,
+    width: 180,
+    height: 5,
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  fill: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 3,
+    // Por defecto `scaleX` escala desde el centro; con `transformOrigin` la
+    // barra crece desde el borde izquierdo (soportado en nativo y web).
+    transformOrigin: 'left',
+  },
+  retry: {
+    marginTop: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingVertical: 10,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.pill,
+  },
+  retryLabel: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  skeleton: {
+    gap: spacing.md,
+    maxWidth: 420,
+    width: '100%',
+    alignSelf: 'center',
+  },
+  skeletonGroup: {
+    gap: spacing.xs,
+  },
+  skeletonField: {
+    height: 44,
+    borderRadius: radii.md,
+  },
+  skeletonButton: {
+    height: 46,
+    borderRadius: radii.pill,
+    width: '55%',
+  },
+});

--- a/mcm-app/components/ui/ComunicaTopProgress.tsx
+++ b/mcm-app/components/ui/ComunicaTopProgress.tsx
@@ -1,0 +1,80 @@
+// components/ui/ComunicaTopProgress.tsx
+// Hilo de progreso para las navegaciones POSTERIORES a la primera carga del
+// WebView de Comunica. La portada completa (`ComunicaLoader`) solo se justifica
+// al entrar; al pulsar un enlace dentro del portal basta una barra fina arriba
+// (patrón navegador) para no tapar lo que el usuario ya estaba viendo.
+
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import brand from '@/constants/colors';
+import { durations, easings } from '@/constants/animations';
+
+interface ComunicaTopProgressProps {
+  scheme: 'light' | 'dark';
+  /** Progreso de carga del WebView (0-1). */
+  progress: number;
+  visible: boolean;
+  /** Offset superior (alto del notch) para no quedar bajo la barra glass. */
+  top?: number;
+}
+
+export default function ComunicaTopProgress({
+  scheme,
+  progress,
+  visible,
+  top = 0,
+}: ComunicaTopProgressProps) {
+  const accent = scheme === 'dark' ? brand.info : brand.primary;
+  const width = useRef(new Animated.Value(0.02)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(width, {
+      toValue: Math.max(0.02, Math.min(progress, 1)),
+      duration: 300,
+      easing: easings.standard,
+      useNativeDriver: true,
+    }).start();
+  }, [width, progress]);
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: visible ? 1 : 0,
+      duration: visible ? 120 : durations.slow,
+      easing: easings.standard,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished && !visible) width.setValue(0.02);
+    });
+  }, [opacity, visible, width]);
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[styles.track, { top, opacity }]}
+    >
+      <Animated.View
+        style={[
+          styles.fill,
+          { backgroundColor: accent, transform: [{ scaleX: width }] },
+        ]}
+      />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: 3,
+    zIndex: 15,
+  },
+  fill: {
+    width: '100%',
+    height: '100%',
+    // Crece desde el borde izquierdo en vez de desde el centro.
+    transformOrigin: 'left',
+  },
+});

--- a/mcm-app/components/ui/GlassSurface.ios.tsx
+++ b/mcm-app/components/ui/GlassSurface.ios.tsx
@@ -25,6 +25,11 @@ export interface GlassSurfaceProps {
   blurTint?: BlurTint;
   /** Optional bottom hairline border (used by GlassHeader to separate from content). */
   bottomBorder?: boolean;
+  /**
+   * Color de esa hairline. El default (negro al 10%) es invisible sobre
+   * superficies oscuras: pásalo explícito en modo oscuro.
+   */
+  bottomBorderColor?: string;
   /** Children rendered on top of the glass effect (rare — usually you wrap content elsewhere). */
   children?: React.ReactNode;
   style?: ViewStyle | ViewStyle[];
@@ -42,6 +47,7 @@ export default function GlassSurface({
   variant = 'regular',
   blurTint: blurTintOverride,
   bottomBorder = false,
+  bottomBorderColor,
   children,
   style,
 }: GlassSurfaceProps) {
@@ -101,7 +107,14 @@ export default function GlassSurface({
   return (
     <View style={[StyleSheet.absoluteFill, style]}>
       {baseLayer}
-      {bottomBorder ? <View style={styles.bottomBorder} /> : null}
+      {bottomBorder ? (
+        <View
+          style={[
+            styles.bottomBorder,
+            bottomBorderColor ? { backgroundColor: bottomBorderColor } : null,
+          ]}
+        />
+      ) : null}
       {children}
     </View>
   );

--- a/mcm-app/components/ui/GlassSurface.tsx
+++ b/mcm-app/components/ui/GlassSurface.tsx
@@ -9,6 +9,11 @@ export interface GlassSurfaceProps {
   variant?: 'clear' | 'regular' | 'material';
   /** Optional bottom hairline border. */
   bottomBorder?: boolean;
+  /**
+   * Color de esa hairline. El default (negro al 10%) es invisible sobre
+   * superficies oscuras: pásalo explícito en modo oscuro.
+   */
+  bottomBorderColor?: string;
   children?: React.ReactNode;
   style?: ViewStyle | ViewStyle[];
 }
@@ -26,6 +31,7 @@ export default function GlassSurface({
   tintColor,
   variant = 'regular',
   bottomBorder = false,
+  bottomBorderColor,
   children,
   style,
 }: GlassSurfaceProps) {
@@ -58,7 +64,14 @@ export default function GlassSurface({
         style,
       ]}
     >
-      {bottomBorder ? <View style={styles.bottomBorder} /> : null}
+      {bottomBorder ? (
+        <View
+          style={[
+            styles.bottomBorder,
+            bottomBorderColor ? { backgroundColor: bottomBorderColor } : null,
+          ]}
+        />
+      ) : null}
       {children}
     </View>
   );

--- a/mcm-app/contexts/AppSettingsContext.tsx
+++ b/mcm-app/contexts/AppSettingsContext.tsx
@@ -9,6 +9,7 @@ import React, {
   ReactNode,
 } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Appearance, Platform } from 'react-native';
 
 export type ThemeScheme = 'light' | 'dark' | 'system';
 
@@ -69,6 +70,23 @@ export const AppSettingsProvider = ({ children }: { children: ReactNode }) => {
       logger.error('Failed saving app settings', e);
     });
   }, [settings, loading]);
+
+  // Alinea la apariencia NATIVA con el tema elegido en la app.
+  //
+  // Sin esto, todo lo que pinta el sistema (tab bar nativa de iOS, materiales
+  // glass, fondo por defecto de los WebView, teclado, menús contextuales) sigue
+  // al modo del SISTEMA OPERATIVO y no al selector de la app: con la app en
+  // Oscuro y el móvil en Claro se veía la franja del notch y la barra de
+  // pestañas en claro sobre contenido oscuro — y no cambiaban nunca.
+  //
+  // `'unspecified'` devuelve el control al sistema (opción «Sistema»).
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    if (loading) return; // aún no se sabe el tema guardado
+    Appearance.setColorScheme(
+      settings.theme === 'system' ? 'unspecified' : settings.theme,
+    );
+  }, [settings.theme, loading]);
 
   const update = useCallback((values: Partial<AppSettings>) => {
     setSettingsState((prev) => ({ ...prev, ...values }));

--- a/mcm-app/hooks/useComunicaWebView.ts
+++ b/mcm-app/hooks/useComunicaWebView.ts
@@ -1,0 +1,188 @@
+// hooks/useComunicaWebView.ts
+// Toda la mecánica del WebView de Comunica que no es maquetación: tema hacia la
+// web, historial atrás/adelante, progreso de carga y estado de error/reintento.
+// La pantalla (`app/screens/ComunicaScreen.tsx`) se queda solo con el layout.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BackHandler, Platform } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import type { WebView, WebViewNavigation } from 'react-native-webview';
+import type { WebViewProgressEvent } from 'react-native-webview/lib/WebViewTypes';
+import { useToast } from '@/contexts/AppToastContext';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { useAppSettings } from '@/contexts/AppSettingsContext';
+
+export const COMUNICA_URL =
+  'https://comunica.movimientoconsolacion.com/aptest/?app=1';
+
+/**
+ * Propaga el tema de la app (claro/oscuro) a la web embebida. Se manda por
+ * TRES vías complementarias, todas inofensivas si la web todavía las ignora:
+ *
+ *   1. `?theme=` en la URL inicial → PHP puede renderizar ya en oscuro en la
+ *      primerísima petición, sin parpadeo.
+ *   2. Cookie `mcm_theme` (1 año, path=/) → viaja en TODAS las peticiones
+ *      siguientes, así que PHP la lee aunque el usuario navegue por el portal.
+ *   3. Atributo/clase en `<html>` + `color-scheme` → sirve a webs que resuelven
+ *      el tema solo con CSS, sin tocar el servidor.
+ *
+ * Se reinyecta en cada carga de página y también en caliente si el usuario
+ * cambia el tema mientras está en la pantalla (sin recargar, para no perder
+ * lo que tenga escrito en un formulario).
+ *
+ * `<meta name="theme-color">` se actualiza también: algunos navegadores
+ * embebidos lo usan para pintar la costura superior/inferior del scroll.
+ */
+export const themeBridgeJS = (theme: 'light' | 'dark', pageBg: string) =>
+  `(function(){try{
+  var t=${JSON.stringify(theme)};
+  var bg=${JSON.stringify(pageBg)};
+  var r=document.documentElement;
+  r.dataset.mcmTheme=t;
+  r.classList.toggle('dark', t==='dark');
+  r.classList.toggle('light', t!=='dark');
+  r.style.colorScheme=t;
+  var m=document.querySelector('meta[name="theme-color"]');
+  if(!m){m=document.createElement('meta');m.setAttribute('name','theme-color');document.head.appendChild(m);}
+  m.setAttribute('content',bg);
+  document.cookie='mcm_theme='+t+';path=/;max-age=31536000;samesite=Lax';
+}catch(e){}})();true;`;
+
+type Status = 'loading' | 'ready' | 'error';
+
+export function useComunicaWebView(pageBg: string) {
+  const scheme = useColorScheme() ?? 'light';
+  const { loading: settingsLoading } = useAppSettings();
+  const { toast } = useToast();
+  const webViewRef = useRef<WebView>(null);
+
+  // ── Historial de la web (atrás/adelante) ──────────────────────────────────
+  const [nav, setNav] = useState({ canGoBack: false, canGoForward: false });
+  const onNavigationStateChange = useCallback((s: WebViewNavigation) => {
+    setNav({ canGoBack: s.canGoBack, canGoForward: s.canGoForward });
+  }, []);
+  const goBack = useCallback(() => webViewRef.current?.goBack(), []);
+  const goForward = useCallback(() => webViewRef.current?.goForward(), []);
+
+  // Android: el botón/gesto atrás del sistema navega primero por el historial
+  // de la web; solo sale de la pantalla cuando ya no hay a dónde volver.
+  useFocusEffect(
+    useCallback(() => {
+      if (Platform.OS !== 'android') return;
+      const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+        if (nav.canGoBack) {
+          webViewRef.current?.goBack();
+          return true;
+        }
+        return false;
+      });
+      return () => sub.remove();
+    }, [nav.canGoBack]),
+  );
+
+  // ── Tema hacia la web ─────────────────────────────────────────────────────
+  // La URL se congela con el PRIMER tema válido: si dependiera de `scheme`, un
+  // cambio de tema mutaría `source.uri` y RECARGARÍA la web, perdiendo lo que
+  // el usuario tuviera escrito. Los cambios en caliente van por injectJavaScript.
+  //
+  // «Válido» = después de que AppSettings haya leído AsyncStorage. Antes de eso
+  // el tema guardado todavía no se conoce y `scheme` cae al del sistema
+  // operativo; congelarlo ahí mandaría `?theme=dark` a alguien que tiene la app
+  // en Claro con el móvil en oscuro (parpadeo del tema equivocado al entrar).
+  const latchedTheme = useRef<'light' | 'dark' | null>(null);
+  if (latchedTheme.current === null && !settingsLoading) {
+    latchedTheme.current = scheme;
+  }
+  const initialTheme = latchedTheme.current;
+  const sourceUri = useMemo(
+    () => (initialTheme ? `${COMUNICA_URL}&theme=${initialTheme}` : null),
+    [initialTheme],
+  );
+  const themeJS = useMemo(
+    () => themeBridgeJS(scheme, pageBg),
+    [scheme, pageBg],
+  );
+
+  useEffect(() => {
+    webViewRef.current?.injectJavaScript(themeJS);
+  }, [themeJS]);
+
+  // ── Carga: progreso, primera carga y errores ──────────────────────────────
+  const [status, setStatus] = useState<Status>('loading');
+  const [progress, setProgress] = useState(0);
+  // Navegación posterior a la primera carga (enlace dentro del portal): no se
+  // tapa la pantalla, solo se muestra el hilo de progreso de arriba.
+  const [pageLoading, setPageLoading] = useState(false);
+
+  const onLoadStart = useCallback(() => {
+    setProgress(0.02);
+    setPageLoading(true);
+  }, []);
+
+  const onLoadProgress = useCallback((e: WebViewProgressEvent) => {
+    setProgress(e.nativeEvent.progress);
+  }, []);
+
+  // Se pone a true en cuanto una carga termina bien: a partir de ahí los
+  // errores son de una navegación concreta, no del arranque de la pantalla.
+  const hasLoadedOk = useRef(false);
+  const failedRef = useRef(false);
+
+  const onLoadEnd = useCallback(() => {
+    setProgress(1);
+    setPageLoading(false);
+    if (failedRef.current) return; // el error manda: no destapamos la web rota
+    hasLoadedOk.current = true;
+    // Reinyecta el tema por si esta carga no aplicó `injectedJavaScript`
+    // (redirecciones, back/forward cache): es idempotente y baratísimo.
+    webViewRef.current?.injectJavaScript(themeJS);
+    setStatus('ready');
+  }, [themeJS]);
+
+  const onError = useCallback(
+    // Sirve tanto para `onError` como para `onHttpError` (tipos distintos en
+    // react-native-webview): no usamos el evento, solo el hecho de que falló.
+    () => {
+      setPageLoading(false);
+      if (!hasLoadedOk.current) {
+        failedRef.current = true;
+        setStatus('error');
+        return;
+      }
+      // Si ya había contenido en pantalla, un toast molesta menos que taparlo.
+      toast.show({
+        variant: 'danger',
+        label: 'No hemos podido cargar esa página de Comunica.',
+        actionLabel: 'Cerrar',
+        onActionPress: ({ hide }) => hide(),
+      });
+    },
+    [toast],
+  );
+
+  const retry = useCallback(() => {
+    failedRef.current = false;
+    setProgress(0);
+    setStatus('loading');
+    webViewRef.current?.reload();
+  }, []);
+
+  return {
+    scheme,
+    webViewRef,
+    sourceUri,
+    themeJS,
+    nav,
+    onNavigationStateChange,
+    goBack,
+    goForward,
+    status,
+    progress,
+    pageLoading,
+    onLoadStart,
+    onLoadProgress,
+    onLoadEnd,
+    onError,
+    retry,
+  };
+}


### PR DESCRIPTION
## Qué es

**Cherry-pick a `production`** del mismo commit de #309 (que va a `main`). Al mergear esto, `ota-production.yml` publica el OTA al canal `production` y lo reciben todos los usuarios en el siguiente arranque (o en 15 min con la app abierta).

Se hace por cherry-pick y no por merge de `main` a propósito: `main` va **67 commits** por delante de `production`, así que un merge arrastraría todo lo demás. Esta rama sale de `production` y lleva **solo** este cambio (más la entrada de CHANGELOG, cuyo conflicto se resolvió dejando ambas entradas en orden cronológico).

## Contenido

Idéntico a #309:

- Las franjas de arriba y abajo de Comunica ya no las pinta WKWebView en blanco (`opaque={false}` + fondo del tema).
- `Appearance.setColorScheme()` alinea la apariencia **nativa de toda la app** con el selector de tema — barra glass, tab bar de iOS, teclado. ⚠️ Es el punto de mayor alcance del cambio y el que conviene mirar primero en producción.
- Barra glass del notch teñida con el tema + hairline visible en oscuro.
- Portada de carga con marca, progreso real y Reintentar; hilo de progreso arriba en las navegaciones siguientes.

## Comprobado sobre la base de `production`

- `npx tsc --noEmit` limpio
- `npm run lint` sin errores
- `npm test`: 286 tests en verde (la suite de `production`, más el test nuevo del puente de tema)
- **Sin dependencias nativas nuevas** → OTA seguro, no lleva `[skip-ota]`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WX3F1WwAETZnLJuXQbNdYB)_