### PR TITLE
Quita el código muerto y dos avisos reales del lint (93 → 87 warnings)

### DIFF
--- a/mcm-app/app/screens/ReflexionesScreen.tsx
+++ b/mcm-app/app/screens/ReflexionesScreen.tsx
@@ -181,10 +181,6 @@ export default function ReflexionesScreen() {
     return pending.length > 0 ? [...pending, ...remoteList] : remoteList;
   }, [justPublished, remoteList]);
 
-  useEffect(() => {
-    setAutor(getDefaultAuthor());
-  }, [getDefaultAuthor]);
-
   const [showForm, setShowForm] = useState(false);
   const [titulo, setTitulo] = useState('');
   const [contenido, setContenido] = useState('');
@@ -193,6 +189,22 @@ export default function ReflexionesScreen() {
   const [showDateSelector, setShowDateSelector] = useState(false);
   const [saving, setSaving] = useState(false);
   const [celebrate, setCelebrate] = useState(false);
+
+  // El autor por defecto sale del perfil (nombre · delegación). Cuando ese
+  // perfil cambia, el campo se re-siembra; pero el usuario puede editarlo, así
+  // que no vale con derivarlo.
+  //
+  // Se ajusta DURANTE el render, el mismo patrón que usa `openFormNonce` unas
+  // líneas más abajo y que documenta React para "cambiar estado cuando cambia
+  // una prop". Antes era un `useEffect` que llamaba a `setAutor`: además del
+  // render intermedio con el autor viejo, dejaba el componente entero sin
+  // compilar por el React Compiler (leía `setAutor` antes de declararlo).
+  const defaultAuthor = getDefaultAuthor();
+  const [lastDefaultAuthor, setLastDefaultAuthor] = useState(defaultAuthor);
+  if (defaultAuthor !== lastDefaultAuthor) {
+    setLastDefaultAuthor(defaultAuthor);
+    setAutor(defaultAuthor);
+  }
 
   // El burst se auto-apaga para poder relanzarse en la siguiente publicación.
   useEffect(() => {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -528,7 +528,10 @@ const SelectedSongsScreen: React.FC = () => {
         logger.error(e);
       }
     }
-  }, [buildShareText, toast]);
+    // `flatSelectedSongs.length` va en las deps aunque hoy `buildShareText` ya
+    // cambie con la lista: sin él, el día que ese memo cambie de dependencias
+    // la analítica empezaría a reportar el tamaño de una playlist vieja.
+  }, [buildShareText, toast, flatSelectedSongs.length]);
 
   const handleStartExportFile = useCallback(() => {
     const monthNames = [

--- a/mcm-app/components/SongControls.tsx
+++ b/mcm-app/components/SongControls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,

--- a/mcm-app/components/contigo/HighlightActionBar.tsx
+++ b/mcm-app/components/contigo/HighlightActionBar.tsx
@@ -1,11 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import React, { useEffect } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, {
   interpolate,
   useAnimatedStyle,

--- a/mcm-app/components/contigo/ReadingCalendarSheet.tsx
+++ b/mcm-app/components/contigo/ReadingCalendarSheet.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,


### PR DESCRIPTION
Revisé los 93 warnings uno a uno. **La mayoría no son deuda: son decisiones ya tomadas y razonadas en `TODO.md` §2.** Este PR arregla solo lo que sí lo era.

## Lo que se arregla

- **Cuatro imports muertos**: `useRef` en `SongControls` y `HighlightActionBar`, `Platform` en `HighlightActionBar` y `ReadingCalendarSheet`. Quedan **cero `no-unused-vars`** en todo el repo.
- **`ReflexionesScreen` re-sembraba el autor por defecto con un `useEffect` que llamaba a `setAutor` antes de declararlo.** Eso dejaba el componente entero sin compilar por el React Compiler *y* metía un render intermedio con el autor viejo. Pasa a **ajuste durante el render**, que es el mismo patrón que ya usa `openFormNonce` treinta líneas más abajo en ese mismo fichero. No vale con derivarlo: el usuario puede editar el campo, así que hay que re-sembrarlo solo cuando cambia el default.
- **`handleShareText` usaba `flatSelectedSongs.length` sin declararlo en las deps.** Hoy no se nota porque `buildShareText` ya cambia con la lista, pero es latente: el día que ese memo cambie de dependencias, la analítica empezaría a reportar el tamaño de una playlist vieja.

## Lo que NO se toca, y por qué

Los 87 restantes, por categoría:

| Cuántos | Qué | Por qué se quedan |
| --- | --- | --- |
| 31 | `max-lines` | Son los gigantes. Es trabajo de la Fase 1 de `PLAN_CALIDAD`, no deuda de lint |
| 20 | `react-hooks/refs` | `TODO.md` §2: son refs legítimas, y el plan es subir la regla a `error` con su `eslint-disable` razonado **cuando la build de tienda esté validada, no antes** |
| 16 | `react-hooks/immutability` | Marcado **NO tocar**: son `sharedValue.value = …`, o sea la API de Reanimated. No tiene arreglo por diseño |
| 7 | acceso a variable antes de declararla | Casi todos son el efecto de deep-link de `SelectedSongsScreen`, que referencia handlers declarados ~700 líneas después. Se cae solo cuando esos handlers salgan a `usePlaylistActions`; forzarlo ahora sería mover un efecto por encima de otros y cambiar el orden de ejecución |
| 5 | `preserve-manual-memoization` | `TODO.md`: «el premio es pequeño, hacerlo solo de pasada si se toca ese fichero por otra cosa» |
| 4 | `set-state-in-effect` | Decisiones documentadas: Wordle congelado, la acción de deep-link, la hidratación de `AddToHomeBanner` y `useSongProcessor` (pendiente de medir en dispositivo) |
| 3 | `react-hooks/purity` | Falsos positivos ya revisados uno a uno |
| 1 | modificar variable local tras el render | `useTabScroll` |

Bajarlos a base de `eslint-disable` sin motivo, o de contorsionar el código, subiría el número de «arreglados» y empeoraría el repo. Prefiero dejar el recuento honesto.

## Verificación

452 tests en verde; `typecheck`, `typecheck:tests` y `lint` sin errores.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AKuVrR584Dn1SwrjUiRVD)_