### PR TITLE
Swipeable month calendar, rolling 7-day streak, and Photos header

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,35 @@
 
 ---
 
+## 2026-08-07 12:40 — Calendario deslizable, racha de 7 días interactiva y header de Fotos
+
+- **Calendario (tab):** el mes ahora se desliza de verdad. El mes visible pasa a
+  ser estado propio (`visibleMonth`), separado del día seleccionado; el swipe
+  sigue al dedo y, al soltar, la rejilla sale por un lado mientras la nueva
+  entra por el otro (`components/calendar/SwipeableMonthCalendar.tsx`, con
+  `react-native-gesture-handler` + reanimated). Antes el gesto movía la lista de
+  eventos pero la rejilla se quedaba clavada: `react-native-calendars` trata
+  `current` como valor inicial, no reactivo. Las flechas del header usan la
+  misma animación. La vista Agenda gana también swipe de mes.
+- **Orden de calendarios:** el calendario de la delegación del perfil sale
+  SIEMPRE el primero (los IDs de delegación y de calendario coinciden), después
+  los `defaultCalendars` del perfil y luego el resto en el orden de Firebase.
+  `CalendarConfig` incorpora `id` (`hooks/useCalendarConfigs.ts`).
+- **Contigo — racha semanal:** la tira pasa de "lunes a domingo" a los
+  **últimos 7 días** terminando en hoy (`getRollingDays`), así el lunes por la
+  mañana ya no aparece vacía. Cada día es pulsable.
+- **Contigo — días interactivos:** pulsar un día (en la racha o en el
+  calendario del mes) abre lo que haya guardado; si hay varias cosas, sale un
+  submenú (`components/contigo/DayActionSheet.tsx` + `hooks/useContigoDayMenu.ts`)
+  para elegir entre revisión, oración y evangelio. Si no hay nada guardado va
+  directo al evangelio de ese día, y ahora cualquier día pasado del calendario
+  es pulsable (antes solo los que tenían algo marcado).
+- **Fotos:** header nativo transparente (blur en iOS, barra semitransparente en
+  Android/Web) SIN texto de título; las portadas pasan por debajo y se funden
+  con él al deslizar, como en el cantoral.
+
+---
+
 ## 2026-08-06 20:10 — Limpieza: 6 módulos sin importador y deps sin uso (Plan 015)
 
 - Borrados `components/SongSearch.tsx`, `components/ExternalLink.tsx`,

--- a/mcm-app/__tests__/contigoRollingWeek.test.ts
+++ b/mcm-app/__tests__/contigoRollingWeek.test.ts
@@ -1,0 +1,40 @@
+import { getRollingDays, weekdayLetter } from '@/components/contigo/theme';
+
+describe('getRollingDays', () => {
+  it('devuelve 7 días terminando HOY (no de lunes a domingo)', () => {
+    // 2026-08-07 es viernes.
+    expect(getRollingDays('2026-08-07', 7)).toEqual([
+      '2026-08-01',
+      '2026-08-02',
+      '2026-08-03',
+      '2026-08-04',
+      '2026-08-05',
+      '2026-08-06',
+      '2026-08-07',
+    ]);
+  });
+
+  it('cruza el cambio de mes sin saltarse días', () => {
+    expect(getRollingDays('2026-03-02', 4)).toEqual([
+      '2026-02-27',
+      '2026-02-28',
+      '2026-03-01',
+      '2026-03-02',
+    ]);
+  });
+
+  it('el último elemento es siempre el día dado', () => {
+    const days = getRollingDays('2026-01-01');
+    expect(days).toHaveLength(7);
+    expect(days[days.length - 1]).toBe('2026-01-01');
+    expect(days[0]).toBe('2025-12-26');
+  });
+});
+
+describe('weekdayLetter', () => {
+  it('usa la semana española empezando en lunes', () => {
+    expect(weekdayLetter('2026-08-03')).toBe('L'); // lunes
+    expect(weekdayLetter('2026-08-07')).toBe('V'); // viernes
+    expect(weekdayLetter('2026-08-09')).toBe('D'); // domingo
+  });
+});

--- a/mcm-app/__tests__/useCalendarEvents.test.ts
+++ b/mcm-app/__tests__/useCalendarEvents.test.ts
@@ -149,6 +149,7 @@ const icsWith = (summary: string, date: string) =>
   ].join('\n');
 
 const cal = (name: string, url: string): CalendarConfig => ({
+  id: name,
   name,
   url,
   color: '#000',

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -1,11 +1,5 @@
 // app/(tabs)/calendario.tsx
-import React, {
-  useState,
-  useMemo,
-  useCallback,
-  useRef,
-  useLayoutEffect,
-} from 'react';
+import React, { useState, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createNativeStackNavigator } from 'expo-router/build/react-navigation/native-stack';
 import {
   View,
@@ -16,11 +10,12 @@ import {
   Platform,
   Text,
 } from 'react-native';
-import { Calendar, CalendarProps, LocaleConfig } from 'react-native-calendars';
+import { CalendarProps, LocaleConfig } from 'react-native-calendars';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import colors, { Colors } from '@/constants/colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { radii } from '@/constants/uiStyles';
-import Animated from 'react-native-reanimated';
+import Animated, { runOnJS } from 'react-native-reanimated';
 import type { SectionListProps } from 'react-native';
 import { useTabScroll, useTabListScroll } from '@/components/tabs/useTabScroll';
 import SegmentedControl from '@/components/ui/SegmentedControl';
@@ -37,6 +32,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { hexAlpha } from '@/utils/colorUtils';
 import { h } from '@/utils/haptics';
 import { localISO } from '@/utils/localDate';
+import SwipeableMonthCalendar from '@/components/calendar/SwipeableMonthCalendar';
 import CalendarSubscribeBottomSheet from '@/components/CalendarSubscribeBottomSheet';
 import EventDetailsBottomSheet from '@/components/EventDetailsBottomSheet';
 import EmptyState from '@/components/ui/EmptyState';
@@ -92,6 +88,24 @@ const AnimatedSectionList = Animated.createAnimatedComponent(
   >,
 );
 
+/** 'YYYY-MM-DD' de un Date, en hora LOCAL (nada de toISOString, que en
+ *  España desplaza el día 1 al último del mes anterior). */
+const dateToStr = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
+/** Día 1 del mes al que pertenece la fecha dada. */
+const monthStart = (dateStr: string): string => `${dateStr.slice(0, 7)}-01`;
+
+/** Suma meses al mes de una fecha y devuelve su día 1. */
+const addMonths = (dateStr: string, delta: number): string => {
+  const [y, m] = dateStr.split('-').map(Number);
+  return dateToStr(new Date(y, m - 1 + delta, 1));
+};
+
 export function CalendarScreen() {
   const scheme = useColorScheme();
   // Modo agenda: es el scroller que representa al tab (re-tap → arriba).
@@ -141,6 +155,11 @@ export function CalendarScreen() {
   const todayStr = localISO();
 
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
+  // El MES visible es estado propio, independiente del día seleccionado: es lo
+  // que comparten la rejilla del mes y la agenda, y lo que mueve el swipe.
+  const [visibleMonth, setVisibleMonth] = useState<string>(() =>
+    monthStart(todayStr),
+  );
   const [viewMode, setViewMode] = useState<'calendar' | 'agenda'>('calendar');
   const [subscribeOpen, setSubscribeOpen] = useState(false);
   const [detailsEvent, setDetailsEvent] = useState<CalendarEvent | null>(null);
@@ -183,6 +202,7 @@ export function CalendarScreen() {
     setLastDateParam(dateParam);
     if (dateParam && typeof dateParam === 'string') {
       setSelectedDate(dateParam);
+      setVisibleMonth(monthStart(dateParam));
     }
   }
 
@@ -210,45 +230,64 @@ export function CalendarScreen() {
   };
 
   const monthLabel = useMemo(() => {
-    const d = new Date(selectedDate + 'T00:00:00');
+    const d = new Date(visibleMonth + 'T00:00:00');
     const label = d.toLocaleDateString('es-ES', {
       month: 'long',
       year: 'numeric',
     });
     return label.charAt(0).toUpperCase() + label.slice(1);
-  }, [selectedDate]);
+  }, [visibleMonth]);
 
-  // Estado extra para forzar que Calendar navegue al mes correcto
-  // (react-native-calendars trata `current` como valor inicial, no reactivo)
-  const [calendarKey, setCalendarKey] = useState(0);
-
-  // 'T12:00:00' evita que el offset UTC+2 (España) desplace el día 1
-  // al último día del mes anterior cuando hacemos new Date(...).toISOString()
-  const dateToStr = (d: Date): string => {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${y}-${m}-${day}`;
-  };
+  // Al cambiar de mes, el día seleccionado se mueve con él: hoy si el mes es
+  // el actual, y si no el día 1. Así la ficha de "eventos del día" nunca se
+  // queda hablando de un mes que ya no está en pantalla.
+  const goToMonth = useCallback(
+    (monthISO: string) => {
+      setVisibleMonth(monthISO);
+      setSelectedDate(
+        monthISO.slice(0, 7) === todayStr.slice(0, 7) ? todayStr : monthISO,
+      );
+    },
+    [todayStr],
+  );
 
   const changeMonth = useCallback(
     (delta: number) => {
-      const d = new Date(selectedDate + 'T12:00:00');
-      const newDate = new Date(d.getFullYear(), d.getMonth() + delta, 1);
-      setSelectedDate(dateToStr(newDate));
+      goToMonth(addMonths(visibleMonth, delta));
     },
-    [selectedDate],
+    [visibleMonth, goToMonth],
   );
 
   const goToToday = useCallback(() => {
     setSelectedDate(todayStr);
-    // Incrementar la key fuerza al componente Calendar a remontarse y
-    // posicionarse en el mes de hoy aunque el usuario estuviera en otro mes
-    setCalendarKey((k) => k + 1);
+    setVisibleMonth(monthStart(todayStr));
   }, [todayStr]);
 
-  // Ref del X inicial para detectar swipes cross-platform (funciona en web y nativo)
-  const swipeTouchX = useRef(0);
+  const selectDay = useCallback(
+    (dateString: string) => {
+      if (dateString === selectedDate) return;
+      h.select();
+      setSelectedDate(dateString);
+      setVisibleMonth(monthStart(dateString));
+    },
+    [selectedDate],
+  );
+
+  // Swipe horizontal para la agenda (la rejilla del mes trae el suyo, con
+  // animación, dentro de SwipeableMonthCalendar). `failOffsetY` deja pasar el
+  // scroll vertical de la lista sin pelearse con el gesto.
+  const agendaSwipe = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX([-18, 18])
+        .failOffsetY([-16, 16])
+        .onEnd((e) => {
+          if (Math.abs(e.translationX) > 60 || Math.abs(e.velocityX) > 700) {
+            runOnJS(changeMonth)(e.translationX < 0 ? 1 : -1);
+          }
+        }),
+    [changeMonth],
+  );
 
   const filteredByDate = useMemo(() => {
     const map: Record<string, CalendarEvent[]> = {};
@@ -262,7 +301,7 @@ export function CalendarScreen() {
   }, [eventsByDate, visibleCalendars]);
 
   const agendaSections = useMemo(() => {
-    const d0 = new Date(selectedDate + 'T12:00:00');
+    const d0 = new Date(visibleMonth + 'T12:00:00');
     const firstDay = new Date(d0.getFullYear(), d0.getMonth(), 1);
     const lastDay = new Date(d0.getFullYear(), d0.getMonth() + 1, 0);
     const sections: { title: string; data: CalendarEvent[] }[] = [];
@@ -271,7 +310,7 @@ export function CalendarScreen() {
       sections.push({ title: dateStr, data: filteredByDate[dateStr] || [] });
     }
     return sections;
-  }, [filteredByDate, selectedDate]);
+  }, [filteredByDate, visibleMonth]);
 
   // Solo secciones CON eventos — así ListEmptyComponent se activa cuando no hay nada
   const agendaSectionsFiltered = useMemo(
@@ -513,49 +552,15 @@ export function CalendarScreen() {
           >
             <View style={isLandscapeWide ? styles.monthRowTwoPane : undefined}>
               <View style={isLandscapeWide ? styles.monthLeftPane : undefined}>
-                {/* Wrapper para detectar swipes horizontales (cross-platform) */}
-                <View
-                  onTouchStart={(e) => {
-                    swipeTouchX.current = e.nativeEvent.pageX;
-                  }}
-                  onTouchEnd={(e) => {
-                    const dx = e.nativeEvent.pageX - swipeTouchX.current;
-                    if (Math.abs(dx) > 60) changeMonth(dx < 0 ? 1 : -1);
-                  }}
-                >
-                  <View style={styles.calendarCardContainer}>
-                    <Calendar
-                      key={`${calendarKey}-${scheme ?? 'light'}`}
-                      current={selectedDate}
-                      onDayPress={(day) => {
-                        if (day.dateString !== selectedDate) {
-                          h.select();
-                          setSelectedDate(day.dateString);
-                        }
-                      }}
-                      onMonthChange={(month) => {
-                        setSelectedDate(month.dateString);
-                      }}
-                      markedDates={markedDates}
-                      markingType="multi-period"
-                      firstDay={1}
-                      style={{ borderRadius: 20 }}
-                      theme={{
-                        calendarBackground: isDark ? '#2C2C2E' : '#FFFFFF',
-                        dayTextColor: isDark ? '#FFFFFF' : '#1C1C1E',
-                        monthTextColor: isDark ? '#FFFFFF' : '#1C1C1E',
-                        textSectionTitleColor: isDark ? '#8E8E93' : '#8E8E93',
-                        selectedDayBackgroundColor: colors.info,
-                        selectedDayTextColor: colors.white,
-                        arrowColor: colors.info,
-                        todayTextColor: colors.info,
-                        textDayFontWeight: '500',
-                        textMonthFontWeight: '700',
-                        textDayHeaderFontWeight: '600',
-                        textMonthFontSize: 18,
-                      }}
-                    />
-                  </View>
+                <View style={styles.calendarCardContainer}>
+                  <SwipeableMonthCalendar
+                    key={scheme ?? 'light'}
+                    visibleMonth={visibleMonth}
+                    markedDates={markedDates}
+                    onDayPress={selectDay}
+                    onChangeMonth={changeMonth}
+                    isDark={isDark}
+                  />
                 </View>
 
                 {/* Filter chips */}
@@ -637,96 +642,98 @@ export function CalendarScreen() {
             {/* Filter chips */}
             {renderFilterChips()}
 
-            {selectedDate.slice(0, 7) !== todayStr.slice(0, 7) && (
+            {visibleMonth.slice(0, 7) !== todayStr.slice(0, 7) && (
               <View style={styles.agendaBackToTodayRow}>
                 <BackToTodayPill onPress={goToToday} styles={styles} />
               </View>
             )}
 
-            <AnimatedSectionList
-              ref={agendaRef}
-              onScroll={onAgendaScroll}
-              scrollEventThrottle={16}
-              sections={agendaSectionsFiltered}
-              keyExtractor={(item, index) => `${item.title}-${index}`}
-              style={styles.agendaList}
-              contentContainerStyle={[
-                styles.agendaContent,
-                { paddingBottom: contentPaddingBottom },
-              ]}
-              stickySectionHeadersEnabled={false}
-              renderSectionHeader={({ section: { title, data } }) => {
-                const isPast = title < todayStr;
-                const isToday = title === todayStr;
-                const isTomorrow =
-                  new Date(title + 'T00:00:00').getTime() ===
-                  new Date(todayStr + 'T00:00:00').getTime() +
-                    24 * 60 * 60 * 1000;
+            <GestureDetector gesture={agendaSwipe}>
+              <AnimatedSectionList
+                ref={agendaRef}
+                onScroll={onAgendaScroll}
+                scrollEventThrottle={16}
+                sections={agendaSectionsFiltered}
+                keyExtractor={(item, index) => `${item.title}-${index}`}
+                style={styles.agendaList}
+                contentContainerStyle={[
+                  styles.agendaContent,
+                  { paddingBottom: contentPaddingBottom },
+                ]}
+                stickySectionHeadersEnabled={false}
+                renderSectionHeader={({ section: { title, data } }) => {
+                  const isPast = title < todayStr;
+                  const isToday = title === todayStr;
+                  const isTomorrow =
+                    new Date(title + 'T00:00:00').getTime() ===
+                    new Date(todayStr + 'T00:00:00').getTime() +
+                      24 * 60 * 60 * 1000;
 
-                const { day, weekday } = formatDateShort(title);
+                  const { day, weekday } = formatDateShort(title);
 
-                return (
-                  <View
-                    style={[
-                      styles.sectionHeader,
-                      isToday && styles.todaySectionHeader,
-                      isPast && styles.pastSectionHeader,
-                    ]}
-                  >
-                    <View style={styles.sectionDateColumn}>
-                      <Text
-                        style={[
-                          styles.sectionDay,
-                          isToday && styles.todayAccent,
-                          isPast && styles.pastText,
-                        ]}
-                      >
-                        {day}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.sectionWeekday,
-                          isToday && styles.todayAccent,
-                          isPast && styles.pastText,
-                        ]}
-                      >
-                        {isToday ? 'HOY' : isTomorrow ? 'MAÑANA' : weekday}
-                      </Text>
+                  return (
+                    <View
+                      style={[
+                        styles.sectionHeader,
+                        isToday && styles.todaySectionHeader,
+                        isPast && styles.pastSectionHeader,
+                      ]}
+                    >
+                      <View style={styles.sectionDateColumn}>
+                        <Text
+                          style={[
+                            styles.sectionDay,
+                            isToday && styles.todayAccent,
+                            isPast && styles.pastText,
+                          ]}
+                        >
+                          {day}
+                        </Text>
+                        <Text
+                          style={[
+                            styles.sectionWeekday,
+                            isToday && styles.todayAccent,
+                            isPast && styles.pastText,
+                          ]}
+                        >
+                          {isToday ? 'HOY' : isTomorrow ? 'MAÑANA' : weekday}
+                        </Text>
+                      </View>
+                      <View style={styles.sectionDivider} />
+                      <View style={styles.sectionBadge}>
+                        <Text
+                          style={[
+                            styles.sectionBadgeText,
+                            isPast && styles.pastText,
+                          ]}
+                        >
+                          {data.length}
+                        </Text>
+                      </View>
                     </View>
-                    <View style={styles.sectionDivider} />
-                    <View style={styles.sectionBadge}>
-                      <Text
-                        style={[
-                          styles.sectionBadgeText,
-                          isPast && styles.pastText,
-                        ]}
-                      >
-                        {data.length}
-                      </Text>
-                    </View>
-                  </View>
-                );
-              }}
-              renderItem={({ item, section }) => {
-                const isPast = section.title < todayStr;
-                return renderEventCard(item, 0, isPast);
-              }}
-              ListEmptyComponent={
-                <EmptyState
-                  icon={allCalendarsHidden ? 'visibility-off' : 'event-busy'}
-                  title={
-                    allCalendarsHidden
-                      ? 'Todos los calendarios ocultos'
-                      : 'Sin eventos este mes'
-                  }
-                  subtitle={
-                    allCalendarsHidden
-                      ? 'Activa algún calendario desde los filtros de arriba'
-                      : 'No hay eventos programados para ' + monthLabel
-                  }
-                />
-              }
-            />
+                  );
+                }}
+                renderItem={({ item, section }) => {
+                  const isPast = section.title < todayStr;
+                  return renderEventCard(item, 0, isPast);
+                }}
+                ListEmptyComponent={
+                  <EmptyState
+                    icon={allCalendarsHidden ? 'visibility-off' : 'event-busy'}
+                    title={
+                      allCalendarsHidden
+                        ? 'Todos los calendarios ocultos'
+                        : 'Sin eventos este mes'
+                    }
+                    subtitle={
+                      allCalendarsHidden
+                        ? 'Activa algún calendario desde los filtros de arriba'
+                        : 'No hay eventos programados para ' + monthLabel
+                    }
+                  />
+                }
+              />
+            </GestureDetector>
           </View>
         )}
       </View>

--- a/mcm-app/app/(tabs)/contigo/index.tsx
+++ b/mcm-app/app/(tabs)/contigo/index.tsx
@@ -14,7 +14,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import Animated from 'react-native-reanimated';
 import { useTabScroll } from '@/components/tabs/useTabScroll';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { useContigoHabits, type DayRecord } from '@/hooks/useContigoHabits';
+import { useContigoHabits } from '@/hooks/useContigoHabits';
 import { useDailyReadings } from '@/hooks/useDailyReadings';
 import { warm, formatDateLong, MONTHS_CAP } from '@/components/contigo/theme';
 import {
@@ -25,7 +25,9 @@ import {
   StatCard,
   MonthHeatmap,
 } from '@/components/contigo/HomeWidgets';
+import DayActionSheet from '@/components/contigo/DayActionSheet';
 import { LiturgicalBadge } from '@/components/contigo/LiturgicalBadge';
+import { useContigoDayMenu } from '@/hooks/useContigoDayMenu';
 import LoginNudgeBanner from '@/components/LoginNudgeBanner';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -81,30 +83,10 @@ export default function ContigoScreen() {
   const year = todayStr.split('-')[0];
   const monthLabel = `${MONTHS_CAP[mNum - 1]} ${year}`;
 
-  // Tapping a calendar day opens the matching record screen.
-  // Priority: revision → oración → evangelio (most reflective first).
-  const handleDayPress = useCallback(
-    (date: string, rec: DayRecord | null) => {
-      if (!rec) return;
-      if (rec.revisionDone) {
-        router.push({
-          pathname: '/(tabs)/contigo/revision' as never,
-          params: { date },
-        });
-      } else if (rec.prayerDone) {
-        router.push({
-          pathname: '/(tabs)/contigo/oracion' as never,
-          params: { date },
-        });
-      } else if (rec.readingDone) {
-        router.push({
-          pathname: '/(tabs)/contigo/evangelio' as never,
-          params: { date },
-        });
-      }
-    },
-    [router],
-  );
+  // Pulsar un día (racha o calendario) abre lo que haya guardado; si hay
+  // varias cosas, pregunta. Ver `useContigoDayMenu`.
+  const { dayMenu, handleDayPress, openDay, closeDayMenu } =
+    useContigoDayMenu();
 
   const bgGradient = isDark
     ? (['#1A1712', '#100F0C'] as const)
@@ -234,7 +216,7 @@ export default function ContigoScreen() {
           {/* ── Esta semana ────────────────────────────── */}
           <View style={[styles.section, { paddingTop: 18 }]}>
             <Text style={[styles.smallLabel, { color: W.textMuted }]}>
-              ESTA SEMANA
+              ÚLTIMOS 7 DÍAS
             </Text>
             <View
               style={[
@@ -250,6 +232,7 @@ export default function ContigoScreen() {
                 records={records}
                 todayStr={todayStr}
                 isDark={isDark}
+                onDayPress={handleDayPress}
               />
             </View>
           </View>
@@ -321,6 +304,14 @@ export default function ContigoScreen() {
           </View>
         </View>
       </Animated.ScrollView>
+
+      <DayActionSheet
+        visible={!!dayMenu}
+        onClose={closeDayMenu}
+        date={dayMenu?.date ?? null}
+        record={dayMenu?.rec ?? null}
+        onSelect={openDay}
+      />
     </View>
   );
 }

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -6,14 +6,16 @@ import {
   FlatList,
   StyleSheet,
   Linking,
+  Platform,
   useWindowDimensions,
   ViewStyle,
   Alert,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
+import { createNativeStackNavigator } from 'expo-router/build/react-navigation/native-stack';
+import { useHeaderHeight } from 'expo-router/react-navigation';
 import { useTabListScroll } from '@/components/tabs/useTabScroll';
 import { Button } from 'heroui-native';
-import TabScreenWrapper from '@/components/ui/TabScreenWrapper';
 import AlbumCard from '@/components/AlbumCard';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import OfflineBanner from '@/components/OfflineBanner';
@@ -59,9 +61,12 @@ interface FotosScreenStyles {
   loadMoreButton: ViewStyle;
 }
 
-export default function FotosScreen() {
+export function FotosScreen() {
   const { listRef, onScroll, contentPaddingBottom } =
     useTabListScroll<FlatList>('fotos');
+  // El header es transparente y las portadas pasan POR DEBAJO: la lista
+  // arranca justo bajo la barra y se funde con ella al deslizar.
+  const headerHeight = useHeaderHeight();
   const { width } = useWindowDimensions();
   const scheme = useColorScheme();
   const styles = React.useMemo(() => createStyles(scheme), [scheme]);
@@ -129,8 +134,14 @@ export default function FotosScreen() {
   }
 
   return (
-    <TabScreenWrapper style={styles.container} edges={['top']}>
-      {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
+    <View style={styles.container}>
+      {/* El header flota sobre el contenido: el aviso de "sin conexión" tiene
+          que bajar hasta debajo de la barra para no quedar tapado. */}
+      {offline && (
+        <View style={{ marginTop: headerHeight }}>
+          <OfflineBanner text="Mostrando datos sin conexión" />
+        </View>
+      )}
       <Animated.FlatList
         ref={listRef}
         onScroll={onScroll}
@@ -158,13 +169,59 @@ export default function FotosScreen() {
             maxWidth: width > 1200 ? 1600 : 1200,
             alignSelf: 'center',
           },
-          { paddingBottom: contentPaddingBottom },
+          {
+            paddingTop: offline ? 12 : headerHeight + 12,
+            paddingBottom: contentPaddingBottom,
+          },
         ]}
+        // El contenido ya reserva el hueco del header; sin esto iOS lo suma
+        // otra vez y deja una franja vacía.
+        contentInsetAdjustmentBehavior="never"
         onEndReached={loadMoreAlbums}
         onEndReachedThreshold={0.5}
         ListFooterComponent={renderFooter}
       />
-    </TabScreenWrapper>
+    </View>
+  );
+}
+
+/**
+ * Tab de Fotos: stack propio para tener un header NATIVO transparente —
+ * las portadas pasan por debajo y se funden con él al deslizar, igual que en
+ * el cantoral, pero SIN texto de título (la pestaña ya se llama Fotos).
+ */
+const FotosStack = createNativeStackNavigator();
+export default function FotosTab() {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const isIOS = Platform.OS === 'ios';
+  return (
+    <FotosStack.Navigator
+      screenOptions={{
+        title: '',
+        headerShadowVisible: false,
+        headerTransparent: true,
+        headerTintColor: isDark ? '#FFFFFF' : '#1a1a1a',
+        // iOS <26 necesita el blur explícito; en iOS 26+ lo pone el sistema
+        // (combinarlo provoca solape, ver cancionero.tsx).
+        ...(isIOS && parseInt(String(Platform.Version), 10) < 26
+          ? { headerBlurEffect: 'systemChromeMaterial' as const }
+          : {}),
+        // Android/Web no tienen blur nativo: una barra semitransparente del
+        // color del fondo deja intuir las fotos por debajo.
+        ...(isIOS
+          ? {}
+          : {
+              headerStyle: {
+                backgroundColor: isDark
+                  ? 'rgba(21,23,24,0.72)'
+                  : 'rgba(255,255,255,0.72)',
+              },
+            }),
+      }}
+    >
+      <FotosStack.Screen name="FotosMain" component={FotosScreen} />
+    </FotosStack.Navigator>
   );
 }
 

--- a/mcm-app/components/calendar/SwipeableMonthCalendar.tsx
+++ b/mcm-app/components/calendar/SwipeableMonthCalendar.tsx
@@ -1,0 +1,171 @@
+// components/calendar/SwipeableMonthCalendar.tsx
+import React, { useCallback, useState } from 'react';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import { Calendar, CalendarProps } from 'react-native-calendars';
+import colors from '@/constants/colors';
+import { h } from '@/utils/haptics';
+
+interface SwipeableMonthCalendarProps {
+  /** Mes visible, en formato `YYYY-MM-DD` (normalmente el día 1). */
+  visibleMonth: string;
+  markedDates: CalendarProps['markedDates'];
+  onDayPress: (dateString: string) => void;
+  /** `delta` = +1 (mes siguiente) o -1 (mes anterior). */
+  onChangeMonth: (delta: number) => void;
+  isDark: boolean;
+}
+
+// Cuánto se desplaza la rejilla al confirmar el cambio de mes (fracción del
+// ancho). Suficiente para leer la dirección sin que el hueco cante.
+const EXIT_RATIO = 0.55;
+// Umbrales para dar por bueno el gesto: o has arrastrado lo suficiente, o has
+// soltado con velocidad (flick corto y rápido).
+const DRAG_THRESHOLD = 52;
+const VELOCITY_THRESHOLD = 620;
+
+/**
+ * Calendario mensual que se desliza de verdad: el mes sigue al dedo y, al
+ * soltar, sale por un lado mientras el nuevo entra por el otro.
+ *
+ * `react-native-calendars` trata `current` como valor INICIAL, no reactivo:
+ * por eso la `key` incluye el mes visible, para que cada mes sea un montaje
+ * nuevo posicionado donde toca. Antes el swipe cambiaba los eventos de abajo
+ * pero la rejilla se quedaba clavada en el mes anterior.
+ */
+export default function SwipeableMonthCalendar({
+  visibleMonth,
+  markedDates,
+  onDayPress,
+  onChangeMonth,
+  isDark,
+}: SwipeableMonthCalendarProps) {
+  const { width: windowWidth } = useWindowDimensions();
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const width = measuredWidth || windowWidth;
+
+  const dx = useSharedValue(0);
+
+  // Cambia de mes y hace entrar la rejilla nueva desde el lado contrario.
+  const commitMonth = useCallback(
+    (dir: number) => {
+      h.select();
+      onChangeMonth(dir);
+      dx.value = dir * width * EXIT_RATIO;
+      dx.value = withSpring(0, { damping: 20, stiffness: 170, mass: 0.7 });
+    },
+    [onChangeMonth, dx, width],
+  );
+
+  // Salida animada + cambio de mes. La usan tanto el swipe como las flechas
+  // del header, así que las dos vías se sienten igual.
+  const animateChange = useCallback(
+    (dir: number) => {
+      dx.value = withTiming(
+        -dir * width * EXIT_RATIO,
+        { duration: 140 },
+        (finished) => {
+          'worklet';
+          if (finished) runOnJS(commitMonth)(dir);
+        },
+      );
+    },
+    [dx, width, commitMonth],
+  );
+
+  const pan = Gesture.Pan()
+    // Sólo se activa con intención horizontal clara, y se rinde ante un
+    // arrastre vertical: así el ScrollView de la pantalla sigue mandando.
+    .activeOffsetX([-14, 14])
+    .failOffsetY([-14, 14])
+    .onUpdate((e) => {
+      const max = width * 0.9;
+      dx.value = Math.max(-max, Math.min(max, e.translationX));
+    })
+    .onEnd((e) => {
+      const commit =
+        Math.abs(e.translationX) > DRAG_THRESHOLD ||
+        Math.abs(e.velocityX) > VELOCITY_THRESHOLD;
+      if (commit) {
+        const dir = e.translationX < 0 ? 1 : -1;
+        dx.value = withTiming(
+          -dir * width * EXIT_RATIO,
+          { duration: 130 },
+          (finished) => {
+            if (finished) runOnJS(commitMonth)(dir);
+          },
+        );
+      } else {
+        dx.value = withSpring(0, { damping: 18, stiffness: 200 });
+      }
+    });
+
+  const gridStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: dx.value }],
+    opacity: interpolate(
+      Math.abs(dx.value),
+      [0, width * EXIT_RATIO],
+      [1, 0.3],
+      'clamp',
+    ),
+  }));
+
+  return (
+    <View
+      style={styles.clip}
+      onLayout={(e) => setMeasuredWidth(e.nativeEvent.layout.width)}
+    >
+      <GestureDetector gesture={pan}>
+        <Animated.View style={gridStyle}>
+          <Calendar
+            key={visibleMonth.slice(0, 7)}
+            current={visibleMonth}
+            onDayPress={(day) => onDayPress(day.dateString)}
+            // Las flechas nativas del header no deben mover el mes por su
+            // cuenta: lo hace nuestro estado (con la misma animación).
+            onPressArrowLeft={() => animateChange(-1)}
+            onPressArrowRight={() => animateChange(1)}
+            markedDates={markedDates}
+            markingType="multi-period"
+            firstDay={1}
+            enableSwipeMonths={false}
+            style={styles.calendar}
+            theme={{
+              calendarBackground: isDark ? '#2C2C2E' : '#FFFFFF',
+              dayTextColor: isDark ? '#FFFFFF' : '#1C1C1E',
+              monthTextColor: isDark ? '#FFFFFF' : '#1C1C1E',
+              textSectionTitleColor: '#8E8E93',
+              selectedDayBackgroundColor: colors.info,
+              selectedDayTextColor: colors.white,
+              arrowColor: colors.info,
+              todayTextColor: colors.info,
+              textDayFontWeight: '500',
+              textMonthFontWeight: '700',
+              textDayHeaderFontWeight: '600',
+              textMonthFontSize: 18,
+            }}
+          />
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Recorta la rejilla que sale de cuadro mientras se desliza.
+  clip: {
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  calendar: {
+    borderRadius: 20,
+  },
+});

--- a/mcm-app/components/contigo/DayActionSheet.tsx
+++ b/mcm-app/components/contigo/DayActionSheet.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import BottomSheet from '@/components/BottomSheet';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { hexAlpha } from '@/utils/colorUtils';
+import { h } from '@/utils/haptics';
+import type { DayRecord } from '@/hooks/useContigoHabits';
+import { formatDateLong, habitColor, warm, type HabitKey } from './theme';
+
+export type DayAction = 'evangelio' | 'oracion' | 'revision';
+
+export interface DayActionOption {
+  key: DayAction;
+  title: string;
+  subtitle: string;
+  icon: string;
+  /** `false` cuando ese día no hay nada guardado y sólo se puede leer. */
+  recorded: boolean;
+}
+
+/**
+ * Qué se puede abrir de un día concreto, en el orden en que tiene sentido
+ * ofrecerlo: primero lo que la persona escribió (revisión, oración) y siempre
+ * el evangelio como fondo de armario — aunque no lo marcara, se puede leer.
+ */
+export function getDayOptions(
+  date: string,
+  rec: DayRecord | null,
+): DayActionOption[] {
+  const options: DayActionOption[] = [];
+  if (rec?.revisionDone) {
+    options.push({
+      key: 'revision',
+      title: 'Revisión del día',
+      subtitle: 'Releer lo que anotaste',
+      icon: 'search',
+      recorded: true,
+    });
+  }
+  if (rec?.prayerDone) {
+    options.push({
+      key: 'oracion',
+      title: 'Oración',
+      subtitle: 'Ver cómo fue el rato de oración',
+      icon: 'self-improvement',
+      recorded: true,
+    });
+  }
+  options.push({
+    key: 'evangelio',
+    title: 'Evangelio',
+    subtitle: rec?.readingDone
+      ? 'Volver a la lectura de ese día'
+      : 'Leer el evangelio de ese día',
+    icon: 'menu-book',
+    recorded: !!rec?.readingDone,
+  });
+  return options;
+}
+
+interface DayActionSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  date: string | null;
+  record: DayRecord | null;
+  onSelect: (action: DayAction, date: string) => void;
+}
+
+/**
+ * Menú de un día del calendario / de la racha: elige qué quieres ver de ese
+ * día. Cuando sólo hay una opción posible (nada guardado → evangelio), quien
+ * llama abre directamente sin pasar por aquí.
+ */
+export default function DayActionSheet({
+  visible,
+  onClose,
+  date,
+  record,
+  onSelect,
+}: DayActionSheetProps) {
+  const isDark = useColorScheme() === 'dark';
+  const W = warm(isDark);
+  const options = date ? getDayOptions(date, record) : [];
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      title={date ? formatDateLong(date) : 'Ese día'}
+    >
+      <View style={styles.list}>
+        {options.map((opt) => {
+          const accent = habitColor(opt.key as HabitKey, isDark);
+          return (
+            <TouchableOpacity
+              key={opt.key}
+              activeOpacity={0.75}
+              onPress={() => {
+                if (!date) return;
+                h.navigate();
+                onSelect(opt.key, date);
+              }}
+              style={[
+                styles.row,
+                { backgroundColor: W.bgCard, borderColor: W.border },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={opt.title}
+            >
+              <View
+                style={[
+                  styles.iconWrap,
+                  { backgroundColor: hexAlpha(accent, '1F') },
+                ]}
+              >
+                <MaterialIcons
+                  name={opt.icon as never}
+                  size={20}
+                  color={accent}
+                />
+              </View>
+              <View style={styles.rowText}>
+                <Text style={[styles.rowTitle, { color: W.text }]}>
+                  {opt.title}
+                </Text>
+                <Text style={[styles.rowSubtitle, { color: W.textMuted }]}>
+                  {opt.subtitle}
+                </Text>
+              </View>
+              {opt.recorded ? (
+                <MaterialIcons name="check-circle" size={16} color={W.green} />
+              ) : null}
+              <MaterialIcons
+                name="chevron-right"
+                size={20}
+                color={W.textMuted}
+              />
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: 10,
+    paddingBottom: 28,
+    paddingTop: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderWidth: 1,
+    borderRadius: 18,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  iconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowText: { flex: 1 },
+  rowTitle: { fontSize: 15, fontWeight: '700', letterSpacing: -0.2 },
+  rowSubtitle: { fontSize: 12, fontWeight: '500', marginTop: 2 },
+});

--- a/mcm-app/components/contigo/HomeWidgets.tsx
+++ b/mcm-app/components/contigo/HomeWidgets.tsx
@@ -13,9 +13,10 @@ import {
   HabitKey,
   WEEKDAYS,
   buildCalendar,
-  getWeekDates,
+  getRollingDays,
   habitColor,
   warm,
+  weekdayLetter,
 } from './theme';
 import type { DayRecord } from '@/hooks/useContigoHabits';
 
@@ -365,23 +366,28 @@ export function EvangelioTeaserCard({
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// WeekStrip — current ISO week Mon–Sun w/ habit dots
+// WeekStrip — ventana móvil de los últimos 7 días (hoy el último), con puntos
+// por hábito. Cada día es pulsable y abre lo que haya guardado.
 // ─────────────────────────────────────────────────────────────────────────────
 export function WeekStrip({
   records,
   todayStr,
   isDark,
+  onDayPress,
 }: {
   records: Record<string, DayRecord>;
   todayStr: string;
   isDark: boolean;
+  onDayPress?: (date: string, rec: DayRecord | null) => void;
 }) {
   const W = warm(isDark);
-  const week = getWeekDates(todayStr);
+  // Últimos 7 días, NO de lunes a domingo: así el lunes por la mañana la tira
+  // no aparece vacía y siempre se ve la semana real que llevas.
+  const week = getRollingDays(todayStr, 7);
   return (
     <View>
       <View style={styles.weekRow}>
-        {week.map((ds, i) => {
+        {week.map((ds) => {
           const rec = records[ds];
           const isToday = ds === todayStr;
           const isFuture = ds > todayStr;
@@ -414,15 +420,27 @@ export function WeekStrip({
               ? 'rgba(167,139,250,0.14)'
               : 'rgba(124,58,237,0.09)';
 
+          const tappable = !!onDayPress && !isFuture;
+
           return (
-            <View key={ds} style={styles.weekCol}>
+            <TouchableOpacity
+              key={ds}
+              style={styles.weekCol}
+              activeOpacity={tappable ? 0.6 : 1}
+              disabled={!tappable}
+              onPress={() => onDayPress?.(ds, rec || null)}
+              accessibilityRole={tappable ? 'button' : undefined}
+              accessibilityLabel={
+                tappable ? `Ver el día ${day}` : `Día ${day}, aún por llegar`
+              }
+            >
               <Text
                 style={[
                   styles.weekHdr,
                   { color: isToday ? W.accent : W.textMuted },
                 ]}
               >
-                {WEEKDAYS[i]}
+                {weekdayLetter(ds)}
               </Text>
               <View
                 style={[
@@ -490,7 +508,7 @@ export function WeekStrip({
                   ]}
                 />
               </View>
-            </View>
+            </TouchableOpacity>
           );
         })}
       </View>
@@ -635,7 +653,9 @@ export function MonthHeatmap({
           else if (rv)
             bg = isDark ? 'rgba(167,139,250,0.20)' : 'rgba(124,58,237,0.14)';
           if (isFuture) bg = 'transparent';
-          const tappable = !!onDayPress && !isFuture && doneCount > 0;
+          // Cualquier día pasado se puede abrir: si no hay nada guardado,
+          // siempre queda el evangelio de ese día.
+          const tappable = !!onDayPress && !isFuture;
           const inner = (
             <View
               style={[

--- a/mcm-app/components/contigo/theme.ts
+++ b/mcm-app/components/contigo/theme.ts
@@ -154,21 +154,20 @@ export function formatDateLong(ds: string): string {
   return `${DAYS_ES[dt.getDay()]}, ${d} de ${MONTHS_ES[m - 1]}`;
 }
 
-export function getWeekDates(todayStr: string): string[] {
-  const [y, m, d] = todayStr.split('-').map(Number);
-  const dt = new Date(y, m - 1, d);
-  const dow = (dt.getDay() + 6) % 7; // Mon = 0
-  const monday = new Date(dt);
-  monday.setDate(dt.getDate() - dow);
-  return Array.from({ length: 7 }, (_, i) => {
-    const dd = new Date(monday);
-    dd.setDate(monday.getDate() + i);
-    return [
-      dd.getFullYear(),
-      String(dd.getMonth() + 1).padStart(2, '0'),
-      String(dd.getDate()).padStart(2, '0'),
-    ].join('-');
-  });
+/**
+ * Últimos `n` días TERMINANDO en `todayStr` (hoy siempre el último).
+ * No se reinicia cada lunes: la racha se lee
+ * como una ventana móvil, que es lo que de verdad refleja el hábito.
+ */
+export function getRollingDays(todayStr: string, n = 7): string[] {
+  return Array.from({ length: n }, (_, i) => offsetDate(todayStr, i - (n - 1)));
+}
+
+/** Inicial del día de la semana (L M X J V S D) de una fecha 'YYYY-MM-DD'. */
+export function weekdayLetter(ds: string): string {
+  const [y, m, d] = ds.split('-').map(Number);
+  const dow = new Date(y, m - 1, d).getDay(); // 0 = domingo
+  return WEEKDAYS[(dow + 6) % 7];
 }
 
 export function buildCalendar(ds: string) {

--- a/mcm-app/hooks/useCalendarConfigs.ts
+++ b/mcm-app/hooks/useCalendarConfigs.ts
@@ -13,6 +13,7 @@ export interface CalendarConfigFirebase {
 }
 
 export interface CalendarConfig {
+  id: string;
   name: string;
   url: string;
   color: string;
@@ -51,11 +52,32 @@ export function useCalendarConfigs() {
     [],
   );
 
-  const calendarsToUse = useMemo(
-    () =>
-      calendarData && calendarData.length > 0 ? calendarData : fallbackConfigs,
-    [calendarData, fallbackConfigs],
-  );
+  // El calendario de MI delegación va SIEMPRE el primero (los IDs de
+  // delegación y de calendario coinciden: `mcm-castellon`, `mcm-madrid`…).
+  // Detrás van los `extraCalendars` que la delegación añade, y luego el resto
+  // conserva el orden que trae Firebase.
+  const calendarsToUse = useMemo(() => {
+    const list =
+      calendarData && calendarData.length > 0 ? calendarData : fallbackConfigs;
+    const delegationId = resolved.delegationId;
+    const extras = resolved.defaultCalendars ?? [];
+    const rank = (cal: CalendarConfigFirebase) => {
+      if (delegationId && cal.id === delegationId) return 0;
+      if (extras.includes(cal.id)) return 1;
+      return 2;
+    };
+    // `map` + índice para que el orden dentro de cada grupo sea estable
+    // (Array.prototype.sort no garantiza estabilidad en todos los motores).
+    return list
+      .map((cal, index) => ({ cal, index, rank: rank(cal) }))
+      .sort((a, b) => a.rank - b.rank || a.index - b.index)
+      .map((entry) => entry.cal);
+  }, [
+    calendarData,
+    fallbackConfigs,
+    resolved.delegationId,
+    resolved.defaultCalendars,
+  ]);
 
   // `null` mientras no se ha leído AsyncStorage; mapa explícito del usuario una
   // vez cargado. Las claves ausentes caen al default del perfil/calendario.
@@ -126,6 +148,7 @@ export function useCalendarConfigs() {
   const calendarConfigs: CalendarConfig[] = useMemo(
     () =>
       calendarsToUse.map((cal) => ({
+        id: cal.id,
         name: cal.name,
         url: cal.url,
         color: cal.color,

--- a/mcm-app/hooks/useContigoDayMenu.ts
+++ b/mcm-app/hooks/useContigoDayMenu.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react';
+import { useRouter } from 'expo-router';
+import {
+  getDayOptions,
+  type DayAction,
+} from '@/components/contigo/DayActionSheet';
+import type { DayRecord } from '@/hooks/useContigoHabits';
+import { h } from '@/utils/haptics';
+
+/**
+ * Qué pasa al pulsar un día en la racha de la semana o en el calendario del
+ * mes: si sólo hay una cosa que ver (nada guardado → el evangelio de ese día)
+ * se abre directamente; si hay varias, se ofrece un submenú en vez de decidir
+ * por la persona.
+ */
+export function useContigoDayMenu() {
+  const router = useRouter();
+  const [dayMenu, setDayMenu] = useState<{
+    date: string;
+    rec: DayRecord | null;
+  } | null>(null);
+
+  const openDay = useCallback(
+    (action: DayAction, date: string) => {
+      setDayMenu(null);
+      router.push({
+        pathname: `/(tabs)/contigo/${action}` as never,
+        params: { date },
+      });
+    },
+    [router],
+  );
+
+  const handleDayPress = useCallback(
+    (date: string, rec: DayRecord | null) => {
+      const options = getDayOptions(date, rec);
+      if (options.length === 1) {
+        openDay(options[0].key, date);
+        return;
+      }
+      h.tap();
+      setDayMenu({ date, rec });
+    },
+    [openDay],
+  );
+
+  const closeDayMenu = useCallback(() => setDayMenu(null), []);
+
+  return { dayMenu, handleDayPress, openDay, closeDayMenu };
+}


### PR DESCRIPTION
## Summary

Refactors the calendar month navigation to use true swipe gestures with animated transitions, separates visible month state from selected date, adds interactive day selection to the weekly streak, and implements a native transparent header for the Photos tab.

## Key Changes

### Calendar Tab (`app/(tabs)/calendario.tsx`)
- **Separated state:** `visibleMonth` now tracks the displayed month independently from `selectedDate`, fixing the issue where swipes moved the event list but left the calendar grid on the previous month
- **Swipeable month grid:** Replaced `react-native-calendars`' built-in navigation with a new `SwipeableMonthCalendar` component that animates the grid following the user's finger, with smooth spring animations when committing the month change
- **Unified month navigation:** Both calendar grid arrows and swipe gestures use the same `changeMonth()` animation, ensuring consistent UX across interaction methods
- **Agenda swipe:** Added horizontal pan gesture to the event list (agenda view) for month navigation, with `failOffsetY` to preserve vertical scrolling
- **Helper functions:** Added `dateToStr()`, `monthStart()`, and `addMonths()` utilities for consistent date string manipulation in local time (avoiding UTC offset issues)
- **Removed:** `useRef` for touch tracking and `calendarKey` workaround (no longer needed with proper state management)

### New Component: `SwipeableMonthCalendar` (`components/calendar/SwipeableMonthCalendar.tsx`)
- Wraps `react-native-calendars` Calendar with gesture detection and animated transforms
- Uses `react-native-gesture-handler` Pan gesture with configurable thresholds (drag distance or velocity)
- Animates grid exit/entry with opacity fade and horizontal translation
- Remounts Calendar component on month change (via `key`) to ensure `current` prop is respected
- Disables native `enableSwipeMonths` to avoid conflicts with custom gesture handling

### Contigo Tab (`app/(tabs)/contigo/index.tsx`)
- **Interactive week strip:** Days in the rolling 7-day streak are now tappable and trigger day selection
- **Day action menu:** New `useContigoDayMenu()` hook and `DayActionSheet` component provide a menu when a day has multiple saved items (revision, prayer, reading); single-option days open directly
- **Rolling week:** Changed from ISO week (Mon–Sun) to last 7 days ending today via `getRollingDays()`, so the streak never appears empty on Monday mornings

### New Hooks & Components
- **`useContigoDayMenu()`** (`hooks/useContigoDayMenu.ts`): Manages day selection logic, menu visibility, and navigation to detail screens
- **`DayActionSheet`** (`components/contigo/DayActionSheet.tsx`): Bottom sheet menu showing available actions for a selected day (revision, prayer, gospel reading) with icons and recorded status indicators
- **`getDayOptions()`**: Determines which actions are available for a day based on saved records

### Photos Tab (`app/(tabs)/fotos.tsx`)
- **Native transparent header:** Wrapped `FotosScreen` in a native stack navigator with transparent header so album covers pass underneath and fade into the header on scroll
- **Header height management:** Uses `useHeaderHeight()` to properly position the offline banner below the floating header
- **Content inset adjustment:** Set `contentInsetAdjustmentBehavior="never"` to prevent iOS from double-counting header space
- **Exported as function:** Changed default export to named `FotosScreen` export, with new `FotosTab` wrapper handling navigation

### Calendar Configuration (`hooks/useCalendarConfigs.ts`)
- **Calendar ID field:** Added `id` to `CalendarConfig` interface
- **Delegation calendar priority:** Calendars are now sorted so the user's delegation calendar (matching `delegationId`) always appears first, followed by `defaultCalendars` from the profile, then others in Firebase order
- **Stable sort:** Uses index-based sorting to maintain order within each priority tier

### Testing & Theme Updates
- **New test file:** `__tests__/contigoRollingWeek.test.ts` validates `getRollingDays()

https://claude.ai/code/session_01EohCytNnZjjw5BgNHykDMa