### PR TITLE
Escáner de QR para importar playlists y unirse al coro [skip-ota]

### DIFF
--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,38 @@
 
 ---
 
+## 2026-08-08 02:20 — Escáner de QR para importar playlists y unirse al coro `[skip-ota]`
+
+Hasta ahora los QR que genera la app (`ShareQrModal`) solo se podían leer con la
+cámara del sistema. Ahora se escanean **desde dentro**, en los dos diálogos en
+los que se teclea un código: "Importar playlist con código" y "Unirse al coro".
+
+- **Botón "Escanear QR"** en `CodeInputModal`, solo en las variantes
+  `cloud-download` y `choir-join` (en las que uno GENERA el código no hay nada
+  que escanear). Al leerlo se rellena y se envía solo: cero toques extra.
+- **Lee los tres formatos** que produce la app: playlist en la nube
+  (`/playlist?p=`), sesión de coro (`/coro?c=`) y playlist **sin conexión**
+  (`mcmapp://playlist?d=`, con las canciones embebidas — se resuelve contra el
+  catálogo cacheado, igual que el deep link). También acepta un QR con solo los
+  4 dígitos.
+- **Si el QR es del otro flujo** (enseñas el del coro en "importar playlist") no
+  se cierra la cámara: sale un aviso y se sigue escaneando.
+- **Animaciones**: el marco se dibuja esquina a esquina al abrir, un láser
+  barre el hueco mientras busca, y al encontrarlo hay fogonazo verde, check,
+  confeti (`CelebrationBurst`) y háptica de éxito antes de continuar.
+- **Nueva dependencia NATIVA: `expo-camera`** → este cambio **NO puede ir por
+  OTA**, necesita build de tienda. El commit lleva `[skip-ota]`. Aun así el
+  módulo se carga con `require` dentro de un try/catch: si una OTA llegase a un
+  binario antiguo, el botón simplemente no aparece en lugar de crashear.
+- **Sin escáner en web**: ahí `expo-camera` depende del navegador y el enlace
+  del QR se puede pinchar directamente.
+- Archivos: `components/playlist/QrScannerModal.tsx`,
+  `components/playlist/QrScanFrame.tsx`,
+  `components/playlist/qrScannerStyles.ts`, `utils/qrScan.ts` (+ tests),
+  `components/playlist/CodeInputModal.tsx` (estilos extraídos a
+  `codeInputModalStyles.ts` para no pasar de 400 líneas),
+  `app/screens/SelectedSongsScreen.tsx`, `app.json`.
+
 ## 2026-08-08 01:55 — El modo tester (Laboratorio Alpha) por fin recibe OTAs de `preview`
 
 El modo alpha nunca llegó a funcionar. El intento anterior (2026-07-22) lo dejó

--- a/mcm-app/__tests__/qrScan.test.ts
+++ b/mcm-app/__tests__/qrScan.test.ts
@@ -1,0 +1,91 @@
+import { describeMismatch, parseScannedQr } from '@/utils/qrScan';
+
+describe('parseScannedQr', () => {
+  it('lee el QR de una playlist en la nube', () => {
+    expect(parseScannedQr('https://mcm.expo.app/playlist?p=1234')).toEqual({
+      kind: 'code',
+      target: 'playlist',
+      code: '1234',
+    });
+  });
+
+  it('lee el QR de una sesión de coro', () => {
+    expect(parseScannedQr('https://mcm.expo.app/coro?c=0704')).toEqual({
+      kind: 'code',
+      target: 'choir',
+      code: '0704',
+    });
+  });
+
+  it('acepta el alias ?code= de las pantallas puente', () => {
+    expect(parseScannedQr('https://mcm.expo.app/playlist?code=0000')).toEqual({
+      kind: 'code',
+      target: 'playlist',
+      code: '0000',
+    });
+  });
+
+  it('lee el QR offline con la playlist embebida y lo desescapa', () => {
+    const payload = '1~D5~A42t2';
+    const result = parseScannedQr(
+      `mcmapp://playlist?d=${encodeURIComponent(payload)}`,
+    );
+    expect(result).toEqual({ kind: 'offline', payload });
+  });
+
+  it('el payload offline manda sobre el código si vienen los dos', () => {
+    expect(parseScannedQr('mcmapp://playlist?d=1~D5&p=1234')).toEqual({
+      kind: 'offline',
+      payload: '1~D5',
+    });
+  });
+
+  it('acepta un código suelto de 4 dígitos, sin flujo concreto', () => {
+    expect(parseScannedQr(' 1234 ')).toEqual({
+      kind: 'code',
+      target: null,
+      code: '1234',
+    });
+  });
+
+  it('ignora QR que no son de la app', () => {
+    expect(parseScannedQr('https://www.youtube.com/watch?v=abc')).toBeNull();
+    expect(parseScannedQr('WIFI:S:MiRed;T:WPA;P:1234;;')).toBeNull();
+    expect(parseScannedQr('https://otracosa.com/algo?p=1234')).toBeNull();
+    expect(parseScannedQr('')).toBeNull();
+  });
+
+  it('ignora códigos mal formados dentro de un enlace nuestro', () => {
+    expect(parseScannedQr('https://mcm.expo.app/playlist?p=12')).toBeNull();
+    expect(parseScannedQr('https://mcm.expo.app/coro?c=abcd')).toBeNull();
+    expect(parseScannedQr('https://mcm.expo.app/playlist')).toBeNull();
+  });
+});
+
+describe('describeMismatch', () => {
+  const playlistCode = {
+    kind: 'code',
+    target: 'playlist',
+    code: '1234',
+  } as const;
+  const choirCode = { kind: 'code', target: 'choir', code: '1234' } as const;
+  const loose = { kind: 'code', target: null, code: '1234' } as const;
+  const offline = { kind: 'offline', payload: '1~D5' } as const;
+
+  it('deja pasar el QR del flujo correcto', () => {
+    expect(describeMismatch(playlistCode, 'playlist')).toBeNull();
+    expect(describeMismatch(choirCode, 'choir')).toBeNull();
+    expect(describeMismatch(offline, 'playlist')).toBeNull();
+  });
+
+  it('un código suelto vale para cualquiera de los dos flujos', () => {
+    expect(describeMismatch(loose, 'playlist')).toBeNull();
+    expect(describeMismatch(loose, 'choir')).toBeNull();
+  });
+
+  it('avisa cuando el QR es del otro flujo', () => {
+    expect(describeMismatch(choirCode, 'playlist')).toMatch(/coro/i);
+    expect(describeMismatch(playlistCode, 'choir')).toMatch(/playlist/i);
+    expect(describeMismatch(offline, 'choir')).toMatch(/playlist/i);
+  });
+});

--- a/mcm-app/app.json
+++ b/mcm-app/app.json
@@ -195,7 +195,14 @@
       "expo-font",
       "expo-image",
       "expo-sharing",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "MCM App usa la cámara para escanear los códigos QR de playlists y sesiones de coro.",
+          "recordAudioAndroid": false
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -939,6 +939,32 @@ const SelectedSongsScreen: React.FC = () => {
     [askMergeOrReplace],
   );
 
+  /**
+   * QR offline escaneado desde el diálogo de importar: la playlist viene
+   * entera dentro del propio código, así que no hay descarga — se resuelve
+   * contra el catálogo cacheado igual que el deep link `?d=`.
+   */
+  const handleScannedOfflinePlaylist = useCallback(
+    (payload: string) => {
+      const { songs, missing } = decodeOfflinePlaylist(
+        payload,
+        offlineFilenameResolver,
+      );
+      if (songs.length === 0) {
+        toast.show({ label: 'No se pudo leer la playlist del QR' });
+        return;
+      }
+      setCodeDialog(null);
+      askMergeOrReplace(songs);
+      if (missing > 0) {
+        toast.show({
+          label: `${missing} canción(es) del QR no están en este dispositivo`,
+        });
+      }
+    },
+    [askMergeOrReplace, offlineFilenameResolver, toast],
+  );
+
   const handleChangeCloudCode = useCallback(
     async (newCode: string) => {
       if (!lastUploadCode) return;
@@ -1587,6 +1613,11 @@ const SelectedSongsScreen: React.FC = () => {
           variant={codeDialog.variant}
           initialCode={codeDialog.initial}
           onClose={() => setCodeDialog(null)}
+          onScanOffline={
+            codeDialog.variant === 'cloud-download'
+              ? handleScannedOfflinePlaylist
+              : undefined
+          }
           onSubmit={async (code, name) => {
             const fn = submitForVariant(codeDialog.variant);
             try {

--- a/mcm-app/components/playlist/CodeInputModal.tsx
+++ b/mcm-app/components/playlist/CodeInputModal.tsx
@@ -11,16 +11,14 @@
  * el código vía `onSubmit`. Devolver una promesa permite mostrar un
  * estado "cargando" durante la operación.
  */
-import { radii } from '@/constants/uiStyles';
 import React, { useMemo, useState } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
   TouchableOpacity,
-  Platform,
   ActivityIndicator,
   TextInput,
+  Keyboard,
 } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import AppTextField from '@/components/ui/AppTextField';
@@ -32,7 +30,13 @@ import {
   isValidCode,
   todayCode,
 } from '@/utils/playlistCodes';
+import QrScannerModal, {
+  isQrScanSupported,
+} from '@/components/playlist/QrScannerModal';
+import type { QrTarget } from '@/utils/qrScan';
+import { h } from '@/utils/haptics';
 import BottomSheet from '../BottomSheet';
+import { createStyles } from './codeInputModalStyles';
 
 export type CodeDialogVariant =
   | 'cloud-upload'
@@ -53,6 +57,12 @@ interface Props {
    * abierto para que reintente o cambie el código.
    */
   onSubmit: (code: string, name?: string) => Promise<void>;
+  /**
+   * Se llama cuando el QR escaneado era una playlist OFFLINE (lleva las
+   * canciones embebidas, no un código): no hay nada que descargar, así que lo
+   * resuelve la pantalla. Si no se pasa, esos QR se rechazan con un aviso.
+   */
+  onScanOffline?: (payload: string) => void;
 }
 
 interface VariantCopy {
@@ -61,6 +71,12 @@ interface VariantCopy {
   primaryLabel: string;
   showSuggestButtons: boolean;
   askForName?: boolean;
+  /**
+   * Flujo al que apunta el escáner de QR. Solo lo tienen las variantes en las
+   * que el usuario TECLEA un código que le han dado; en las que lo genera él
+   * (subir, iniciar coro, cambiar código) no hay nada que escanear.
+   */
+  scanTarget?: QrTarget;
 }
 
 const COPY: Record<CodeDialogVariant, VariantCopy> = {
@@ -74,9 +90,11 @@ const COPY: Record<CodeDialogVariant, VariantCopy> = {
   },
   'cloud-download': {
     title: 'Descargar playlist',
-    description: 'Introduce el código de 4 dígitos que te han compartido.',
+    description:
+      'Escanea el QR que te han compartido o introduce el código de 4 dígitos.',
     primaryLabel: 'Descargar',
     showSuggestButtons: false,
+    scanTarget: 'playlist',
   },
   'choir-start': {
     title: 'Iniciar sesión de coro',
@@ -88,9 +106,10 @@ const COPY: Record<CodeDialogVariant, VariantCopy> = {
   'choir-join': {
     title: 'Unirse al coro',
     description:
-      'Introduce el código proporcionado para seguir las canciones automáticamente.',
+      'Escanea el QR del coro o introduce el código para seguir las canciones automáticamente.',
     primaryLabel: 'Unirse',
     showSuggestButtons: false,
+    scanTarget: 'choir',
   },
   'change-code': {
     title: 'Cambiar código',
@@ -122,12 +141,23 @@ function seedFor(
   return { code, name };
 }
 
+/**
+ * Estado del escáner. Tiene un paso a cada lado a propósito: iOS rechaza en
+ * silencio un Modal que aparece en el mismo ciclo de render en que otro se
+ * cierra. Así que al ABRIR escondemos la hoja y esperamos a que `BottomSheet`
+ * confirme que está desmontada (`onCloseComplete` → `scanning`), y al CERRAR
+ * esperamos a que la cámara confirme que se ha ido (`onDismissed` → `idle`)
+ * antes de dejar que la hoja vuelva.
+ */
+type ScanState = 'idle' | 'pending' | 'scanning' | 'closing';
+
 const CodeInputModal: React.FC<Props> = ({
   visible,
   variant,
   initialCode,
   onClose,
   onSubmit,
+  onScanOffline,
 }) => {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
@@ -138,6 +168,9 @@ const CodeInputModal: React.FC<Props> = ({
   const [name, setName] = useState<string>('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [scan, setScan] = useState<ScanState>('idle');
+
+  const canScan = !!copy.scanTarget && isQrScanSupported();
 
   // Al abrir se siembran los valores iniciales, ajustando el estado durante el
   // render (el patrón que documenta React para "cambiar estado cuando cambia
@@ -154,6 +187,7 @@ const CodeInputModal: React.FC<Props> = ({
       const seed = seedFor(variant, initialCode);
       setError(null);
       setSubmitting(false);
+      setScan('idle');
       setCode(seed.code);
       setName(seed.name);
     }
@@ -161,16 +195,39 @@ const CodeInputModal: React.FC<Props> = ({
 
   const valid = isValidCode(code);
 
-  const handleSubmit = async () => {
-    if (!valid || submitting) return;
+  /**
+   * `override` llega desde el escáner: el código recién leído todavía no está
+   * en el estado (React lo aplica en el siguiente render) y no queremos hacer
+   * esperar al usuario un toque más.
+   */
+  const handleSubmit = async (override?: string) => {
+    const value = override ?? code;
+    if (!isValidCode(value) || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      await onSubmit(code, name.trim() || undefined);
+      await onSubmit(value, name.trim() || undefined);
     } catch (e: any) {
       setError(e?.message ?? 'Algo salió mal');
       setSubmitting(false);
     }
+  };
+
+  /**
+   * QR leído con código: se rellena y se envía sin pedir confirmación — que es
+   * justo la gracia de escanear. El envío arranca ya, mientras la cámara se va:
+   * si sale bien, la pantalla cierra el diálogo entero y la hoja no llega a
+   * reaparecer; si falla, vuelve con el código puesto y el error escrito.
+   */
+  const handleScannedCode = (scanned: string) => {
+    setScan('closing');
+    setCode(scanned);
+    void handleSubmit(scanned);
+  };
+
+  const handleScannedOffline = (payload: string) => {
+    setScan('closing');
+    onScanOffline?.(payload);
   };
 
   const handleChangeText = (txt: string) => {
@@ -180,255 +237,168 @@ const CodeInputModal: React.FC<Props> = ({
   };
 
   return (
-    <BottomSheet
-      visible={visible}
-      onClose={() => {
-        if (!submitting) onClose();
-      }}
-      title={copy.title}
-    >
-      <View style={styles.container}>
-        <Text style={styles.description}>{copy.description}</Text>
+    <>
+      <BottomSheet
+        visible={visible && scan === 'idle'}
+        onClose={() => {
+          if (!submitting) onClose();
+        }}
+        onCloseComplete={() => {
+          // Solo abrimos la cámara si la hoja se escondió PARA escanear; un
+          // cierre normal (cancelar, swipe) pasa por aquí igualmente.
+          setScan((s) => (s === 'pending' ? 'scanning' : s));
+        }}
+        title={copy.title}
+      >
+        <View style={styles.container}>
+          <Text style={styles.description}>{copy.description}</Text>
 
-        {copy.askForName && (
-          <View style={styles.nameRow}>
-            <Text style={styles.inputLabel}>Nombre</Text>
-            <AppTextField
-              value={name}
-              onChangeText={setName}
-              placeholder="Ej. Eucaristía domingo 7 abril 2031"
-              editable={!submitting}
-              accentColor={isDark ? '#7AB3FF' : '#253883'}
-              accentWhenFilled
-            />
-          </View>
-        )}
+          {copy.askForName && (
+            <View style={styles.nameRow}>
+              <Text style={styles.inputLabel}>Nombre</Text>
+              <AppTextField
+                value={name}
+                onChangeText={setName}
+                placeholder="Ej. Eucaristía domingo 7 abril 2031"
+                editable={!submitting}
+                accentColor={isDark ? '#7AB3FF' : '#253883'}
+                accentWhenFilled
+              />
+            </View>
+          )}
 
-        <Text style={[styles.inputLabel, copy.askForName && { marginTop: 12 }]}>
-          Código (4 dígitos)
-        </Text>
-        <View style={styles.codeRow}>
-          {/* Para máxima fiabilidad cross-platform (web + RN) usamos un
+          <Text
+            style={[styles.inputLabel, copy.askForName && { marginTop: 12 }]}
+          >
+            Código (4 dígitos)
+          </Text>
+          <View style={styles.codeRow}>
+            {/* Para máxima fiabilidad cross-platform (web + RN) usamos un
               único TextInput de N dígitos en lugar de N TextInputs
               separados. Visualmente lo presentamos con celdas. */}
-          <TextInput
-            value={code}
-            onChangeText={handleChangeText}
-            keyboardType="number-pad"
-            inputMode="numeric"
-            autoFocus
-            maxLength={CODE_LENGTH}
-            selectTextOnFocus
-            style={styles.hiddenInput}
-            editable={!submitting}
-            onSubmitEditing={handleSubmit}
-            returnKeyType="done"
-          />
-          <View style={styles.cells} pointerEvents="none">
-            {Array.from({ length: CODE_LENGTH }).map((_, i) => {
-              const char = code[i] ?? '';
-              const active = i === code.length;
-              return (
-                <View
-                  key={i}
-                  style={[
-                    styles.cell,
-                    active && !submitting && styles.cellActive,
-                    !!char && styles.cellFilled,
-                  ]}
-                >
-                  <Text style={styles.cellText}>{char}</Text>
-                </View>
-              );
-            })}
+            <TextInput
+              value={code}
+              onChangeText={handleChangeText}
+              keyboardType="number-pad"
+              inputMode="numeric"
+              autoFocus
+              maxLength={CODE_LENGTH}
+              selectTextOnFocus
+              style={styles.hiddenInput}
+              editable={!submitting}
+              onSubmitEditing={() => void handleSubmit()}
+              returnKeyType="done"
+            />
+            <View style={styles.cells} pointerEvents="none">
+              {Array.from({ length: CODE_LENGTH }).map((_, i) => {
+                const char = code[i] ?? '';
+                const active = i === code.length;
+                return (
+                  <View
+                    key={i}
+                    style={[
+                      styles.cell,
+                      active && !submitting && styles.cellActive,
+                      !!char && styles.cellFilled,
+                    ]}
+                  >
+                    <Text style={styles.cellText}>{char}</Text>
+                  </View>
+                );
+              })}
+            </View>
           </View>
-        </View>
 
-        {copy.showSuggestButtons && (
-          <View style={styles.suggestRow}>
+          {canScan && (
             <TouchableOpacity
-              style={styles.suggestBtn}
-              onPress={() => setCode(generateRandomCode())}
+              style={styles.scanBtn}
+              onPress={() => {
+                if (submitting) return;
+                h.tap();
+                // El teclado numérico está abierto por el `autoFocus` del código:
+                // sin esto se queda flotando sobre la cámara al abrirse.
+                Keyboard.dismiss();
+                setScan('pending');
+              }}
+              disabled={submitting}
+              accessibilityRole="button"
+              accessibilityLabel="Escanear un código QR con la cámara"
+            >
+              <MaterialIcons name="qr-code-scanner" size={20} color="#fff" />
+              <Text style={styles.scanBtnText}>Escanear QR</Text>
+            </TouchableOpacity>
+          )}
+
+          {copy.showSuggestButtons && (
+            <View style={styles.suggestRow}>
+              <TouchableOpacity
+                style={styles.suggestBtn}
+                onPress={() => setCode(generateRandomCode())}
+                disabled={submitting}
+              >
+                <MaterialIcons
+                  name="casino"
+                  size={16}
+                  color={isDark ? '#7AB3FF' : '#253883'}
+                />
+                <Text style={styles.suggestText}>Aleatorio</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.suggestBtn}
+                onPress={() => setCode(todayCode())}
+                disabled={submitting}
+              >
+                <MaterialIcons
+                  name="event"
+                  size={16}
+                  color={isDark ? '#7AB3FF' : '#253883'}
+                />
+                <Text style={styles.suggestText}>Hoy (DDMM)</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
+          <View style={styles.buttons}>
+            <TouchableOpacity
+              style={[styles.btn, styles.btnSecondary]}
+              onPress={onClose}
               disabled={submitting}
             >
-              <MaterialIcons
-                name="casino"
-                size={16}
-                color={isDark ? '#7AB3FF' : '#253883'}
-              />
-              <Text style={styles.suggestText}>Aleatorio</Text>
+              <Text style={styles.btnSecondaryText}>Cancelar</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={styles.suggestBtn}
-              onPress={() => setCode(todayCode())}
-              disabled={submitting}
+              style={[
+                styles.btn,
+                styles.btnPrimary,
+                (!valid || submitting) && styles.btnDisabled,
+              ]}
+              onPress={() => void handleSubmit()}
+              disabled={!valid || submitting}
             >
-              <MaterialIcons
-                name="event"
-                size={16}
-                color={isDark ? '#7AB3FF' : '#253883'}
-              />
-              <Text style={styles.suggestText}>Hoy (DDMM)</Text>
+              {submitting ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.btnPrimaryText}>{copy.primaryLabel}</Text>
+              )}
             </TouchableOpacity>
           </View>
-        )}
-
-        {error ? <Text style={styles.error}>{error}</Text> : null}
-
-        <View style={styles.buttons}>
-          <TouchableOpacity
-            style={[styles.btn, styles.btnSecondary]}
-            onPress={onClose}
-            disabled={submitting}
-          >
-            <Text style={styles.btnSecondaryText}>Cancelar</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[
-              styles.btn,
-              styles.btnPrimary,
-              (!valid || submitting) && styles.btnDisabled,
-            ]}
-            onPress={handleSubmit}
-            disabled={!valid || submitting}
-          >
-            {submitting ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text style={styles.btnPrimaryText}>{copy.primaryLabel}</Text>
-            )}
-          </TouchableOpacity>
         </View>
-      </View>
-    </BottomSheet>
+      </BottomSheet>
+
+      {copy.scanTarget ? (
+        <QrScannerModal
+          visible={scan === 'scanning'}
+          expected={copy.scanTarget}
+          onClose={() => setScan('closing')}
+          onDismissed={() => setScan('idle')}
+          onCode={handleScannedCode}
+          onOffline={onScanOffline ? handleScannedOffline : undefined}
+        />
+      ) : null}
+    </>
   );
 };
-
-const createStyles = (isDark: boolean) =>
-  StyleSheet.create({
-    container: {
-      paddingBottom: 24,
-    },
-    description: {
-      fontSize: 14,
-      color: isDark ? '#A0A0A8' : '#6B6B70',
-      marginBottom: 18,
-      lineHeight: 20,
-    },
-    codeRow: {
-      position: 'relative',
-      alignItems: 'center',
-      justifyContent: 'center',
-      marginBottom: 14,
-      marginTop: 6,
-    },
-    nameRow: {
-      marginBottom: 8,
-    },
-    inputLabel: {
-      fontSize: 13,
-      fontWeight: '600',
-      color: isDark ? '#A0A0A8' : '#6B6B70',
-      marginBottom: 6,
-      textTransform: 'uppercase',
-      letterSpacing: 0.5,
-    },
-    hiddenInput: {
-      position: 'absolute',
-      width: '100%',
-      height: 56,
-      opacity: 0.01,
-      color: 'transparent',
-      // En web, dejamos un caret invisible para no ver doble cursor.
-      ...(Platform.OS === 'web' ? ({ caretColor: 'transparent' } as any) : {}),
-      fontSize: 1,
-    },
-    cells: {
-      flexDirection: 'row',
-      gap: 10,
-    },
-    cell: {
-      width: 52,
-      height: 60,
-      borderRadius: radii.md,
-      borderWidth: 1.5,
-      borderColor: isDark ? '#48484A' : '#D1D1D6',
-      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cellFilled: {
-      borderColor: isDark ? '#7AB3FF' : '#253883',
-    },
-    cellActive: {
-      borderColor: isDark ? '#7AB3FF' : '#253883',
-      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
-    },
-    cellText: {
-      fontSize: 26,
-      fontWeight: '700',
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
-      fontVariant: ['tabular-nums'],
-    },
-    suggestRow: {
-      flexDirection: 'row',
-      gap: 8,
-      marginBottom: 14,
-      justifyContent: 'center',
-    },
-    suggestBtn: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 6,
-      paddingVertical: 8,
-      paddingHorizontal: 12,
-      borderRadius: radii.sm,
-      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
-    },
-    suggestText: {
-      fontSize: 13,
-      fontWeight: '600',
-      color: isDark ? '#7AB3FF' : '#253883',
-    },
-    error: {
-      color: '#FF453A',
-      fontSize: 13,
-      marginBottom: 8,
-      textAlign: 'center',
-    },
-    buttons: {
-      flexDirection: 'row',
-      gap: 10,
-      justifyContent: 'flex-end',
-      marginTop: 4,
-    },
-    btn: {
-      paddingVertical: 11,
-      paddingHorizontal: 18,
-      borderRadius: 10,
-      minWidth: 110,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    btnSecondary: {
-      backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : '#F2F2F7',
-    },
-    btnSecondaryText: {
-      fontSize: 15,
-      fontWeight: '600',
-      color: isDark ? '#F5F5F7' : '#1C1C1E',
-    },
-    btnPrimary: {
-      backgroundColor: '#253883',
-    },
-    btnPrimaryText: {
-      fontSize: 15,
-      fontWeight: '700',
-      color: '#FFFFFF',
-    },
-    btnDisabled: {
-      opacity: 0.45,
-    },
-  });
 
 export default CodeInputModal;

--- a/mcm-app/components/playlist/QrScanFrame.tsx
+++ b/mcm-app/components/playlist/QrScanFrame.tsx
@@ -1,0 +1,229 @@
+/**
+ * La "ventana" animada del escáner de QR: las cuatro esquinas y el láser que
+ * barre el hueco. Vive aparte de `QrScannerModal` para que ninguno de los dos
+ * se convierta en un gigante (y porque aquí no hay nada de cámara: son formas
+ * animadas y se pueden mirar en aislado).
+ *
+ * Todo corre en Reanimated (hilo de UI), así que el barrido no se entrecorta
+ * mientras JS está ocupado decodificando fotogramas.
+ */
+import React, { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import { LinearGradient } from 'expo-linear-gradient';
+
+/** Lado del hueco transparente por el que se apunta al QR. */
+export const FRAME_SIZE = 250;
+/** Largo del brazo de cada esquina. */
+const CORNER = 42;
+const BORDER = 4;
+const IDLE_COLOR = '#FFFFFF';
+const OK_COLOR = '#A3BD31';
+
+const CORNERS = [
+  { top: 0, left: 0, rx: 0 },
+  { top: 0, right: 0, rx: 90 },
+  { bottom: 0, right: 0, rx: 180 },
+  { bottom: 0, left: 0, rx: 270 },
+] as const;
+
+interface Props {
+  /** Al pasar a `true` el marco se pone verde y da un golpe de escala. */
+  found: boolean;
+}
+
+export default function QrScanFrame({ found }: Props) {
+  // 0 → cerrado (recién abierto), 1 → marco montado y listo para escanear.
+  const open = useSharedValue(0);
+  // 0 → escaneando, 1 → ¡lo tenemos!
+  const hit = useSharedValue(0);
+
+  useEffect(() => {
+    open.value = withDelay(
+      120,
+      withSpring(1, { stiffness: 140, damping: 13, mass: 0.9 }),
+    );
+  }, [open]);
+
+  useEffect(() => {
+    if (!found) return;
+    // Golpe seco hacia fuera y vuelta: el marco "atrapa" el código.
+    hit.value = withSequence(
+      withTiming(1, { duration: 160, easing: Easing.out(Easing.quad) }),
+      withSpring(0.6, { stiffness: 200, damping: 12 }),
+    );
+  }, [found, hit]);
+
+  const wrapStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(open.value, [0, 0.4, 1], [0, 1, 1]),
+    transform: [
+      { scale: interpolate(open.value, [0, 1], [0.78, 1]) },
+      { scale: interpolate(hit.value, [0, 1], [1, 1.08]) },
+    ],
+  }));
+
+  return (
+    <Animated.View style={[styles.frame, wrapStyle]}>
+      {CORNERS.map((c, i) => (
+        <FrameCorner key={i} corner={c} index={i} found={found} />
+      ))}
+      {found ? <FoundFlash /> : <ScanLaser />}
+    </Animated.View>
+  );
+}
+
+/**
+ * Una esquina en forma de L. Entra girando un poco y escalonada respecto a las
+ * demás, que es lo que hace que el marco parezca "dibujarse" al abrir.
+ */
+function FrameCorner({
+  corner,
+  index,
+  found,
+}: {
+  corner: (typeof CORNERS)[number];
+  index: number;
+  found: boolean;
+}) {
+  const enter = useSharedValue(0);
+
+  useEffect(() => {
+    enter.value = withDelay(
+      140 + index * 70,
+      withSpring(1, { stiffness: 170, damping: 12 }),
+    );
+  }, [enter, index]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: enter.value,
+    transform: [
+      { scale: interpolate(enter.value, [0, 1], [0.4, 1]) },
+      {
+        rotate: `${corner.rx + interpolate(enter.value, [0, 1], [-25, 0])}deg`,
+      },
+    ],
+  }));
+
+  // Posicionamiento estático (top/left/…) fuera del estilo animado.
+  const place: any = {};
+  if ('top' in corner) place.top = corner.top;
+  if ('bottom' in corner) place.bottom = (corner as any).bottom;
+  if ('left' in corner) place.left = (corner as any).left;
+  if ('right' in corner) place.right = (corner as any).right;
+
+  const color = found ? OK_COLOR : IDLE_COLOR;
+
+  return (
+    <Animated.View style={[styles.corner, place, style]}>
+      <View style={[styles.armH, { backgroundColor: color }]} />
+      <View style={[styles.armV, { backgroundColor: color }]} />
+    </Animated.View>
+  );
+}
+
+/** Línea que barre el hueco de arriba abajo sin parar mientras se escanea. */
+function ScanLaser() {
+  const sweep = useSharedValue(0);
+
+  useEffect(() => {
+    sweep.value = withRepeat(
+      withTiming(1, { duration: 1800, easing: Easing.inOut(Easing.quad) }),
+      -1,
+      true,
+    );
+  }, [sweep]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: interpolate(sweep.value, [0, 0.1, 0.9, 1], [0.2, 1, 1, 0.2]),
+    transform: [
+      {
+        translateY: interpolate(
+          sweep.value,
+          [0, 1],
+          [BORDER, FRAME_SIZE - BORDER],
+        ),
+      },
+    ],
+  }));
+
+  return (
+    <Animated.View style={[styles.laser, style]} pointerEvents="none">
+      <LinearGradient
+        colors={['rgba(149,210,242,0)', '#95d2f2', 'rgba(149,210,242,0)']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 0 }}
+        style={styles.laserLine}
+      />
+    </Animated.View>
+  );
+}
+
+/** Fogonazo verde que rellena el hueco justo al encontrar el código. */
+function FoundFlash() {
+  const flash = useSharedValue(0);
+
+  useEffect(() => {
+    flash.value = withSequence(
+      withTiming(1, { duration: 120 }),
+      withTiming(0.25, { duration: 320 }),
+    );
+  }, [flash]);
+
+  const style = useAnimatedStyle(() => ({ opacity: flash.value * 0.55 }));
+
+  return <Animated.View style={[styles.flash, style]} pointerEvents="none" />;
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    width: FRAME_SIZE,
+    height: FRAME_SIZE,
+    overflow: 'hidden',
+    borderRadius: 28,
+  },
+  corner: {
+    position: 'absolute',
+    width: CORNER,
+    height: CORNER,
+  },
+  armH: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: CORNER,
+    height: BORDER,
+    borderRadius: BORDER,
+  },
+  armV: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: BORDER,
+    height: CORNER,
+    borderRadius: BORDER,
+  },
+  laser: {
+    position: 'absolute',
+    left: 8,
+    right: 8,
+    height: 3,
+  },
+  laserLine: {
+    flex: 1,
+    borderRadius: 3,
+  },
+  flash: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: OK_COLOR,
+  },
+});

--- a/mcm-app/components/playlist/QrScannerModal.tsx
+++ b/mcm-app/components/playlist/QrScannerModal.tsx
@@ -1,0 +1,341 @@
+/**
+ * Escáner de QR a pantalla completa para los flujos de "meter un código":
+ * importar una playlist de la nube y unirse a una sesión de coro.
+ *
+ * Lee los tres QR que genera `ShareQrModal` (playlist con código, coro con
+ * código y playlist offline con la lista embebida) — ver `utils/qrScan.ts`.
+ *
+ * ## Sobre `expo-camera`
+ *
+ * Es un módulo NATIVO: no existe en un binario publicado antes de añadirlo. Por
+ * eso lo cargamos con `require` dentro de un try/catch en vez de importarlo
+ * arriba — si una OTA llegase a una build antigua, el botón de escanear
+ * simplemente no aparece en lugar de reventar la pantalla entera.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import Animated, { FadeIn, FadeOut, ZoomIn } from 'react-native-reanimated';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import CelebrationBurst from '@/components/ui/CelebrationBurst';
+import QrScanFrame from '@/components/playlist/QrScanFrame';
+import {
+  describeMismatch,
+  parseScannedQr,
+  type QrScanResult,
+  type QrTarget,
+} from '@/utils/qrScan';
+import { h } from '@/utils/haptics';
+import { logger } from '@/utils/logger';
+import { styles } from './qrScannerStyles';
+
+/** Milisegundos que dejamos ver la animación de éxito antes de resolver. */
+const CELEBRATION_MS = 850;
+/** Antirrebote de los avisos ("ese QR es de coro") para no parpadear. */
+const HINT_COOLDOWN_MS = 2200;
+
+type CameraModule = typeof import('expo-camera');
+
+let cached: CameraModule | null | undefined;
+
+/** `null` si el binario instalado no trae el módulo nativo de cámara. */
+function getCamera(): CameraModule | null {
+  if (cached === undefined) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      cached = require('expo-camera') as CameraModule;
+    } catch (e) {
+      logger.warn('expo-camera no disponible en este binario', e);
+      cached = null;
+    }
+  }
+  return cached;
+}
+
+/**
+ * ¿Se puede ofrecer el botón de escanear? En web `expo-camera` necesita
+ * permisos de getUserMedia y el decodificador no es fiable en todos los
+ * navegadores, así que ahí no lo enseñamos: quien esté en el navegador ya
+ * puede pinchar el enlace del QR directamente.
+ */
+export function isQrScanSupported(): boolean {
+  return Platform.OS !== 'web' && getCamera() !== null;
+}
+
+interface Props {
+  visible: boolean;
+  /** Flujo desde el que se abre, para avisar si el QR es del otro. */
+  expected: QrTarget;
+  onClose: () => void;
+  /** QR con código de 4 dígitos. */
+  onCode: (code: string) => void;
+  /** QR offline con la playlist embebida (solo llega en `expected: playlist`). */
+  onOffline?: (payload: string) => void;
+  /**
+   * La cámara ya NO está en pantalla. Quien nos abrió tiene que esperar a esto
+   * para volver a enseñar su propio Modal: iOS rechaza en silencio un Modal que
+   * se presenta en el mismo ciclo de render en que otro se cierra.
+   */
+  onDismissed?: () => void;
+}
+
+const QrScannerModal: React.FC<Props> = ({
+  visible,
+  expected,
+  onClose,
+  onCode,
+  onOffline,
+  onDismissed,
+}) => {
+  const insets = useSafeAreaInsets();
+  const camera = getCamera();
+
+  const [granted, setGranted] = useState<boolean | null>(null);
+  const [found, setFound] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+  // Una vez encontrado dejamos de mirar fotogramas: si no, el mismo QR entra
+  // veinte veces mientras corre la animación de celebración.
+  const lockedRef = useRef(false);
+  const hintAtRef = useRef(0);
+  const celebrationRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Al ABRIR se olvida el escaneo anterior. Se ajusta durante el render (el
+  // patrón que documenta React para "cambiar estado cuando cambia una prop"),
+  // no en un efecto: así la cámara nunca llega a pintarse un fotograma con el
+  // marco todavía en verde de la vez pasada.
+  const [lastVisible, setLastVisible] = useState(visible);
+  if (visible !== lastVisible) {
+    setLastVisible(visible);
+    if (visible) {
+      lockedRef.current = false;
+      setFound(false);
+      setHint(null);
+    }
+  }
+
+  // Aviso de "ya no estoy en pantalla". En iOS lo da UIKit por el `onDismiss`
+  // del Modal, que es el único momento en que de verdad se ha ido; en el resto
+  // de plataformas basta con el cambio de la prop.
+  const wasVisibleRef = useRef(visible);
+  useEffect(() => {
+    if (Platform.OS !== 'ios' && wasVisibleRef.current && !visible) {
+      onDismissed?.();
+    }
+    wasVisibleRef.current = visible;
+  }, [visible, onDismissed]);
+
+  // Pedimos permiso al abrir. `getCameraPermissionsAsync` primero para no
+  // enseñar el diálogo del sistema a quien ya dijo que sí.
+  useEffect(() => {
+    if (!visible || !camera) return;
+    let alive = true;
+    (async () => {
+      try {
+        const current = await camera.Camera.getCameraPermissionsAsync();
+        const res = current.granted
+          ? current
+          : await camera.Camera.requestCameraPermissionsAsync();
+        if (alive) setGranted(res.granted);
+      } catch (e) {
+        logger.warn('No se pudo pedir permiso de cámara', e);
+        if (alive) setGranted(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [visible, camera]);
+
+  /** Aviso efímero que no cierra la cámara: se sigue escaneando. */
+  const showHint = useCallback((text: string) => {
+    const now = Date.now();
+    if (now - hintAtRef.current < HINT_COOLDOWN_MS) return;
+    hintAtRef.current = now;
+    h.error();
+    setHint(text);
+  }, []);
+
+  const resolve = useCallback(
+    (result: QrScanResult) => {
+      lockedRef.current = true;
+      setHint(null);
+      setFound(true);
+      h.formSuccess();
+      celebrationRef.current = setTimeout(() => {
+        celebrationRef.current = null;
+        if (result.kind === 'offline') onOffline?.(result.payload);
+        else onCode(result.code);
+      }, CELEBRATION_MS);
+    },
+    [onCode, onOffline],
+  );
+
+  // Si cierran la cámara a mano mientras corre la celebración, el código leído
+  // se descarta: no queremos importar una playlist que acaban de cancelar. La
+  // limpieza va atada a `visible` para que salte también al cerrar, no solo al
+  // desmontar (el escáner se queda montado entre aperturas).
+  useEffect(
+    () => () => {
+      if (celebrationRef.current) {
+        clearTimeout(celebrationRef.current);
+        celebrationRef.current = null;
+      }
+    },
+    [visible],
+  );
+
+  const handleScan = useCallback(
+    ({ data }: { data: string }) => {
+      if (lockedRef.current) return;
+      const result = parseScannedQr(data);
+      if (!result) {
+        showHint('Ese QR no es de la app');
+        return;
+      }
+      const mismatch = describeMismatch(result, expected);
+      if (mismatch) {
+        showHint(mismatch);
+        return;
+      }
+      if (result.kind === 'offline' && !onOffline) {
+        showHint('Ese QR lleva la playlist entera; ábrelo con la cámara');
+        return;
+      }
+      resolve(result);
+    },
+    [expected, onOffline, resolve, showHint],
+  );
+
+  if (!camera) return null;
+  const { CameraView } = camera;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      transparent={false}
+      statusBarTranslucent
+      onRequestClose={onClose}
+      onDismiss={onDismissed}
+    >
+      <View style={styles.root}>
+        {granted === null ? (
+          <View style={styles.center}>
+            <ActivityIndicator color="#fff" size="large" />
+          </View>
+        ) : granted === false ? (
+          <PermissionDenied onClose={onClose} />
+        ) : (
+          <>
+            <CameraView
+              style={StyleSheet.absoluteFill}
+              facing="back"
+              barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+              onBarcodeScanned={handleScan}
+            />
+
+            {/* Penumbra alrededor del hueco: cuatro paneles en vez de una
+                máscara, que es lo único que se ve igual en iOS, Android y web. */}
+            <View style={styles.dimTop} />
+            <View style={styles.dimBottom} />
+            <View style={styles.dimRow} pointerEvents="box-none">
+              <View style={styles.dimSide} />
+              <View style={styles.frameSlot} pointerEvents="none">
+                <QrScanFrame found={found} />
+                {found ? (
+                  <>
+                    <CelebrationBurst visible emoji="🎉" emojiSize={54} />
+                    <Animated.View
+                      style={styles.check}
+                      entering={ZoomIn.springify().damping(11)}
+                    >
+                      <MaterialIcons name="check" size={44} color="#fff" />
+                    </Animated.View>
+                  </>
+                ) : null}
+              </View>
+              <View style={styles.dimSide} />
+            </View>
+
+            <Animated.View
+              entering={FadeIn.delay(150)}
+              style={[styles.header, { paddingTop: insets.top + 10 }]}
+            >
+              <Text style={styles.title}>
+                {expected === 'choir'
+                  ? 'Escanea el QR del coro'
+                  : 'Escanea el QR de la playlist'}
+              </Text>
+              <TouchableOpacity
+                onPress={() => {
+                  h.tap();
+                  onClose();
+                }}
+                style={styles.closeBtn}
+                hitSlop={12}
+                accessibilityRole="button"
+                accessibilityLabel="Cerrar el escáner"
+              >
+                <MaterialIcons name="close" size={26} color="#fff" />
+              </TouchableOpacity>
+            </Animated.View>
+
+            <View
+              style={[styles.footer, { paddingBottom: insets.bottom + 24 }]}
+              pointerEvents="none"
+            >
+              {found ? (
+                <Animated.Text
+                  entering={ZoomIn.springify()}
+                  style={styles.foundText}
+                >
+                  ¡Lo tengo! 🎶
+                </Animated.Text>
+              ) : hint ? (
+                <Animated.Text
+                  key={hint}
+                  entering={FadeIn}
+                  exiting={FadeOut}
+                  style={styles.hintText}
+                >
+                  {hint}
+                </Animated.Text>
+              ) : (
+                <Animated.Text entering={FadeIn.delay(400)} style={styles.help}>
+                  Apunta al QR · se lee solo
+                </Animated.Text>
+              )}
+            </View>
+          </>
+        )}
+      </View>
+    </Modal>
+  );
+};
+
+/** Pantalla de "no hay permiso", con la salida a mano. */
+function PermissionDenied({ onClose }: { onClose: () => void }) {
+  return (
+    <View style={styles.center}>
+      <MaterialIcons name="no-photography" size={56} color="#8E8E93" />
+      <Text style={styles.deniedTitle}>Sin acceso a la cámara</Text>
+      <Text style={styles.deniedText}>
+        Dale permiso a MCM App en los ajustes del móvil para escanear los QR. Si
+        no, siempre puedes teclear el código de 4 dígitos.
+      </Text>
+      <TouchableOpacity onPress={onClose} style={styles.deniedBtn}>
+        <Text style={styles.deniedBtnText}>Escribir el código</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+export default QrScannerModal;

--- a/mcm-app/components/playlist/codeInputModalStyles.ts
+++ b/mcm-app/components/playlist/codeInputModalStyles.ts
@@ -1,0 +1,149 @@
+/**
+ * Estilos de `CodeInputModal`. Extraídos a su propio módulo al añadir el botón
+ * de escanear QR: con ellos dentro, el componente pasaba de las 400 líneas que
+ * marca la convención del proyecto.
+ */
+import { Platform, StyleSheet } from 'react-native';
+import { radii } from '@/constants/uiStyles';
+
+export const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    container: {
+      paddingBottom: 24,
+    },
+    description: {
+      fontSize: 14,
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      marginBottom: 18,
+      lineHeight: 20,
+    },
+    codeRow: {
+      position: 'relative',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 14,
+      marginTop: 6,
+    },
+    nameRow: {
+      marginBottom: 8,
+    },
+    inputLabel: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      marginBottom: 6,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    hiddenInput: {
+      position: 'absolute',
+      width: '100%',
+      height: 56,
+      opacity: 0.01,
+      color: 'transparent',
+      // En web, dejamos un caret invisible para no ver doble cursor.
+      ...(Platform.OS === 'web' ? ({ caretColor: 'transparent' } as any) : {}),
+      fontSize: 1,
+    },
+    cells: {
+      flexDirection: 'row',
+      gap: 10,
+    },
+    cell: {
+      width: 52,
+      height: 60,
+      borderRadius: radii.md,
+      borderWidth: 1.5,
+      borderColor: isDark ? '#48484A' : '#D1D1D6',
+      backgroundColor: isDark ? '#1C1C1E' : '#F8F8FA',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cellFilled: {
+      borderColor: isDark ? '#7AB3FF' : '#253883',
+    },
+    cellActive: {
+      borderColor: isDark ? '#7AB3FF' : '#253883',
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    cellText: {
+      fontSize: 26,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      fontVariant: ['tabular-nums'],
+    },
+    scanBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      paddingVertical: 12,
+      borderRadius: radii.md,
+      backgroundColor: isDark ? '#31AADF' : '#253883',
+      marginBottom: 14,
+    },
+    scanBtnText: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: '#FFFFFF',
+    },
+    suggestRow: {
+      flexDirection: 'row',
+      gap: 8,
+      marginBottom: 14,
+      justifyContent: 'center',
+    },
+    suggestBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingVertical: 8,
+      paddingHorizontal: 12,
+      borderRadius: radii.sm,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    suggestText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: isDark ? '#7AB3FF' : '#253883',
+    },
+    error: {
+      color: '#FF453A',
+      fontSize: 13,
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    buttons: {
+      flexDirection: 'row',
+      gap: 10,
+      justifyContent: 'flex-end',
+      marginTop: 4,
+    },
+    btn: {
+      paddingVertical: 11,
+      paddingHorizontal: 18,
+      borderRadius: 10,
+      minWidth: 110,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    btnSecondary: {
+      backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : '#F2F2F7',
+    },
+    btnSecondaryText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    btnPrimary: {
+      backgroundColor: '#253883',
+    },
+    btnPrimaryText: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: '#FFFFFF',
+    },
+    btnDisabled: {
+      opacity: 0.45,
+    },
+  });

--- a/mcm-app/components/playlist/qrScannerStyles.ts
+++ b/mcm-app/components/playlist/qrScannerStyles.ts
@@ -1,0 +1,151 @@
+/**
+ * Estilos de `QrScannerModal`. Van aparte porque el escáner ya tiene bastante
+ * lógica (permisos, antirrebote, animación de éxito) y la convención del
+ * proyecto es no dejar crecer los archivos por encima de las 400 líneas.
+ *
+ * El escáner es siempre oscuro, en las dos apariencias: la cámara ocupa toda la
+ * pantalla y un tema claro solo restaría contraste al marco.
+ */
+import { StyleSheet } from 'react-native';
+import { radii } from '@/constants/uiStyles';
+import { FRAME_SIZE } from './QrScanFrame';
+
+/** Penumbra que rodea el hueco de escaneo. */
+const DIM = 'rgba(0,0,0,0.62)';
+
+export const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    gap: 12,
+  },
+
+  // --- Penumbra en cuatro paneles (arriba / fila central / abajo) ----------
+  dimTop: {
+    flex: 1,
+    backgroundColor: DIM,
+  },
+  dimBottom: {
+    flex: 1,
+    backgroundColor: DIM,
+  },
+  dimRow: {
+    flexDirection: 'row',
+    height: FRAME_SIZE,
+  },
+  dimSide: {
+    flex: 1,
+    backgroundColor: DIM,
+  },
+  frameSlot: {
+    width: FRAME_SIZE,
+    height: FRAME_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // --- Éxito ---------------------------------------------------------------
+  check: {
+    position: 'absolute',
+    width: 76,
+    height: 76,
+    borderRadius: 38,
+    backgroundColor: '#A3BD31',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // --- Cabecera y pie ------------------------------------------------------
+  header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 18,
+    paddingBottom: 12,
+    gap: 12,
+  },
+  title: {
+    flex: 1,
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  closeBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.14)',
+  },
+  footer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    minHeight: 90,
+    justifyContent: 'flex-end',
+  },
+  help: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 14.5,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  hintText: {
+    color: '#FFD8D6',
+    fontSize: 14.5,
+    fontWeight: '700',
+    textAlign: 'center',
+    backgroundColor: 'rgba(255,69,58,0.35)',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: radii.pill,
+    overflow: 'hidden',
+  },
+  foundText: {
+    color: '#FFFFFF',
+    fontSize: 20,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+
+  // --- Permiso denegado ----------------------------------------------------
+  deniedTitle: {
+    color: '#F5F5F7',
+    fontSize: 18,
+    fontWeight: '700',
+    marginTop: 6,
+    textAlign: 'center',
+  },
+  deniedText: {
+    color: '#AEAEB2',
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+  deniedBtn: {
+    marginTop: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 22,
+    borderRadius: radii.md,
+    backgroundColor: '#253883',
+  },
+  deniedBtnText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/mcm-app/package-lock.json
+++ b/mcm-app/package-lock.json
@@ -22,6 +22,7 @@
         "expo-asset": "~57.0.8",
         "expo-blur": "~57.0.2",
         "expo-build-properties": "~57.0.8",
+        "expo-camera": "~57.0.3",
         "expo-clipboard": "~57.0.1",
         "expo-constants": "~57.0.8",
         "expo-dev-client": "~57.0.10",
@@ -7257,6 +7258,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -8810,6 +8817,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/barcode-detector": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.2.1.tgz",
+      "integrity": "sha512-zLL7AbT9uNJBUzYpKg9v5tUA4yQGReExSi60q0g660Mj0wjUhKmN0GrUF3qELo8ITW9THzyJXdZQkXLMnsieiw==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.1.1"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11344,6 +11360,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-57.0.3.tgz",
+      "integrity": "sha512-Q+3aZ63eQCkdB6/FZrO/lfacNAg/j8JCeKQL2nBdf6vBeOo1Y2PKYx1/vK+U5LaRnIo/0tMGmCOzZ1JGhTeMIw==",
+      "license": "MIT",
+      "dependencies": {
+        "barcode-detector": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-clipboard": {
@@ -20311,6 +20347,18 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -21889,6 +21937,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.1.tgz",
+      "integrity": "sha512-g0sPJBIubO6zLcJh1jftLPIN6xziaqLsvLgtpGKwDrEhyXXqla3E3yjFrznlr78UHIOMzbJPi0HDWKs/KgaB7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/mcm-app/package.json
+++ b/mcm-app/package.json
@@ -34,6 +34,7 @@
     "expo-asset": "~57.0.8",
     "expo-blur": "~57.0.2",
     "expo-build-properties": "~57.0.8",
+    "expo-camera": "~57.0.3",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.8",
     "expo-dev-client": "~57.0.10",

--- a/mcm-app/utils/qrScan.ts
+++ b/mcm-app/utils/qrScan.ts
@@ -1,0 +1,107 @@
+/**
+ * Lectura de los QR que la propia app genera (ver `ShareQrModal`).
+ *
+ * Hay tres formatos posibles y el escáner tiene que reconocerlos todos:
+ *
+ *   1. Playlist en la nube  → https://mcm.expo.app/playlist?p=1234
+ *   2. Sesión de coro       → https://mcm.expo.app/coro?c=1234
+ *   3. Playlist sin conexión → mcmapp://playlist?d=<payload>
+ *
+ * Además aceptamos que alguien escriba/pegue un QR con solo los 4 dígitos.
+ *
+ * NO usamos `URL`/`URLSearchParams`: la implementación de React Native es
+ * parcial (y en Hermes `searchParams` no existe), así que troceamos a mano.
+ * Todo esto es lógica pura y sin dependencias para poder testearla.
+ */
+import { isValidCode } from '@/utils/playlistCodes';
+
+/** A qué flujo apunta un QR escaneado. */
+export type QrTarget = 'playlist' | 'choir';
+
+export type QrScanResult =
+  /**
+   * QR con código corto: hay que descargar de Firebase. `target` es `null`
+   * cuando el QR traía solo los 4 dígitos, sin decir de qué flujo son: en ese
+   * caso vale para el que esté abierto.
+   */
+  | { kind: 'code'; target: QrTarget | null; code: string }
+  /** QR offline: la playlist entera viaja embebida en el payload. */
+  | { kind: 'offline'; payload: string };
+
+/** Trocea `a=1&b=2` en un mapa, con los valores ya decodificados. */
+function parseQuery(query: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const pair of query.split('&')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    if (eq < 0) continue;
+    const key = pair.slice(0, eq);
+    const raw = pair.slice(eq + 1);
+    if (!key || out[key] !== undefined) continue;
+    try {
+      out[key] = decodeURIComponent(raw.replace(/\+/g, ' '));
+    } catch {
+      // Un payload mal escapado es mejor pasarlo crudo que descartarlo.
+      out[key] = raw;
+    }
+  }
+  return out;
+}
+
+/**
+ * Interpreta el contenido de un QR. Devuelve `null` si no es nuestro (una
+ * tarjeta de contacto, una wifi, la URL de un vídeo…), para que el escáner
+ * pueda seguir buscando sin molestar al usuario.
+ */
+export function parseScannedQr(raw: string): QrScanResult | null {
+  const text = (raw ?? '').trim();
+  if (!text) return null;
+
+  // 1. Solo el código, sin URL alrededor.
+  if (isValidCode(text)) return { kind: 'code', target: null, code: text };
+
+  const qIndex = text.indexOf('?');
+  if (qIndex < 0) return null;
+
+  const path = text.slice(0, qIndex).toLowerCase();
+  const params = parseQuery(text.slice(qIndex + 1));
+
+  // El path nos dice de qué flujo es el QR. Sin esto, cualquier enlace con un
+  // `?p=1234` suelto se colaría como playlist.
+  const isPlaylist = /(^|\/)playlist\/?$/.test(path);
+  const isChoir = /(^|\/)coro\/?$/.test(path);
+  if (!isPlaylist && !isChoir) return null;
+
+  // 2. Playlist offline: el payload manda sobre el código.
+  if (isPlaylist && params.d) return { kind: 'offline', payload: params.d };
+
+  // 3. Código corto. `code` es el alias que aceptan las dos pantallas puente.
+  const code = isChoir ? (params.c ?? params.code) : (params.p ?? params.code);
+  if (code && isValidCode(code)) {
+    return { kind: 'code', target: isChoir ? 'choir' : 'playlist', code };
+  }
+
+  return null;
+}
+
+/**
+ * ¿Sirve este QR para el flujo que el usuario tiene abierto?
+ *
+ * Un QR de coro escaneado desde "importar playlist" (o al revés) no es un
+ * error de lectura: es que han enseñado el papel equivocado. Devolvemos el
+ * aviso ya redactado para poder enseñarlo sin cerrar la cámara.
+ */
+export function describeMismatch(
+  result: QrScanResult,
+  expected: QrTarget,
+): string | null {
+  if (result.kind === 'offline') {
+    return expected === 'playlist'
+      ? null
+      : 'Ese QR es una playlist, no una sesión de coro';
+  }
+  if (result.target === null || result.target === expected) return null;
+  return result.target === 'choir'
+    ? 'Ese QR es de una sesión de coro, no de una playlist'
+    : 'Ese QR es de una playlist, no de una sesión de coro';
+}


### PR DESCRIPTION
Los QR que ya genera la app (`ShareQrModal`) solo se podían leer con la cámara del sistema. Ahora se escanean **desde dentro**, en los dos diálogos donde se teclea un código: *Importar playlist con código* y *Unirse al coro*.

## ⚠️ Esto NO puede ir por OTA

`expo-camera` es un módulo **nativo**: no existe en el binario que la gente tiene instalado. Necesita **build de tienda**. El commit lleva `[skip-ota]` para que el guard de `ota-production.yml` no falle en rojo y no se publique la OTA.

Como red de seguridad, el módulo se carga con `require` dentro de un `try/catch`: si una OTA llegase a un binario antiguo, el botón de escanear **simplemente no aparece** en lugar de reventar la pantalla.

> **Sobre la rama destino:** pediste "si no es OTA, solo a producción". Va a `main` a propósito, no a `production` — ver la nota al final.

## Qué hace

- **Botón "Escanear QR"** en `CodeInputModal`, solo en las variantes en las que el usuario *teclea* un código que le han dado (`cloud-download` y `choir-join`). En las que lo genera él (subir, iniciar coro, cambiar código) no hay nada que escanear.
- **Al leerlo se rellena y se envía solo**, sin toques extra: la gracia de escanear es no tener que confirmar nada.
- **Lee los tres formatos** que produce la app:
  - playlist en la nube — `https://mcm.expo.app/playlist?p=1234`
  - sesión de coro — `https://mcm.expo.app/coro?c=1234`
  - playlist **sin conexión** — `mcmapp://playlist?d=<payload>`, con las canciones embebidas; se resuelve contra el catálogo cacheado igual que el deep link
  - y también un QR con solo los 4 dígitos
- **Si el QR es del otro flujo** (enseñas el del coro en "importar playlist") no se cierra la cámara: sale un aviso y se sigue escaneando. Lo mismo con un QR ajeno (una wifi, un vídeo): se ignora en silencio.
- **Sin escáner en web**: ahí `expo-camera` depende del navegador y el enlace del QR se puede pinchar directamente.

## Las animaciones

- Al abrir, el marco **se dibuja esquina a esquina** (muelle escalonado) y el hueco entra creciendo.
- Mientras busca, un **láser** con degradado barre el hueco de arriba abajo, sin parar.
- Al encontrarlo: **fogonazo verde**, el marco da un golpe de escala, **check** que entra con muelle, **confeti** (`CelebrationBurst`, el mismo de Reflexiones y Contigo) y **háptica de éxito** — antes de continuar.

Todo en Reanimated (hilo de UI), así que el barrido no se entrecorta mientras JS decodifica fotogramas.

## Detalles de implementación

- **`utils/qrScan.ts`** — parser puro y sin dependencias (11 tests). No usa `URL`/`URLSearchParams`: la implementación de React Native es parcial y en Hermes `searchParams` no existe.
- **Handshake entre modales** — el paso de la hoja a la cámara y la vuelta pasan por `onCloseComplete` / `onDismiss`. iOS rechaza **en silencio** un Modal que se presenta en el mismo ciclo de render en que otro se cierra (ya estaba documentado en `BottomSheet.tsx`).
- **Antirrebote** — una vez encontrado el código se dejan de mirar fotogramas, y los avisos tienen enfriamiento para que no parpadeen.
- **Si cierran la cámara** durante la celebración, el código leído se descarta: no se importa una playlist que acaban de cancelar.
- Estilos de `CodeInputModal` extraídos a `codeInputModalStyles.ts` para no pasar del límite de 400 líneas.

## Archivos

| Archivo | Qué |
| --- | --- |
| `utils/qrScan.ts` | Parser de los tres formatos + aviso de flujo equivocado |
| `__tests__/qrScan.test.ts` | 11 tests del parser |
| `components/playlist/QrScannerModal.tsx` | Cámara, permisos, estados, celebración |
| `components/playlist/QrScanFrame.tsx` | Marco animado + láser + fogonazo |
| `components/playlist/qrScannerStyles.ts` | Estilos del escáner |
| `components/playlist/CodeInputModal.tsx` | Botón "Escanear QR" + handshake |
| `components/playlist/codeInputModalStyles.ts` | Estilos extraídos |
| `app/screens/SelectedSongsScreen.tsx` | Resuelve el QR offline escaneado |
| `app.json` · `package.json` | `expo-camera` + texto del permiso de cámara |

## Verificación

- `npx tsc --noEmit` — limpio
- `npm run lint` — 0 errores, 88 avisos (**exactamente los mismos que en `main`**, ninguno nuevo)
- `npm test` — 52 suites, 478 tests, todos en verde

No se ha podido probar en dispositivo desde aquí: la cámara necesita build nativa.

## Por qué a `main` y no a `production`

`production` está en **Expo SDK 55** (app 2.0.0) y `main` en **SDK 57** (app 2.1.0) — está esperando la build de tienda que documenta `docs/desarrollo/BUILD_AGOSTO_2026.md`, cuyo orden explícito es *"build primero, `production` después"*.

Eso hace que `production` sea hoy el destino equivocado para este cambio:

1. Habría que fijar `expo-camera` a `~55.x`, no a la `~57.0.3` que necesita este código.
2. `production` alimenta las OTAs del binario SDK 55 que hay instalado, donde un módulo nativo nuevo **nunca puede activarse**.
3. Cuando `production` reciba el SDK 57 tras la build, ese `expo-camera@55` sería un conflicto más que resolver.

Como este cambio necesita build de tienda igualmente, lo natural es que viaje con la del SDK 57. **Si aun así lo quieres en `production` ya, dilo y abro el backport** (`-prod` a partir de `origin/production`, con `expo-camera@~55.x` y los conflictos de `CodeInputModal` resueltos contra la versión antigua del archivo).

---
_Generated by [Claude Code](https://claude.ai/code/session_0126gqFNjxHmFAmdWM1A3Qex)_