### PR TITLE
Cierra tres huecos que dejaron los planes 003, 006 y 012

### DIFF
--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -29,6 +29,27 @@ Es lo que desbloquea el resto: la rama `claude/compact-tabs-bar-uxxaoz` lleva
 SDK 57, barra flotante, Reanimated 4, NSE de iOS, Sentry, analítica, icono de
 Carismochito y subrayado nativo. Todo NATIVO, nada sale por OTA.
 
+### 1-bis. `expo export --platform web` está ROTO (bloquea el deploy web)
+
+- [ ] **`npx expo export --platform web` falla** con
+      `The method or property expo-modules-core.requireNativeViewManager is not
+      available on web`. Es el **renderizado estático** (activado en la config)
+      intentando cargar `app/(tabs)/_layout.tsx` en un entorno Node, donde los
+      módulos nativos nuevos (`expo-native-compact-tabs`,
+      `modules/highlight-menu`) no existen. La exportación no genera ni
+      `index.html` ni el bundle: solo `manifest.json`, `sw.js` e iconos.
+- **Por qué importa ahora**: `.github/workflows/deploy-web.yml` ejecuta ese
+      comando en cada push a `production`. Cuando lo nativo llegue a
+      `production`, **el deploy web deja de funcionar**.
+- **Comprobado el 2026-08-07**: falla igual en el commit base `7682615`, así que
+      NO lo introduce ningún cambio reciente de código de app — viene con los
+      módulos nativos de la build de agosto. El bundle del grafo de la app sí se
+      construye; lo que revienta es el paso de render estático.
+- Caminos posibles (a decidir): desactivar el static rendering para web, dar un
+      shim `.web.ts` a los módulos nativos que se cargan desde el layout de tabs,
+      o mover su import a un punto que el SSG no toque. Verificar con
+      `npx expo export --platform web` en local antes de publicar.
+
 ### 2. React Compiler — lo que SÍ merece la pena
 
 > Contexto: el React Compiler está ACTIVADO (`experiments.reactCompiler: true`

--- a/mcm-app/__tests__/pushNotificationServiceStorage.test.ts
+++ b/mcm-app/__tests__/pushNotificationServiceStorage.test.ts
@@ -9,6 +9,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   saveReceivedNotificationLocally,
   getLocalNotificationsHistory,
+  dismissNotification,
+  clearLocalNotifications,
 } from '@/services/pushNotificationService';
 import type { ReceivedNotification } from '@/types/notifications';
 
@@ -33,5 +35,38 @@ describe('saveReceivedNotificationLocally — escrituras concurrentes', () => {
 
     const history = await getLocalNotificationsHistory();
     expect(history.map((n) => n.id).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('dismissNotification y clearLocalNotifications entran en la cola', () => {
+  it('descartar dos notificaciones a la vez no resucita ninguna', async () => {
+    await saveReceivedNotificationLocally(mk('a'));
+    await saveReceivedNotificationLocally(mk('b'));
+    await saveReceivedNotificationLocally(mk('c'));
+
+    // Sin lock, el segundo descarte parte del snapshot previo al primero y
+    // devuelve al historial la notificación que el primero acababa de quitar.
+    await Promise.all([
+      dismissNotification(mk('a')),
+      dismissNotification(mk('b')),
+    ]);
+
+    const history = await getLocalNotificationsHistory();
+    expect(history.map((n) => n.id)).toEqual(['c']);
+  });
+
+  it('un guardado concurrente con el borrado del historial no deja estado a medias', async () => {
+    await saveReceivedNotificationLocally(mk('viejo'));
+
+    await Promise.all([
+      clearLocalNotifications(),
+      saveReceivedNotificationLocally(mk('nuevo')),
+    ]);
+
+    // Las dos operaciones se serializan, así que el resultado es uno de los dos
+    // estados coherentes: vacío (si el guardado fue primero) o solo el nuevo.
+    // Lo que NO puede pasar es que quede el viejo.
+    const history = await getLocalNotificationsHistory();
+    expect(history.map((n) => n.id)).not.toContain('viejo');
   });
 });

--- a/mcm-app/__tests__/useCalendarEvents.test.ts
+++ b/mcm-app/__tests__/useCalendarEvents.test.ts
@@ -9,6 +9,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import useCalendarEvents, {
   addDaysISO,
   parseICS,
+  MAX_EVENT_DAYS,
   __resetCalendarCacheForTests,
 } from '@/hooks/useCalendarEvents';
 import type { CalendarConfig } from '@/hooks/useCalendarConfigs';
@@ -264,5 +265,55 @@ describe('useCalendarEvents — descarga en paralelo (Plan 008)', () => {
     expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(
       callsAfterFirst,
     );
+  });
+});
+
+describe('expansión multi-día acotada', () => {
+  it('un DTEND corrupto no expande medio milenio de fechas', async () => {
+    // Sin tope, un rango 2026 → 3000 metía el mismo evento en ~355.000 claves,
+    // colgando el parseo del ICS entero.
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'SUMMARY:Evento con DTEND roto',
+      'DTSTART;VALUE=DATE:20260101',
+      'DTEND;VALUE=DATE:30000101',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ]
+      .map((l) => `${l}\r`)
+      .join('\n');
+
+    const [ev] = parseICS(ics);
+    expect(ev.startDate).toBe('2026-01-01');
+
+    __resetCalendarCacheForTests();
+    const calendars: CalendarConfig[] = [
+      {
+        id: 'roto',
+        name: 'roto',
+        url: 'https://example.test/roto.ics',
+        color: '#000000',
+      },
+    ];
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve(ics) }),
+    ) as unknown as typeof fetch;
+
+    try {
+      const { result } = await renderHook(() => useCalendarEvents(calendars));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await waitFor(() =>
+        expect(Object.keys(result.current.eventsByDate).length).toBeGreaterThan(
+          0,
+        ),
+      );
+      expect(Object.keys(result.current.eventsByDate).length).toBe(
+        MAX_EVENT_DAYS,
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });

--- a/mcm-app/hooks/useCalendarEvents.ts
+++ b/mcm-app/hooks/useCalendarEvents.ts
@@ -21,6 +21,14 @@ export interface CalendarEvent {
 
 /** Suma `n` días a una fecha 'YYYY-MM-DD' sin pasar por la hora local (evita
  * que un cambio de hora DST duplique o salte un día al iterar). */
+/**
+ * Tope de días que se expanden de UN evento. Un ICS corrupto con un `DTEND` en
+ * el año 3000 hacía un bucle de cientos de miles de iteraciones metiendo el
+ * mismo evento en cada fecha; ningún evento real de este calendario dura más de
+ * un año.
+ */
+export const MAX_EVENT_DAYS = 366;
+
 export function addDaysISO(iso: string, n: number): string {
   const [y, m, d] = iso.split('-').map(Number);
   const t = Date.UTC(y, m - 1, d + n);
@@ -273,13 +281,24 @@ function fetchAndParseCalendars(
             // For multi-day events, iterate through the range using pure
             // calendar arithmetic (UTC de punta a punta) — evita el bug de
             // duplicar/saltar un día al cruzar un cambio de hora DST.
+            // Acotado a MAX_EVENT_DAYS: un DTEND corrupto no puede colgar el
+            // parseo.
+            let days = 0;
             for (
               let cur = ev.startDate;
-              cur <= ev.endDate;
-              cur = addDaysISO(cur, 1)
+              cur <= ev.endDate && days < MAX_EVENT_DAYS;
+              cur = addDaysISO(cur, 1), days++
             ) {
               if (!map[cur]) map[cur] = [];
               map[cur].push(withCal);
+            }
+            if (days >= MAX_EVENT_DAYS) {
+              logger.warn(
+                '[calendar] evento con rango absurdo, truncado',
+                ev.startDate,
+                ev.endDate,
+                ev.title,
+              );
             }
           }
         });

--- a/mcm-app/services/pushNotificationService.ts
+++ b/mcm-app/services/pushNotificationService.ts
@@ -548,11 +548,15 @@ export const getUnreadNotificationsCount = async (
  * Limpia el historial local de notificaciones
  */
 export const clearLocalNotifications = async (): Promise<void> => {
-  try {
-    await AsyncStorage.removeItem(NOTIFICATIONS_HISTORY_KEY);
-  } catch (error) {
-    logger.error('Error limpiando historial local:', error);
-  }
+  // También pasa por la cola: si el borrado cayera entre el read y el write de
+  // otra operación sobre el historial, esa otra lo resucitaría entero.
+  await withStorageLock(NOTIFICATIONS_HISTORY_KEY, async () => {
+    try {
+      await AsyncStorage.removeItem(NOTIFICATIONS_HISTORY_KEY);
+    } catch (error) {
+      logger.error('Error limpiando historial local:', error);
+    }
+  });
 };
 
 /**
@@ -586,34 +590,42 @@ export const getDismissedNotificationKeys = async (): Promise<Set<string>> => {
 export const dismissNotification = async (
   notification: NotificationData | ReceivedNotification,
 ): Promise<void> => {
-  try {
-    const contentKey = notificationContentKey(notification);
+  // Cuarto ciclo read-modify-write sobre el historial: dejar la clave con solo
+  // tres de sus cuatro escritores serializados es peor que no serializarla,
+  // porque el lock da una falsa sensación de seguridad. De paso queda
+  // serializado DISMISSED_NOTIFICATIONS_KEY, cuyo único escritor es esta
+  // función: dos descartes rápidos ya no se pisan.
+  await withStorageLock(NOTIFICATIONS_HISTORY_KEY, async () => {
+    try {
+      const contentKey = notificationContentKey(notification);
 
-    // 1) Quitar del historial local (por id o por contenido equivalente).
-    const data = await AsyncStorage.getItem(NOTIFICATIONS_HISTORY_KEY);
-    if (data) {
-      const notifications: ReceivedNotification[] = JSON.parse(data);
-      const filtered = notifications.filter(
-        (n) =>
-          n.id !== notification.id && notificationContentKey(n) !== contentKey,
-      );
+      // 1) Quitar del historial local (por id o por contenido equivalente).
+      const data = await AsyncStorage.getItem(NOTIFICATIONS_HISTORY_KEY);
+      if (data) {
+        const notifications: ReceivedNotification[] = JSON.parse(data);
+        const filtered = notifications.filter(
+          (n) =>
+            n.id !== notification.id &&
+            notificationContentKey(n) !== contentKey,
+        );
+        await AsyncStorage.setItem(
+          NOTIFICATIONS_HISTORY_KEY,
+          JSON.stringify(filtered),
+        );
+      }
+
+      // 2) Registrar como descartada (id + clave de contenido).
+      const dismissed = await getDismissedNotificationKeys();
+      if (notification.id) dismissed.add(notification.id);
+      dismissed.add(contentKey);
       await AsyncStorage.setItem(
-        NOTIFICATIONS_HISTORY_KEY,
-        JSON.stringify(filtered),
+        DISMISSED_NOTIFICATIONS_KEY,
+        JSON.stringify(Array.from(dismissed)),
       );
+    } catch (error) {
+      logger.error('Error eliminando notificación:', error);
     }
-
-    // 2) Registrar como descartada (id + clave de contenido).
-    const dismissed = await getDismissedNotificationKeys();
-    if (notification.id) dismissed.add(notification.id);
-    dismissed.add(contentKey);
-    await AsyncStorage.setItem(
-      DISMISSED_NOTIFICATIONS_KEY,
-      JSON.stringify(Array.from(dismissed)),
-    );
-  } catch (error) {
-    logger.error('Error eliminando notificación:', error);
-  }
+  });
 };
 
 const NOTIFICATIONS_INITIALIZED_KEY = '@mcm_notifications_initialized';


### PR DESCRIPTION
Ejecuté los 15 planes de `plans/` en paralelo con la sesión que abrió la #317, sin saberlo. Las dos implementaciones son equivalentes casi en todo, así que **cerré mi rama** (#319) en vez de mergear un duplicado. Al comparar las dos aparecieron tres huecos reales, y son lo único que trae este PR.

## 1. `@mcm_notifications_history` estaba protegida a medias

`withStorageLock` envolvía tres funciones, pero **`dismissNotification` hace el mismo ciclo `getItem → mutar → setItem` sobre esa misma clave** y se quedó fuera. Una clave con tres de sus cuatro escritores serializados es peor que ninguna: el lock da una falsa sensación de seguridad y el caso que queda suelto es justo el que el usuario provoca a mano.

Descartar dos notificaciones seguidas **resucitaba una**: el segundo descarte partía del snapshot previo al primero. Hay test centinela y **falla si se quita el lock** (comprobado).

`clearLocalNotifications` entra también: si el borrado cae entre el read y el write de otra operación, esa otra lo resucita entero. Ese entrelazado el mock de AsyncStorage no lo reproduce, así que ese test es un guard de coherencia, no una reproducción — lo digo por no vender más de lo que hay.

De paso queda serializado `@mcm_dismissed_notifications`, cuyo único escritor es `dismissNotification`.

## 2. La expansión multi-día del calendario no tenía tope

El `addDaysISO` de `main` es correcto y arregla el bug del cambio de hora. Pero el bucle no está acotado: un ICS con un `DTEND` corrupto en el año 3000 mete el mismo evento en **~355.000 claves** y cuelga el parseo del calendario entero. Acotado a `MAX_EVENT_DAYS` (366 — ningún evento real de este calendario dura más de un año) con un `logger.warn` para que se vea si pasa. Test incluido.

## 3. `npx expo export --platform web` está roto y no estaba anotado

Falla con `The method or property expo-modules-core.requireNativeViewManager is not available on web`: el **renderizado estático** intenta cargar `app/(tabs)/_layout.tsx` en un entorno Node, donde `expo-native-compact-tabs` y `modules/highlight-menu` no existen. La exportación no genera ni `index.html` ni el bundle — solo `manifest.json`, `sw.js` e iconos.

**Comprobado que falla igual en el commit base `7682615`**, así que no lo introduce ningún cambio reciente de código de app: viene con los módulos nativos de la build de agosto. Lo que importa es que **`deploy-web.yml` ejecuta ese comando en cada push a `production`**, así que cuando lo nativo llegue allí el deploy web se cae. Documentado en `mcm-app/TODO.md` §1-bis con los caminos posibles; no lo arreglo aquí porque la decisión (desactivar el SSG para web vs. dar un shim `.web.ts` a los módulos) es de producto.

## Lo que NO trae

Dos cosas que parecían huecos y no lo eran, por si alguien las busca:

- El `update()` multi-path atómico de reflexiones **sí tiene reintentos** en `main`; usa `withRetry` inline en vez de una primitiva `updateWithRetry`. Diferencia cosmética, no la toco.
- La expansión del calendario en `main` **no** usa `setDate()`/`toISOString()` en el bucle: el arreglo del DST está bien hecho.

## Verificación

452 tests en verde; `typecheck`, `typecheck:tests` y `lint` sin errores, y **93 warnings — los mismos que `main`**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AKuVrR584Dn1SwrjUiRVD)_