### PR TITLE
Arregla `expo export --platform web`: la barra de pestañas nativa entraba en el bundle de web

### DIFF
--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -29,26 +29,21 @@ Es lo que desbloquea el resto: la rama `claude/compact-tabs-bar-uxxaoz` lleva
 SDK 57, barra flotante, Reanimated 4, NSE de iOS, Sentry, analítica, icono de
 Carismochito y subrayado nativo. Todo NATIVO, nada sale por OTA.
 
-### 1-bis. `expo export --platform web` está ROTO (bloquea el deploy web)
+### 1-bis. `expo export --platform web` — ✅ ARREGLADO (2026-08-08)
 
-- [ ] **`npx expo export --platform web` falla** con
-      `The method or property expo-modules-core.requireNativeViewManager is not
-      available on web`. Es el **renderizado estático** (activado en la config)
-      intentando cargar `app/(tabs)/_layout.tsx` en un entorno Node, donde los
-      módulos nativos nuevos (`expo-native-compact-tabs`,
-      `modules/highlight-menu`) no existen. La exportación no genera ni
-      `index.html` ni el bundle: solo `manifest.json`, `sw.js` e iconos.
-- **Por qué importa ahora**: `.github/workflows/deploy-web.yml` ejecuta ese
-      comando en cada push a `production`. Cuando lo nativo llegue a
-      `production`, **el deploy web deja de funcionar**.
-- **Comprobado el 2026-08-07**: falla igual en el commit base `7682615`, así que
-      NO lo introduce ningún cambio reciente de código de app — viene con los
-      módulos nativos de la build de agosto. El bundle del grafo de la app sí se
-      construye; lo que revienta es el paso de render estático.
-- Caminos posibles (a decidir): desactivar el static rendering para web, dar un
-      shim `.web.ts` a los módulos nativos que se cargan desde el layout de tabs,
-      o mover su import a un punto que el SSG no toque. Verificar con
-      `npx expo export --platform web` en local antes de publicar.
+Fallaba con `The method or property expo-modules-core.requireNativeViewManager
+is not available on web` y no generaba ni `index.html` ni el bundle. La causa no
+era el renderizado estático en sí: `app/(tabs)/_layout.tsx` importaba
+**estáticamente** los tres layouts de pestañas, así que el grafo de módulos de
+web llegaba a `expo-native-compact-tabs` — que llama a
+`requireNativeViewManager()` al cargarse y no trae shim web. Con importarlo
+bastaba, aunque la rama de `Platform.OS` no llegara a ejecutarse nunca.
+
+Arreglado con resolución por plataforma (`components/tabs/PlatformTabsLayout.tsx`
++ `.web.tsx`), que es la convención que ya usa el repo: en web Metro empaqueta el
+shim y el paquete nativo no entra en el bundle. Candado en
+`__tests__/tabsLayoutWebSafety.test.ts` para que un `import` directo no lo vuelva
+a romper — el fallo solo se vería al desplegar.
 
 ### 2. React Compiler — lo que SÍ merece la pena
 

--- a/mcm-app/__tests__/tabsLayoutWebSafety.test.ts
+++ b/mcm-app/__tests__/tabsLayoutWebSafety.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Candado: el layout de pestañas no puede importar lo NATIVO directamente.
+ *
+ * `expo-native-compact-tabs` llama a `requireNativeViewManager()` a nivel de
+ * módulo y no trae shim web, así que basta con que el grafo de módulos de web
+ * lo alcance —aunque sea desde una rama de `Platform.OS` que nunca se ejecuta—
+ * para que reviente con «requireNativeViewManager is not available on web».
+ *
+ * Eso es lo que tumbaba `npx expo export --platform web`: el renderizado
+ * estático evalúa `app/(tabs)/_layout.tsx` en Node, sin módulos nativos, y la
+ * exportación entera moría sin generar ni `index.html` ni el bundle. Como
+ * `deploy-web.yml` corre ese comando en cada push a `production`, el síntoma
+ * era un deploy web roto.
+ *
+ * La rama por plataforma la resuelve Metro por sufijo de fichero
+ * (`PlatformTabsLayout.web.tsx`). Este test comprueba que sigue siendo así: un
+ * `import` directo de los layouts nativos desde el layout compartido volvería a
+ * romperlo, y el fallo solo se vería al desplegar.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const read = (rel: string) =>
+  fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+
+describe('el layout de pestañas es seguro para web', () => {
+  it('`(tabs)/_layout.tsx` no importa los layouts nativos', () => {
+    const layout = read('app/(tabs)/_layout.tsx');
+
+    expect(layout).not.toMatch(/from '@\/components\/tabs\/IOSTabsLayout'/);
+    expect(layout).not.toMatch(/from '@\/components\/tabs\/AndroidTabsLayout'/);
+    expect(layout).toMatch(/from '@\/components\/tabs\/PlatformTabsLayout'/);
+  });
+
+  it('existe el shim web y NO arrastra la barra nativa', () => {
+    const web = read('components/tabs/PlatformTabsLayout.web.tsx');
+
+    expect(web).toMatch(/WebTabsLayout/);
+    expect(web).not.toMatch(/IOSTabsLayout|AndroidTabsLayout/);
+  });
+
+  it('la versión nativa sí monta la barra flotante', () => {
+    const native = read('components/tabs/PlatformTabsLayout.tsx');
+
+    expect(native).toMatch(/IOSTabsLayout/);
+    expect(native).toMatch(/AndroidTabsLayout/);
+  });
+
+  it('solo la rama nativa IMPORTA expo-native-compact-tabs', () => {
+    // Quien importa el paquete es CompactTabBar, y a él solo se llega desde los
+    // dos layouts nativos. Si apareciera un `import` en un fichero compartido,
+    // el bundle de web volvería a incluirlo. Se busca el IMPORT, no la mención:
+    // los comentarios de estos ficheros nombran el paquete a propósito.
+    const IMPORT_RE =
+      /^\s*(?:import|export)[^;]*from\s+'expo-native-compact-tabs'/m;
+
+    const compartidos = [
+      'app/(tabs)/_layout.tsx',
+      'components/tabs/PlatformTabsLayout.web.tsx',
+      'components/tabs/WebTabsLayout.tsx',
+      'components/tabs/useTabScroll.ts',
+      'components/tabs/tabBarController.ts',
+    ];
+
+    const conImport = compartidos.filter((rel) => IMPORT_RE.test(read(rel)));
+    expect(conImport).toEqual([]);
+
+    // Y el sitio donde SÍ vive el import sigue siendo ese, para que este test
+    // no se quede verde por haberse movido el paquete a otra parte.
+    expect(read('components/tabs/CompactTabBar.tsx')).toMatch(IMPORT_RE);
+  });
+});

--- a/mcm-app/app/(tabs)/_layout.tsx
+++ b/mcm-app/app/(tabs)/_layout.tsx
@@ -5,20 +5,22 @@
 //     que al compactarse mantiene todos los iconos visibles.
 //   - Web           → barra clásica de expo-router, sin cambios.
 //
+// La rama la resuelve METRO por sufijo de fichero (`PlatformTabsLayout.web.tsx`),
+// no un `if` aquí: importar los layouts nativos desde web arrastraba
+// `expo-native-compact-tabs`, que llama a `requireNativeViewManager()` al
+// cargarse, y eso tumbaba `expo export --platform web` entero.
+//
 // La metadata de cada tab vive en `constants/tabsCatalog.ts` (TABS_CONFIG
 // define el ORDEN de la barra) y qué tabs se ven lo decide
 // `hooks/useVisibleTabs.ts` a partir del perfil.
 
 import React from 'react';
-import { Platform } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useVisibleTabs } from '@/hooks/useVisibleTabs';
 import { splitTabsForBar } from '@/constants/tabsCatalog';
-import IOSTabsLayout from '@/components/tabs/IOSTabsLayout';
-import AndroidTabsLayout from '@/components/tabs/AndroidTabsLayout';
-import WebTabsLayout from '@/components/tabs/WebTabsLayout';
+import PlatformTabsLayout from '@/components/tabs/PlatformTabsLayout';
 
 export default function TabsLayout() {
   const scheme = useColorScheme();
@@ -27,13 +29,7 @@ export default function TabsLayout() {
 
   return (
     <>
-      {Platform.OS === 'web' ? (
-        <WebTabsLayout />
-      ) : Platform.OS === 'ios' ? (
-        <IOSTabsLayout barTabs={mainTabs} />
-      ) : (
-        <AndroidTabsLayout barTabs={mainTabs} />
-      )}
+      <PlatformTabsLayout barTabs={mainTabs} />
       <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
     </>
   );

--- a/mcm-app/components/tabs/PlatformTabsLayout.tsx
+++ b/mcm-app/components/tabs/PlatformTabsLayout.tsx
@@ -1,0 +1,32 @@
+// Layout de pestañas para iOS y Android: barra flotante nativa.
+//
+// Este fichero existe para que el grafo de módulos de WEB no llegue nunca a
+// `expo-native-compact-tabs`. Ese paquete llama a `requireNativeViewManager()`
+// a nivel de módulo y no trae shim web, así que basta con IMPORTARLO —aunque
+// sea en una rama de `Platform.OS` que nunca se ejecuta— para que reviente con
+// «requireNativeViewManager is not available on web». Y reventaba: el
+// renderizado estático de `expo export --platform web` evalúa
+// `app/(tabs)/_layout.tsx` en Node, donde no hay módulos nativos, y ahí moría
+// la exportación entera.
+//
+// La rama por plataforma la resuelve ahora Metro con el sufijo `.web.tsx`
+// (misma convención que el resto del repo), no un `if` en tiempo de ejecución:
+// en web se empaqueta `PlatformTabsLayout.web.tsx` y estos imports no existen.
+import React from 'react';
+import { Platform } from 'react-native';
+
+import IOSTabsLayout from '@/components/tabs/IOSTabsLayout';
+import AndroidTabsLayout from '@/components/tabs/AndroidTabsLayout';
+import type { TabConfig } from '@/constants/tabsCatalog';
+
+export default function PlatformTabsLayout({
+  barTabs,
+}: {
+  barTabs: TabConfig[];
+}) {
+  return Platform.OS === 'ios' ? (
+    <IOSTabsLayout barTabs={barTabs} />
+  ) : (
+    <AndroidTabsLayout barTabs={barTabs} />
+  );
+}

--- a/mcm-app/components/tabs/PlatformTabsLayout.web.tsx
+++ b/mcm-app/components/tabs/PlatformTabsLayout.web.tsx
@@ -1,0 +1,18 @@
+// Layout de pestañas en WEB: la barra clásica de expo-router.
+//
+// Metro resuelve este fichero (sufijo `.web.tsx`) en lugar de
+// `PlatformTabsLayout.tsx`, así que el bundle de web NO contiene los layouts
+// nativos y, con ellos, tampoco `expo-native-compact-tabs` — que llama a
+// `requireNativeViewManager()` al cargarse y no tiene equivalente en web.
+//
+// `barTabs` se acepta y se ignora a propósito: mantiene la misma firma que la
+// versión nativa para que `app/(tabs)/_layout.tsx` no tenga que saber en qué
+// plataforma está.
+import React from 'react';
+
+import WebTabsLayout from '@/components/tabs/WebTabsLayout';
+import type { TabConfig } from '@/constants/tabsCatalog';
+
+export default function PlatformTabsLayout(_props: { barTabs: TabConfig[] }) {
+  return <WebTabsLayout />;
+}


### PR DESCRIPTION
`npx expo export --platform web` fallaba con `The method or property expo-modules-core.requireNativeViewManager is not available on web` y **no generaba ni `index.html` ni el bundle** — solo `manifest.json`, `sw.js` e iconos. Como `deploy-web.yml` corre ese comando en cada push a `production`, el deploy web quedaba roto en cuanto lo nativo llegara allí.

## La causa no era la que parecía

Lo había diagnosticado como «el renderizado estático carga los módulos nativos en Node», y eso es el síntoma, no la causa. Al abrir el código:

`app/(tabs)/_layout.tsx` importaba **estáticamente los tres** layouts de pestañas y elegía con un `if (Platform.OS === …)` en tiempo de ejecución. Pero un `import` estático entra en el grafo de módulos **aunque su rama no se ejecute nunca**, y `expo-native-compact-tabs` llama a `requireNativeViewManager()` **a nivel de módulo** (`src/index.tsx:56`) y no trae shim web. Con importarlo bastaba para reventar.

```
app/(tabs)/_layout.tsx
  └─ IOSTabsLayout / AndroidTabsLayout
       └─ components/tabs/CompactTabBar.tsx
            └─ expo-native-compact-tabs  ← requireNativeViewManager() al cargarse
```

Por eso desactivar el static rendering habría tapado el aviso sin arreglar nada: el paquete nativo seguiría en el bundle de web.

## El arreglo

Resolución por plataforma con sufijo de fichero — la convención que **ya usa el repo** (`.ios.tsx`, `.web.ts`) — en vez de un `if` en tiempo de ejecución:

- `components/tabs/PlatformTabsLayout.tsx` → rama nativa (iOS / Android)
- `components/tabs/PlatformTabsLayout.web.tsx` → `WebTabsLayout`

`_layout.tsx` importa solo `PlatformTabsLayout`, así que en web Metro empaqueta el shim y **el paquete nativo no entra en el bundle**.

## Verificación

- **`npx expo export --platform web` termina en exit 0**, con `index.html`, el bundle y las ~40 rutas (14 MB de salida).
- **`ExpoNativeCompactTabsView` no aparece en el output** — comprobado con grep sobre `_expo/`, no solo por que el comando no falle.
- 456 tests en verde (los 5 de `CompactTabBar` incluidos); `typecheck`, `typecheck:tests` y `lint` sin errores y 87 warnings, igual que `main`.

## El candado

`__tests__/tabsLayoutWebSafety.test.ts`. Este bug solo se veía **al desplegar**, así que sin guard vuelve solo en cuanto alguien añada un import "inofensivo". El test comprueba el **`import`, no la mención** (los comentarios de esos ficheros nombran el paquete a propósito) y verifica que el import sigue viviendo donde debe, para no quedarse verde si el paquete se mueve. Comprobado que **falla si se revierte** el layout.

Cerrado el ítem §1-bis de `mcm-app/TODO.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AKuVrR584Dn1SwrjUiRVD)_