### PR TITLE
⚡ Bolt: Optimize Wordle leaderboard stats iteration and React list rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-07-08 - [Split useMemo for O(1) state updates]
 **Learning:** [Combining large dataset processing (O(N log N) sorting and O(N) mapping) with frequently changing scalar dependencies (like `selectedSongs.length`) inside a single `useMemo` causes massive unnecessary re-computations when the scalar value changes.]
 **Action:** [Always split such `useMemo` hooks. Compute and memoize the expensive heavy-lifting using only the large dataset as a dependency, then use a second, lightweight `useMemo` to combine the pre-computed array with the scalar state.]
+## 2026-07-09 - [Object.entries over large dynamic objects]
+**Learning:** [Using \`Object.entries()\` combined with array methods like \`.reduce\` or \`.map\` on large, unstructured dynamic Firebase data (e.g. Wordle stats leaderboard) creates intermediate array allocations that bloat memory and heavily tax garbage collection. This causes noticeable UI stutters on lower-end devices.]
+**Action:** [Use native \`for...in\` loops to iterate over dynamic objects directly and accumulate results iteratively instead of chaining map/reduce/filter array methods.]

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -1484,60 +1484,79 @@ const SelectedSongsScreen: React.FC = () => {
     [visibleCount, lastUploadCode, viewMode, setViewMode, styles],
   );
 
-  const renderCategoryGroup = ({ item }: { item: CategorizedSongs }) => (
-    <View style={styles.categoryContainer}>
-      <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
-      {item.data.map((song) => {
-        const isNow = choir.session?.current?.filename === song.filename;
-        return (
-          <PlaylistRow
-            key={song.filename}
-            song={song}
-            transpose={song.transpose}
-            capoOverride={song.capoOverride}
-            isNowPlaying={isNow}
-            onPress={() => handleSongPress(song)}
-            onRemove={() => removeSong(song.filename)}
-          />
-        );
-      })}
-    </View>
+  const renderCategoryGroup = useCallback(
+    ({ item }: { item: CategorizedSongs }) => (
+      <View style={styles.categoryContainer}>
+        <Text style={styles.categoryTitle}>{item.categoryTitle}</Text>
+        {item.data.map((song) => {
+          const isNow = choir.session?.current?.filename === song.filename;
+          return (
+            <PlaylistRow
+              key={song.filename}
+              song={song}
+              transpose={song.transpose}
+              capoOverride={song.capoOverride}
+              isNowPlaying={isNow}
+              onPress={() => handleSongPress(song)}
+              onRemove={() => removeSong(song.filename)}
+            />
+          );
+        })}
+      </View>
+    ),
+    [styles, choir.session, handleSongPress, removeSong],
   );
 
-  const manualRowProps = (
-    item: (typeof flatSelectedSongs)[number],
-    index: number,
-  ): React.ComponentProps<typeof PlaylistRow> => ({
-    song: item,
-    transpose: item.transpose,
-    capoOverride: item.capoOverride,
-    position: index + 1,
-    showReorderControls: true,
-    canMoveUp: index > 0,
-    canMoveDown: index < flatSelectedSongs.length - 1,
-    onMoveUp: () => handleMoveUp(item.filename),
-    onMoveDown: () => handleMoveDown(item.filename),
-    onContextMenu: () => setMenuFilename(item.filename),
-    isNowPlaying: choir.session?.current?.filename === item.filename,
-    onPress: () => handleSongPress(item),
-    onRemove: () => removeSong(item.filename),
-  });
+  const manualRowProps = useCallback(
+    (
+      item: (typeof flatSelectedSongs)[number],
+      index: number,
+    ): React.ComponentProps<typeof PlaylistRow> => ({
+      song: item,
+      transpose: item.transpose,
+      capoOverride: item.capoOverride,
+      position: index + 1,
+      showReorderControls: true,
+      canMoveUp: index > 0,
+      canMoveDown: index < flatSelectedSongs.length - 1,
+      onMoveUp: () => handleMoveUp(item.filename),
+      onMoveDown: () => handleMoveDown(item.filename),
+      onContextMenu: () => setMenuFilename(item.filename),
+      isNowPlaying: choir.session?.current?.filename === item.filename,
+      onPress: () => handleSongPress(item),
+      onRemove: () => removeSong(item.filename),
+    }),
+    [
+      flatSelectedSongs.length,
+      handleMoveUp,
+      handleMoveDown,
+      choir.session,
+      handleSongPress,
+      removeSong,
+    ],
+  );
 
-  const renderManualItem = ({
-    item,
-    index,
-  }: {
-    item: (typeof flatSelectedSongs)[number];
-    index: number;
-  }) => <PlaylistRow {...manualRowProps(item, index)} />;
+  const renderManualItem = useCallback(
+    ({
+      item,
+      index,
+    }: {
+      item: (typeof flatSelectedSongs)[number];
+      index: number;
+    }) => <PlaylistRow {...manualRowProps(item, index)} />,
+    [manualRowProps],
+  );
 
-  const renderDraggableManualItem = ({
-    item,
-    index,
-  }: {
-    item: (typeof flatSelectedSongs)[number];
-    index: number;
-  }) => <DraggableManualRow {...manualRowProps(item, index)} />;
+  const renderDraggableManualItem = useCallback(
+    ({
+      item,
+      index,
+    }: {
+      item: (typeof flatSelectedSongs)[number];
+      index: number;
+    }) => <DraggableManualRow {...manualRowProps(item, index)} />,
+    [manualRowProps],
+  );
 
   const handleReorder = ({ from, to }: ReorderableListReorderEvent) => {
     const song = flatSelectedSongs[from];

--- a/mcm-app/app/screens/SongListScreen.tsx
+++ b/mcm-app/app/screens/SongListScreen.tsx
@@ -466,18 +466,24 @@ export default function SongsListScreen({
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: Song }) => (
-      <SongListItem
-        song={item}
-        onPress={handleSongPress}
-        onLongPress={handleSongLongPress}
-        isSearchAllMode={isSearchAll}
-        isSelected={isSongSelected(item.filename)}
-        selectedTranspose={getSelectedSong(item.filename)?.transpose ?? 0}
-        onAddSong={addSong}
-        onRemoveSong={removeSong}
-      />
-    ),
+    ({ item }: { item: Song }) => {
+      const isSelected = isSongSelected(item.filename);
+      const selectedTranspose = isSelected
+        ? (getSelectedSong(item.filename)?.transpose ?? 0)
+        : 0;
+      return (
+        <SongListItem
+          song={item}
+          onPress={handleSongPress}
+          onLongPress={handleSongLongPress}
+          isSearchAllMode={isSearchAll}
+          isSelected={isSelected}
+          selectedTranspose={selectedTranspose}
+          onAddSong={addSong}
+          onRemoveSong={removeSong}
+        />
+      );
+    },
     [
       handleSongPress,
       handleSongLongPress,

--- a/mcm-app/hooks/useWordleLeaderboard.ts
+++ b/mcm-app/hooks/useWordleLeaderboard.ts
@@ -57,23 +57,31 @@ export default function useWordleLeaderboard(
 
         if (statsSnap.exists()) {
           const statsData = statsSnap.val() as Record<string, any>;
-          const entries = Object.entries(statsData).map(([uid, data]) => {
-            const totalAttempts = data.distribution
-              ? Object.entries(data.distribution).reduce(
-                  (sum, [k, v]) => sum + Number(k) * Number(v),
-                  0,
-                )
-              : 0;
-            const played = data.played || 0;
-            const avg = played ? totalAttempts / played : Infinity;
-            return {
-              userId: uid,
-              name: data.userName || users[uid]?.name || 'Anónimo',
-              place: data.userLocation || users[uid]?.place || '',
-              played,
-              average: avg,
-            };
-          });
+          const entries: LeaderboardEntry[] = [];
+          for (const uid in statsData) {
+            if (Object.prototype.hasOwnProperty.call(statsData, uid)) {
+              const data = statsData[uid];
+              let totalAttempts = 0;
+              if (data.distribution) {
+                for (const k in data.distribution) {
+                  if (
+                    Object.prototype.hasOwnProperty.call(data.distribution, k)
+                  ) {
+                    totalAttempts += Number(k) * Number(data.distribution[k]);
+                  }
+                }
+              }
+              const played = data.played || 0;
+              const avg = played ? totalAttempts / played : Infinity;
+              entries.push({
+                userId: uid,
+                name: data.userName || users[uid]?.name || 'Anónimo',
+                place: data.userLocation || users[uid]?.place || '',
+                played,
+                average: avg,
+              });
+            }
+          }
 
           const general = [...entries].sort((a, b) => a.average - b.average);
           const participation = [...entries].sort(


### PR DESCRIPTION
### 💡 What
- Refactored `useWordleLeaderboard` to replace chained `Object.entries().map()` and `.reduce()` operations with native `for...in` loops.
- Short-circuited the `getSelectedSong()` lookup inside the `SongListScreen`'s `FlatList` `renderItem` so it only evaluates if the song is currently selected.
- Wrapped inline `renderItem` helpers (`renderManualItem`, `renderCategoryGroup`, etc.) and the `manualRowProps` factory in `SelectedSongsScreen` with `useCallback` and proper dependency arrays.

### 🎯 Why
- **Memory Pressure:** `Object.entries()` creates tuples (intermediate arrays) for every key-value pair. When processing a dynamic dictionary of Wordle stats, mapping and reducing these tuples causes significant Garbage Collection (GC) churn and memory allocation spikes, resulting in UI stutter. Native `for...in` loops achieve the same result without intermediate allocations.
- **Redundant Lookups:** Calculating the transposed key for *every* song in the list on every re-render (even though most are unselected) was doing unnecessary work. Short-circuiting saves CPU cycles during rapid scrolling or search input.
- **Referential Stability:** Inline functions passed to `renderItem` (or props used within it) cause `FlatList` to believe the item's render logic has changed on every parent re-render, forcing a complete layout and sub-tree diffing pass.

### 📊 Impact
- Reduces GC overhead and memory allocations when calculating the Wordle leaderboard by O(N).
- Prevents unnecessary O(N) Re-renders and layout thrashing in `SelectedSongsScreen` lists when scalar dependencies (like `viewMode` or contextual menu state) change.
- Minor reduction in CPU cycles per frame when rendering the main song list.

### 🔬 Measurement
- Scroll performance and memory profile while viewing the Wordle leaderboard on lower-end devices.
- React DevTools Profiler: verify `PlaylistRow` components do not re-render unnecessarily when parent state in `SelectedSongsScreen` changes.

---
*PR created automatically by Jules for task [7680489167923915839](https://jules.google.com/task/7680489167923915839) started by @mcmespana*