### PR TITLE
Aplica las 2 optimizaciones de Bolt que merecían la pena

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-06-16 - [ListHeaderComponent React Element Memory Leak]
 **Learning:** [Defining a React Element for \`ListHeaderComponent\` directly inside the parent render loop without memoization causes the `FlatList` to unmount and remount the header entirely on every parent re-render (like keystrokes in a search input). This also forces the \`FlatList\` internal layout mechanics to recalculate.]
 **Action:** [Always wrap \`ListHeaderComponent\` elements defined inside functional components with \`useMemo\`, or extract them into separate memoized components outside the main render loop.]
+## 2026-07-08 - [Split useMemo for O(1) state updates]
+**Learning:** [Combining large dataset processing (O(N log N) sorting and O(N) mapping) with frequently changing scalar dependencies (like `selectedSongs.length`) inside a single `useMemo` causes massive unnecessary re-computations when the scalar value changes.]
+**Action:** [Always split such `useMemo` hooks. Compute and memoize the expensive heavy-lifting using only the large dataset as a dependency, then use a second, lightweight `useMemo` to combine the pre-computed array with the scalar state.]

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
 ## 2026-06-16 - [ListHeaderComponent React Element Memory Leak]
 **Learning:** [Defining a React Element for \`ListHeaderComponent\` directly inside the parent render loop without memoization causes the `FlatList` to unmount and remount the header entirely on every parent re-render (like keystrokes in a search input). This also forces the \`FlatList\` internal layout mechanics to recalculate.]
-**Action:** [Always wrap \`ListHeaderComponent\` elements defined inside functional components with \`useMemo\`, or extract them into separate memoized components outside the main render loop.]
+**Action:** [Always extract \`ListHeaderComponent\` elements into separate memoized components wrapped with \`React.memo\` outside the main render loop. Avoid memoizing large JSX blocks directly using \`useMemo\` as it introduces a high risk of brittle dependency arrays and stale closures.]

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -78,7 +78,10 @@ export default function CategoriesScreen({
     { categoryTitle: string; songs: any[] }
   > | null>('songs', 'songs', filterSongsData);
   const { selectedSongs } = useSelectedSongs();
-  const { sortedCategories, displayCategories } = useMemo(() => {
+  // ⚡ Bolt Optimization:
+  // Split the useMemo to prevent re-sorting and re-mapping all categories
+  // every time `selectedSongs.length` changes (O(N log N) -> O(1) on selection change).
+  const { sortedCategories, baseCategoryItems } = useMemo(() => {
     const actualCategories = songsData ? Object.keys(songsData) : [];
     const sortedCats = actualCategories.sort((a, b) => {
       const titleA = songsData?.[a]?.categoryTitle ?? a;
@@ -86,21 +89,25 @@ export default function CategoriesScreen({
       return titleA.localeCompare(titleB);
     });
 
-    const displayCats = [
+    const mappedCats = sortedCats.map((cat) => ({
+      id: cat,
+      name: songsData?.[cat]?.categoryTitle ?? cat,
+      songCount: songsData?.[cat]?.songs?.length || 0,
+    }));
+
+    return { sortedCategories: sortedCats, baseCategoryItems: mappedCats };
+  }, [songsData]);
+
+  const displayCategories = useMemo(() => {
+    return [
       {
         id: SELECTED_SONGS_CATEGORY_ID,
         name: 'Tu selección',
         songCount: selectedSongs.length,
       },
-      ...sortedCats.map((cat) => ({
-        id: cat,
-        name: songsData?.[cat]?.categoryTitle ?? cat,
-        songCount: songsData?.[cat]?.songs?.length || 0,
-      })),
+      ...baseCategoryItems,
     ];
-
-    return { sortedCategories: sortedCats, displayCategories: displayCats };
-  }, [songsData, selectedSongs.length]);
+  }, [baseCategoryItems, selectedSongs.length]);
 
   const [showForm, setShowForm] = useState(false);
   const { toast } = useToast();

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -126,6 +126,76 @@ const OVERWRITE_PASSWORD = 'coco';
 
 type ViewMode = 'category' | 'manual';
 
+interface HeaderBarProps {
+  visibleCount: number;
+  lastUploadCode: string | null;
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => void;
+  styles: any;
+}
+
+const HeaderBar = React.memo(function HeaderBar({
+  visibleCount,
+  lastUploadCode,
+  viewMode,
+  setViewMode,
+  styles,
+}: HeaderBarProps) {
+  return (
+    <View>
+      <ChoirSessionBanner />
+      <View style={styles.summaryRow}>
+        <View>
+          <Text style={styles.selectionCount}>
+            {visibleCount} {visibleCount === 1 ? 'canción' : 'canciones'}
+          </Text>
+          {lastUploadCode ? (
+            <Text style={styles.subInfo}>
+              ☁️ Guardada con código {lastUploadCode}
+            </Text>
+          ) : null}
+        </View>
+        {visibleCount > 1 ? (
+          <View style={styles.viewToggle}>
+            <TouchableOpacity
+              onPress={() => setViewMode('category')}
+              style={[
+                styles.viewToggleBtn,
+                viewMode === 'category' && styles.viewToggleBtnActive,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.viewToggleText,
+                  viewMode === 'category' && styles.viewToggleTextActive,
+                ]}
+              >
+                Por categoría
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setViewMode('manual')}
+              style={[
+                styles.viewToggleBtn,
+                viewMode === 'manual' && styles.viewToggleBtnActive,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.viewToggleText,
+                  viewMode === 'manual' && styles.viewToggleTextActive,
+                ]}
+              >
+                Orden ajustado
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+});
+
 /**
  * Fila del modo "Orden ajustado" dentro de `ReorderableList` (nativo):
  * long-press sobre la fila inicia el arrastre. `useReorderableDrag` solo
@@ -1321,10 +1391,6 @@ const SelectedSongsScreen: React.FC = () => {
 
   // --- Render ---------------------------------------------------------------
 
-  if (loading && selectedSongs.length === 0 && isHydrated) {
-    return <ProgressWithMessage message="Cargando canciones..." />;
-  }
-
   const submitForVariant = (
     variant: CodeDialogVariant,
   ): ((code: string, name?: string) => Promise<void>) => {
@@ -1405,61 +1471,18 @@ const SelectedSongsScreen: React.FC = () => {
     </View>
   );
 
-  const renderHeaderBar = () => {
-    return (
-      <View>
-        <ChoirSessionBanner />
-        <View style={styles.summaryRow}>
-          <View>
-            <Text style={styles.selectionCount}>
-              {visibleCount} {visibleCount === 1 ? 'canción' : 'canciones'}
-            </Text>
-            {lastUploadCode ? (
-              <Text style={styles.subInfo}>
-                ☁️ Guardada con código {lastUploadCode}
-              </Text>
-            ) : null}
-          </View>
-          {visibleCount > 1 ? (
-            <View style={styles.viewToggle}>
-              <TouchableOpacity
-                onPress={() => setViewMode('category')}
-                style={[
-                  styles.viewToggleBtn,
-                  viewMode === 'category' && styles.viewToggleBtnActive,
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.viewToggleText,
-                    viewMode === 'category' && styles.viewToggleTextActive,
-                  ]}
-                >
-                  Por categoría
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                onPress={() => setViewMode('manual')}
-                style={[
-                  styles.viewToggleBtn,
-                  viewMode === 'manual' && styles.viewToggleBtnActive,
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.viewToggleText,
-                    viewMode === 'manual' && styles.viewToggleTextActive,
-                  ]}
-                >
-                  Orden ajustado
-                </Text>
-              </TouchableOpacity>
-            </View>
-          ) : null}
-        </View>
-      </View>
-    );
-  };
+  const headerComponent = useMemo(
+    () => (
+      <HeaderBar
+        visibleCount={visibleCount}
+        lastUploadCode={lastUploadCode}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+        styles={styles}
+      />
+    ),
+    [visibleCount, lastUploadCode, viewMode, setViewMode, styles],
+  );
 
   const renderCategoryGroup = ({ item }: { item: CategorizedSongs }) => (
     <View style={styles.categoryContainer}>
@@ -1525,6 +1548,10 @@ const SelectedSongsScreen: React.FC = () => {
 
   const isEmpty = selectedSongs.length === 0;
 
+  if (loading && selectedSongs.length === 0 && isHydrated) {
+    return <ProgressWithMessage message="Cargando canciones..." />;
+  }
+
   return (
     <View style={styles.container}>
       {isEmpty ? (
@@ -1540,7 +1567,7 @@ const SelectedSongsScreen: React.FC = () => {
             data={flatSelectedSongs}
             renderItem={renderManualItem}
             keyExtractor={(it) => it.filename}
-            ListHeaderComponent={renderHeaderBar()}
+            ListHeaderComponent={headerComponent}
             contentContainerStyle={styles.listContentContainer}
             contentInsetAdjustmentBehavior="automatic"
             showsVerticalScrollIndicator={false}
@@ -1551,7 +1578,7 @@ const SelectedSongsScreen: React.FC = () => {
             onReorder={handleReorder}
             renderItem={renderDraggableManualItem}
             keyExtractor={(it) => it.filename}
-            ListHeaderComponent={renderHeaderBar()}
+            ListHeaderComponent={headerComponent}
             contentContainerStyle={[
               styles.listContentContainer,
               { paddingTop: reorderableTopInset },
@@ -1565,7 +1592,7 @@ const SelectedSongsScreen: React.FC = () => {
           data={categorized}
           renderItem={renderCategoryGroup}
           keyExtractor={(it) => it.categoryKey}
-          ListHeaderComponent={renderHeaderBar()}
+          ListHeaderComponent={headerComponent}
           contentContainerStyle={styles.listContentContainer}
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## Summary
- Incorpora PR #287 (Bolt): divide el `useMemo` de `CategoriesScreen.tsx` en dos hooks para evitar recalcular el sort completo cuando solo cambia `selectedSongs.length`.
- Incorpora PR #276 (Bolt): extrae el header de `SelectedSongsScreen.tsx` a un componente `React.memo` separado, evitando remounts innecesarios en las listas.
- El resto de PRs/ramas de Bolt (duplicadas o de bajo valor) se han cerrado y borrado tras revisión.

## Test plan
- [x] `git merge-tree` sin conflictos de código (solo conflicto trivial en `.jules/bolt.md`, resuelto combinando ambas entradas)
- [ ] Verificar visualmente en la app: pantalla de categorías al añadir/quitar canciones, y pantalla de canciones seleccionadas (reordenar/quitar)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6R92sL3UMAkzCz3xMjN4g)_