### PR TITLE
Tab navigation: exhaustive test coverage + fix for unreachable "Más"

### DIFF
--- a/docs/desarrollo/BUILD_AGOSTO_2026.md
+++ b/docs/desarrollo/BUILD_AGOSTO_2026.md
@@ -196,6 +196,22 @@ Y que el módulo local del subrayado se autolinka:
 npx expo-modules-autolinking search -p apple --json | grep highlight-menu
 ```
 
+> ⚠️ **Ojo: que autolinke AQUÍ no basta.** Lo anterior mira tu carpeta local; lo
+> que compila EAS es lo que le SUBE, y eso lo decide `.easignore` — que cuando
+> existe **sustituye** a `.gitignore`. Tuvo el mismo agujero que tuvo el
+> `.gitignore` (reglas `ios/` y `android/` sin barra inicial, que casan a
+> cualquier profundidad) y se llevaba por delante
+> `modules/highlight-menu/{ios,android}`: el módulo subía con su
+> `expo-module.config.json` y su JS pero SIN Swift ni Kotlin, autolinking lo
+> saltaba en silencio y la app salía sin el ítem "Subrayar" del menú del sistema.
+> Comprobación de que no ha vuelto (no debe imprimir nada):
+>
+> ```bash
+> git -c core.excludesFile=.easignore check-ignore -v --no-index \
+>   modules/highlight-menu/ios/HighlightMenuView.swift \
+>   modules/highlight-menu/android/build.gradle
+> ```
+
 Lo mismo para Android (**necesita `google-services.json` en `mcm-app/`**, que
 está gitignoreado — cógelo de la consola de Firebase si no lo tienes):
 

--- a/docs/desarrollo/TABS_MAINTENANCE.md
+++ b/docs/desarrollo/TABS_MAINTENANCE.md
@@ -89,6 +89,27 @@ impuesto por `UITabBarController`; con barra propia es una decisión de diseño 
 se aplica igual en iOS y Android. Los que no caben se muestran como tarjetas en
 `MasHomeScreen` vía `splitTabsForBar`. En web se ven todos.
 
+#### ⚠️ En iOS, un tab de overflow NO TIENE RUTA
+
+`IOSTabsLayout` crea un `NativeTabs.Trigger` **solo por cada tab de la barra**,
+así que para los de overflow `router.push('/calendario')` no falla: no hace
+nada. En Android y web están registrados TODOS los tabs visibles del perfil
+(solo la barra está recortada), y allí el push directo siempre vale.
+
+Y **qué tabs caben depende del perfil y de si hay un evento en curso**, así que
+no se puede decidir el camino con un `Platform.OS === 'ios'` ni con un `href`
+fijo: es justo lo que hacía que los botones de la Home llevaran al tab
+equivocado —o a ninguno— según el día. **Para navegar a un tab desde cualquier
+sitio, usa `hooks/useTabNavigation.ts` (`goToTab`)**, que pregunta si el tab está
+de verdad en la barra y, si no, entra por su pantalla espejo del stack de "Más".
+
+El mapa de espejos vive en `utils/tabNavigation.ts` (`MAS_STACK_MIRROR`) y es
+**fuente única**: lo usan tanto `goToTab` como las tarjetas de overflow de
+`MasHomeScreen`. Si añades un tab que pueda quedar en overflow (o reordenas
+`TABS_CONFIG` y cambias quién se queda fuera), **regístrale su pantalla espejo en
+`mas.tsx` y su entrada en `MAS_STACK_MIRROR`** — si no, en iOS será inalcanzable.
+Cubierto por `__tests__/tabNavigation.test.ts`.
+
 ### La barra FLOTA: hay que reservarle hueco
 
 No ocupa layout en iOS ni en Android, así que cada pantalla de tab tiene que

--- a/docs/funcionalidades/SUBRAYADO.md
+++ b/docs/funcionalidades/SUBRAYADO.md
@@ -85,10 +85,44 @@ pasa a `HighlightActionBar`.
 
 Está cubierto por tests en `__tests__/highlightRanges.test.ts`.
 
+## Seleccionar primero, tocar el lápiz después
+
+El botón de subrayar de la cabecera **usa la selección que ya hubiera hecha**.
+Para eso `HighlightableReading` reporta `onSelectionChange` SIEMPRE que el texto
+sea un `TextInput` (en iOS, leyendo y subrayando), no solo dentro del modo lápiz:
+si solo escuchara dentro del modo, la selección que había era invisible para JS y
+la barra salía pidiendo "selecciona un texto" hasta que movías las asas un pelo.
+
+La selección es "pegajosa" (`useReadingHighlights`): se conserva la última no
+vacía. Hace falta por dos motivos —iOS colapsa la selección nativa antes de que
+llegue el `onPress` del chip de color, y el propio toque en el botón del lápiz
+puede deshacerla—. Quien la limpia de verdad es `exitHighlightMode` (al salir del
+modo, al cambiar de día o al elegir otra fecha).
+
+**En Android este camino no existe**: leyendo, el texto es un `Text selectable`
+y un `Text` no reporta offsets. El atajo bueno en Android es el ítem "Subrayar"
+del propio menú de selección.
+
 ## "Subrayar" en el menú nativo del sistema
 
 > Implementado el 2026-08-03 (build de tienda de agosto). **Requiere binario
 > nuevo**: no sale por OTA.
+>
+> ⚠️ **Nunca ha llegado a un binario todavía.** El código estaba, pero
+> `.easignore` —que cuando existe SUSTITUYE a `.gitignore` para decidir qué sube
+> a EAS— conservaba las reglas `ios/` y `android/` sin barra inicial, que casan a
+> cualquier profundidad y se llevaban por delante
+> `modules/highlight-menu/{ios,android}`. El módulo subía con su
+> `expo-module.config.json` y su JS pero sin Swift, sin Kotlin, sin podspec ni
+> `build.gradle`: autolinking lo saltaba en silencio y la app se construía sin el
+> ítem. Arreglado el 2026-08-08; la comprobación de que no vuelve está en
+> `docs/desarrollo/BUILD_AGOSTO_2026.md` §3.
+>
+> Mientras el binario no lo lleve, `HighlightMenuView` detecta que el módulo no
+> está (`requireOptionalNativeModule`) y renderiza un `View` pelado. Antes
+> montaba la vista nativa inexistente, que React Native sustituye por su
+> placeholder de "componente sin implementar" — y como esta vista ENVUELVE el
+> texto de la lectura, eso se llevaba por delante el render del texto.
 
 Al seleccionar texto en cualquier lectura, el menú del sistema trae un ítem
 **"Subrayar"** junto a Copiar / Traducir / Buscar / Herramientas de escritura.
@@ -127,6 +161,14 @@ propia se antepone con `replacingChildren`.
 **Offsets**: el `NSRange` de iOS y el `selectionStart/End` de Android van en
 unidades UTF-16, que es exactamente cómo indexa JavaScript las cadenas. Los
 offsets casan con el texto canónico sin convertir nada.
+
+**Reenganche**: las dos plataformas reintentan el enganche en cada layout, y no
+solo la primera vez. React Native se reasigna el delegate (iOS) / el
+`customSelectionActionModeCallback` (Android) al recrear o reconfigurar el
+texto, así que con un enganche único el ítem desaparecía en cuanto el texto se
+volvía a montar —cambio de día, de tamaño de letra, de modo— y no volvía hasta
+reiniciar. `attachIfNeeded` compara con lo que hay puesto y nunca encadena dos
+proxies nuestros.
 
 ### Lo que NO cambió
 

--- a/docs/planes/PLAN_CALIDAD.md
+++ b/docs/planes/PLAN_CALIDAD.md
@@ -52,19 +52,29 @@ Objetivo: que el problema deje de crecer mientras se arregla el resto.
 - [x] **0.1 — ESLint como muro** (`mcm-app/eslint.config.js`): _hecho 2026-06-28._
   - [x] `'prettier/prettier': 'error'`.
   - [x] `'no-console': 'error'` — con override solo para `utils/logger.ts` (la migración de `console.*` está completa, 0 en el código).
-  - [x] `'max-lines': ['warn', { max: 400, skipBlankLines: true, skipComments: true }]` — `warn` a propósito (señala 13 gigantes + archivos nuevos sin bloquear los legacy en CI). Cuando la Fase 1 termine, subir a `error` con `max: 800`.
+  - [x] `'max-lines': ['warn', { max: 1000, skipBlankLines: true, skipComments: true }]` — **umbral subido de 400 a 1000 el 2026-08-08** por decisión del usuario: con agentes de IA leyendo el código, un archivo largo pero coherente cuesta menos que la misma lógica repartida en seis ficheros que hay que reconstruir mentalmente. Sigue en `warn`. **Los gigantes que ya hay SE QUEDAN**: la Fase 1 deja de ser trabajo pendiente por tamaño (sí sigue valiendo trocear cuando el motivo sea otro — acoplamiento, reutilización, un módulo que se toca a la vez desde varios sitios).
   - [ ] `'@typescript-eslint/no-explicit-any': 'warn'` → pendiente: hay 66 `: any` en archivos grandes; con `lint-staged --max-warnings=0` activar el `warn` bloquearía cualquier commit que toque esos archivos. Activar al limpiarlos (Fase 4.1) o, si se quiere ya, hacerlo a la vez que se eliminan.
 - [x] **0.2 — Logger central** (`mcm-app/utils/logger.ts`): _hecho._ Niveles `debug/info/log/warn/error`; `debug`/`info`/`log` silenciados en producción (gate por `__DEV__`); enganche `setReporter` listo para Sentry (Fase 6). **Migración completada: 0 `console.*` en el código** (test en `__tests__/logger.test.ts`).
 - [x] **0.3 — `lint-staged` con ESLint** (raíz `package.json`): _hecho._ Corre `prettier --write` + `eslint --max-warnings=0 --fix` para `mcm-app/**/*.{js,jsx,ts,tsx}`. `.husky/pre-commit` (`npx lint-staged`) restaurado.
-- [ ] **0.4 — Regla escrita en `mcm-app/CLAUDE.md`**: _hecho 2026-06-28_ (sección «Convenciones de código»): «Ningún archivo nuevo > 400 líneas; si una pantalla supera 600, extraer componentes/hooks ANTES de añadir la feature.»
+- [ ] **0.4 — Regla escrita en `mcm-app/CLAUDE.md`**: _hecho 2026-06-28, actualizado 2026-08-08_ (sección «Convenciones de código»): techo de 1.000 líneas; a partir de 1.500 trocear de verdad antes de añadir la feature.
 
 **Criterio de salida:** ✅ lint en CI bloquea formato y `console.*`; CI corre `typecheck` + `typecheck:tests` + `lint` + `test` en PRs; regla anti-gigantes documentada. Pendiente solo el `no-explicit-any: warn` (atado a Fase 4.1).
 
 ---
 
-## Fase 1 — Descuartizar los 9 gigantes (~2-3 semanas · 1-2 archivos por PR)
+## Fase 1 — Descuartizar los 9 gigantes ⏸️ CERRADA POR DECISIÓN (2026-08-08)
 
-Objetivo: ninguna pantalla > 800 líneas; cada pantalla = composición de componentes + un hook de lógica.
+> **Los gigantes se quedan.** Decisión del usuario: con agentes de IA leyendo y
+> editando el código, un archivo largo pero coherente cuesta menos que la misma
+> lógica repartida en seis ficheros que hay que reconstruir mentalmente. El
+> umbral de `max-lines` pasó a 1.000 (avisar) / 1.500 (trocear de verdad).
+>
+> Lo que sigue valiendo de esta fase: trocear cuando el motivo **no** sea el
+> tamaño — acoplamiento, código que se reutiliza desde varios sitios, o lógica
+> pura que gana un test propio al salir del componente. Lo ya hecho (estilos y
+> subcomponentes extraídos) se queda como está.
+
+Objetivo original: ninguna pantalla > 800 líneas; cada pantalla = composición de componentes + un hook de lógica.
 
 **Patrón por archivo** (igual en todos, sin cambiar comportamiento):
 

--- a/mcm-app/.easignore
+++ b/mcm-app/.easignore
@@ -48,12 +48,20 @@ GoogleService-Info.plist
 firebase.json
 
 # prebuilds (CNG/Prebuild generated folders)
+#
+# OJO: SOLO con barra inicial (el mismo agujero que tuvo `.gitignore`, ver el
+# comentario allí). Sin ancla, `ios/` y `android/` casan con CUALQUIER carpeta
+# con ese nombre a cualquier profundidad, así que se llevaban por delante el
+# código nativo de `modules/highlight-menu/{ios,android}`: el módulo subía a EAS
+# con su `expo-module.config.json` y su JS pero SIN Swift, sin Kotlin, sin
+# podspec ni build.gradle. Autolinking lo saltaba en silencio y la app se
+# construía sin el ítem "Subrayar" del menú del sistema.
+#
+# `.easignore`, cuando existe, SUSTITUYE a `.gitignore` para decidir qué sube a
+# EAS: arreglarlo allí no arregla esto. Estas dos carpetas solo existen en la
+# raíz de `mcm-app/`, así que con la barra inicial basta.
 /android/
 /ios/
-android/
-ios/
-android/**
-ios/**
 
 # builds
 *.apk

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,97 @@
 
 ---
 
+## 2026-08-08 18:15 — Cuatro cosas pedidas que seguían sin estar `[skip-ota]`
+
+### El ítem "Subrayar" del menú nativo NUNCA llegó a un binario (causa raíz)
+
+El código estaba desde el 3 de agosto, pero **`.easignore` se comía las fuentes
+nativas del módulo**. Es el mismo agujero que se arregló en `.gitignore` el 3 de
+agosto (`a280e9d`) y que allí se quedó: reglas `ios/` y `android/` **sin barra
+inicial**, que casan con cualquier carpeta con ese nombre a cualquier
+profundidad. Y `.easignore`, cuando existe, **sustituye** a `.gitignore` para
+decidir qué sube a EAS, así que arreglarlo allí no arreglaba esto.
+
+Resultado: `modules/highlight-menu/` subía con su `expo-module.config.json` y su
+JS pero **sin Swift, sin Kotlin, sin podspec ni `build.gradle`**. Autolinking lo
+saltaba en silencio y todas las builds salieron sin el ítem del menú.
+Comprobación de que no vuelve (no debe imprimir nada), añadida a
+`docs/desarrollo/BUILD_AGOSTO_2026.md` §3:
+
+```bash
+git -c core.excludesFile=.easignore check-ignore -v --no-index \
+  modules/highlight-menu/ios/HighlightMenuView.swift \
+  modules/highlight-menu/android/build.gradle
+```
+
+Encima, tres cosas más del módulo:
+
+- **Degradación limpia si el módulo no está en el binario.**
+  `requireNativeView` NO lanza cuando falta: devuelve un componente cuyo nombre
+  de vista nativa no existe y React Native lo sustituye por su placeholder de
+  "componente sin implementar" — y como esta vista **envuelve** el texto de la
+  lectura, eso se llevaba por delante el render del texto. Ahora se pregunta con
+  `requireOptionalNativeModule` y sin módulo se renderiza un `View` pelado.
+- **Reenganche en iOS y Android.** React Native se reasigna el delegate (iOS) y
+  el `customSelectionActionModeCallback` (Android) al recrear el texto, así que
+  con el enganche de una sola vez el ítem desaparecía en cuanto el texto se
+  volvía a montar (cambio de día, de tamaño de letra, de modo) y no volvía hasta
+  reiniciar la app. `attachIfNeeded` compara ahora con lo que hay puesto y nunca
+  encadena dos proxies nuestros.
+
+### Subrayar: seleccionas, tocas el lápiz y salen los colores
+
+`HighlightableReading` solo reportaba la selección **dentro** del modo lápiz, así
+que al entrar en el modo la barra decía "selecciona un texto" aunque hubiera
+texto seleccionado, y no reaccionaba hasta mover las asas un pelo. Ahora la
+reporta siempre que el texto sea un `TextInput` (en iOS, los dos modos). En
+Android leyendo sigue siendo un `Text selectable`, que no da offsets: allí el
+atajo es el ítem del menú nativo.
+
+De paso, un bug que sacó el test nuevo: una selección hecha **de derecha a
+izquierda** se descartaba como vacía (`end > start` en vez de `end !== start`; el
+`Math.min`/`Math.max` de al lado era código muerto).
+
+### Calendario: fuera el título del header
+
+Volvió en la pasada del 7 de agosto y se comía el sitio del conmutador
+Mes/Agenda, chocando con el botón de suscribirse. El **título lo pone ahora cada
+anfitrión**, no la pantalla: en el tab no hay (`headerTitle: ''`), en el stack de
+"Más" sí, porque allí es una pantalla apilada con su back. Y el cuerpo reserva la
+altura real del header (`useHeaderHeight()`) en iOS, donde es transparente: antes
+solo dejaba el hueco de la barra de estado y el contenido se metía debajo.
+
+### Reproductor de audio/vídeo del cantoral
+
+Cadena revisada de punta a punta y cubierta con tests (`songMediaFlow.test.tsx`):
+la hoja avisa bien y el reproductor monta el embed correcto. Encima, tres cosas
+que sí podían dejarlo en "no hace nada":
+
+- **El reproductor nace cuando la hoja ya está DESMONTADA** (`onCloseComplete`,
+  el gancho que el propio `BottomSheet` documenta para esto). En iOS la hoja es
+  un `Modal` en su propia ventana: aparecer por debajo dejaba el reproductor
+  tapado y el WebView arrancando en una ventana que no se ve.
+- **El PiP de audio pasa de 64 a 116pt de alto.** El iframe de `/preview` de
+  Drive pinta su propia cabecera encima de los controles: con 64 se veía una
+  franja negra **sin el botón de play**.
+- **Nunca es un callejón sin salida.** Se muestra "cargando", y si el embed falla
+  (`onError`/`onHttpError`) sale un "toca para abrirlo fuera". El audio gana
+  además su botón de abrir en Drive en la barra, que solo tenía el vídeo.
+
+**Modificados**: `.easignore`, `modules/highlight-menu/` (JS + Swift + Kotlin),
+`components/contigo/HighlightableReading.tsx`, `hooks/useReadingHighlights.ts`,
+`app/(tabs)/calendario.tsx`, `app/screens/SongDetailScreen.tsx`,
+`components/song-media/{SongMediaSheet,FloatingMediaPlayer}.tsx`,
+`__tests__/{highlightSelection,songMediaFlow}.test.tsx`,
+`docs/funcionalidades/SUBRAYADO.md`, `docs/desarrollo/BUILD_AGOSTO_2026.md`.
+Suite: 55 ficheros, 491 tests en verde.
+
+> ⚠️ **El ítem "Subrayar" del menú nativo necesita BUILD DE TIENDA.** Es código
+> nativo: por OTA no va. El commit lleva `[skip-ota]`. Lo demás (lápiz,
+> calendario, reproductor) sí sale por OTA.
+
+---
+
 ## 2026-08-08 02:20 — Escáner de QR para importar playlists y unirse al coro `[skip-ota]`
 
 Hasta ahora los QR que genera la app (`ShareQrModal`) solo se podían leer con la

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,53 @@
 
 ---
 
+## 2026-08-08 19:40 — La Home ya no se equivoca de camino al ir a un tab
+
+**Bug:** desde la Home, la tarjeta de un evento próximo y el botón "Ver
+calendario" no llevaban al calendario. La causa: `navigateToCalendar` decidía el
+camino con `Platform.OS === 'ios'` y entraba **siempre** por el stack de "Más".
+
+Y eso solo acierta a veces. En iOS `IOSTabsLayout` crea un `NativeTabs.Trigger`
+**solo por cada tab que cabe en la barra**, así que para un tab de overflow
+`router.push('/calendario')` no falla: no hace nada. En Android y web están
+registrados TODOS los tabs visibles del perfil, y allí el push directo siempre
+vale. Y **qué tabs caben depende del perfil y de si hay evento en curso**: con
+evento el calendario cae en overflow (y pasar por "Más" es lo correcto), sin
+evento está en la barra (y pasar por "Más" aterriza en el tab equivocado, o en
+ningún sitio si el perfil no tiene "Más").
+
+Ahora eso lo resuelve un sitio, no cada botón a su manera:
+
+- **`utils/tabNavigation.ts`** (puro, con tests): `resolveTabRoute` responde
+  "¿ruta propia o entro por Más?" mirando el reparto REAL de la barra
+  (`splitTabsForBar`), y `MAS_STACK_MIRROR` es la **fuente única** de qué tab
+  tiene pantalla espejo en "Más".
+- **`hooks/useTabNavigation.ts`**: `goToTab(tab, params?)` y
+  `goToEventScreen(pantalla, params?)`.
+- **Home**: el botón de calendario, las tarjetas de eventos próximos, el banner
+  del evento activo y el CTA "Evalúa la actividad" pasan por ahí. De paso, dos
+  cosas que estaban a fuego: el banner del evento hacía `router.push('/visitapapa')`
+  ignorando el `tabId` del perfil, y el acceso de Fotos entraba por "Más" incluso
+  siendo Fotos un tab de la barra.
+- **`MasHomeScreen`**: sus tarjetas de overflow usaban su propia lista de espejos
+  (`OVERFLOW_STACK_TARGETS`, sin `comunica`) — ahora usan la compartida, y el tab
+  del evento resuelve al hub con su `eventId` en vez de a una ruta que en iOS no
+  existe.
+
+**Umbral de `max-lines`: 400 → 1.000** (y la guía de "trocear de verdad" 600 →
+1.500), en `eslint.config.js` y `CLAUDE.md`. Con agentes de IA leyendo el código,
+un archivo largo pero coherente cuesta menos que la misma lógica repartida en
+seis ficheros. **Los gigantes se quedan**: la Fase 1 de `PLAN_CALIDAD.md` se
+cierra por decisión, no por completada. Avisos de lint: 88 → 60.
+
+**Nuevos**: `utils/tabNavigation.ts`, `hooks/useTabNavigation.ts`,
+`__tests__/tabNavigation.test.ts` (10 tests). **Modificados**:
+`app/(tabs)/index.tsx`, `app/screens/MasHomeScreen.tsx`, `eslint.config.js`,
+`CLAUDE.md`, `docs/desarrollo/TABS_MAINTENANCE.md`, `docs/planes/PLAN_CALIDAD.md`.
+Suite: 56 ficheros, 501 tests en verde.
+
+---
+
 ## 2026-08-08 18:15 — Cuatro cosas pedidas que seguían sin estar `[skip-ota]`
 
 ### El ítem "Subrayar" del menú nativo NUNCA llegó a un binario (causa raíz)

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,42 @@
 
 ---
 
+## 2026-08-08 20:25 — Navegación a tabs: un hueco más y 50 tests nuevos
+
+Repaso del arreglo anterior. **Un hueco real que quedaba**: si el camino
+resuelto era "entra por Más" pero **"Más" tampoco tenía ruta** —el perfil no lo
+trae, o en iOS no cabe en la barra—, `router.push('/mas')` era otro no-op y el
+botón volvía a no hacer nada. Ahora `resolveTabRoute` comprueba que "Más" sea
+alcanzable antes de mandar por ahí y, si no lo es, devuelve el intento directo:
+en Android/web funciona y en iOS no había camino de todas formas.
+
+De paso, la condición "¿tiene ruta este tab?" se unificó en un solo predicado
+(`hasRoute`) en vez de repartirse entre tres ramas: en iOS los tabs de la barra,
+en Android/web los visibles del perfil.
+
+**Cobertura: +50 tests en 4 ficheros nuevos**, con barridos exhaustivos en vez de
+casos sueltos —el bug original vivía justo en una combinación que nadie había
+recorrido—:
+
+- `__tests__/tabNavigationInvariants.test.ts` (16): los **2^8 = 256 perfiles
+  posibles × 3 plataformas**, comprobando que ningún tab visible se queda sin
+  camino. Y dos invariantes atadas al código real: que cada espejo de
+  `MAS_STACK_MIRROR` esté **registrado de verdad** en `mas.tsx` (se lee el
+  fuente, incluido lo que entra por `renderEventScreens`), y que **todo tab que
+  pueda caer en overflow tenga espejo** — sin él, en iOS es inalcanzable.
+- `__tests__/useTabNavigation.test.tsx` (14): el cableado del hook con `router`
+  mockeado — qué `push` sale y qué destino pendiente queda apuntado, incluido que
+  no se ensucien los buzones.
+- `__tests__/pendingNavigation.test.ts` (9): el contrato de los dos buzones de
+  navegación pendiente (un solo uso, el nuevo pisa al viejo, independientes).
+- `__tests__/splitTabsForBar.test.ts` (11): la premisa de todo, que no tenía
+  tests propios — barra + overflow = los visibles sin perder ni duplicar, "mas"
+  nunca en overflow, el orden lo manda `TABS_CONFIG` y no el perfil.
+
+Suite: 60 ficheros, **551 tests** en verde (antes 56 / 501).
+
+---
+
 ## 2026-08-08 19:40 — La Home ya no se equivoca de camino al ir a un tab
 
 **Bug:** desde la Home, la tarjeta de un evento próximo y el botón "Ver

--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -309,7 +309,7 @@ danger: '#9D1E74'; // Morado LC
 - **Nombres**: PascalCase componentes, camelCase hooks/utils, kebab-case archivos de assets
 - **Importaciones**: usar `@/` siempre, no rutas relativas largas
 - **Plataforma**: usar `Platform.OS` para diferencias, archivos `.ios.tsx` para componentes iOS-only
-- **Tamaño de archivo (anti-gigantes)**: ningún archivo **nuevo** debe superar las **400 líneas** (ESLint avisa con `max-lines`). Si una pantalla supera las **600 líneas**, extraer subcomponentes a `components/<área>/` y la lógica a un hook `use<Pantalla>.ts` **ANTES** de añadir la feature. No engordar un archivo ya grande: el saneamiento de los gigantes está en `docs/planes/PLAN_CALIDAD.md` (Fase 1).
+- **Tamaño de archivo**: el techo son **1.000 líneas** (ESLint avisa con `max-lines`); a partir de **1.500** hay que trocear de verdad — extraer subcomponentes a `components/<área>/` y la lógica a un hook `use<Pantalla>.ts` **ANTES** de añadir la feature. Umbrales subidos desde 400/600 el 2026-08-08: con agentes de IA leyendo el código, un archivo largo pero coherente cuesta menos que la misma lógica repartida en seis ficheros que hay que reconstruir mentalmente. Los gigantes que ya hay **se quedan**: no hace falta trocearlos por tamaño.
 - **Logging**: nunca `console.*` (ESLint lo bloquea como error). Usar el logger central `@/utils/logger` (`logger.debug/info/warn/error`).
 
 ## Patrones comunes

--- a/mcm-app/__tests__/highlightSelection.test.tsx
+++ b/mcm-app/__tests__/highlightSelection.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Selección de las lecturas: seleccionar PRIMERO y tocar el lápiz DESPUÉS.
+ *
+ * Era el fallo que se colaba: `HighlightableReading` solo reportaba la selección
+ * dentro del modo lápiz, así que al entrar en el modo la barra decía "selecciona
+ * un texto" aunque hubiera texto seleccionado, y no reaccionaba hasta mover las
+ * asas un pelo.
+ */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { TextInput } from 'react-native';
+import { HighlightableReading } from '@/components/contigo/HighlightableReading';
+import {
+  useReadingHighlights,
+  type ReadingHighlights,
+} from '@/hooks/useReadingHighlights';
+
+const TEXT = 'En aquel tiempo, Jesús dijo a sus discípulos.';
+
+function renderReading(props: {
+  penMode: boolean;
+  onSelectionChange: (sel: { start: number; end: number } | null) => void;
+}) {
+  let tree!: ReturnType<typeof create>;
+  act(() => {
+    tree = create(
+      <HighlightableReading
+        text={TEXT}
+        penMode={props.penMode}
+        onSelectionChange={props.onSelectionChange}
+        color="#000"
+        fontSize={18}
+        lineHeight={28}
+        isDark={false}
+      />,
+    );
+  });
+  return tree;
+}
+
+/** Simula la selección nativa del UITextView / EditText. */
+function selectRange(
+  tree: ReturnType<typeof create>,
+  start: number,
+  end: number,
+) {
+  act(() => {
+    tree.root.findByType(TextInput).props.onSelectionChange({
+      nativeEvent: { selection: { start, end } },
+    });
+  });
+}
+
+describe('HighlightableReading — reporte de selección', () => {
+  it('reporta la selección FUERA del modo lápiz', () => {
+    const onSelectionChange = jest.fn();
+    const tree = renderReading({ penMode: false, onSelectionChange });
+
+    selectRange(tree, 16, 21);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 16, end: 21 });
+  });
+
+  it('normaliza una selección hecha de derecha a izquierda', () => {
+    const onSelectionChange = jest.fn();
+    const tree = renderReading({ penMode: true, onSelectionChange });
+
+    selectRange(tree, 21, 16);
+
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 16, end: 21 });
+  });
+
+  it('una selección vacía se reporta como null', () => {
+    const onSelectionChange = jest.fn();
+    const tree = renderReading({ penMode: false, onSelectionChange });
+
+    selectRange(tree, 7, 7);
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
+  });
+});
+
+describe('useReadingHighlights — selección pegajosa', () => {
+  const readings = {
+    evangelio: { cita: 'Mt 1,1', texto: TEXT },
+  } as never;
+
+  it('mantiene la selección aunque luego llegue una vacía', () => {
+    let hl!: ReadingHighlights;
+    function Probe() {
+      hl = useReadingHighlights('2026-08-08', readings, undefined, () => {});
+      return null;
+    }
+    act(() => {
+      create(<Probe />);
+    });
+
+    act(() => {
+      hl.onSelectionChange.evangelio({ start: 16, end: 21 });
+    });
+    expect(hl.hasSelection).toBe(true);
+
+    // Al tocar un chip de color, iOS colapsa la selección nativa antes de que
+    // llegue el onPress: si la vaciáramos, el color no tendría a qué aplicarse.
+    act(() => {
+      hl.onSelectionChange.evangelio(null);
+    });
+    expect(hl.hasSelection).toBe(true);
+
+    act(() => {
+      hl.clearSelection();
+    });
+    expect(hl.hasSelection).toBe(false);
+  });
+});

--- a/mcm-app/__tests__/pendingNavigation.test.ts
+++ b/mcm-app/__tests__/pendingNavigation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Los dos "buzones" de navegación pendiente: `masNavigation` y
+ * `eventNavigation`. Son singletons de módulo, así que su contrato importa —
+ * un destino que no se limpia reaparece en la siguiente pantalla que enfoque.
+ */
+import {
+  setPendingMasScreen,
+  takePendingMasScreen,
+} from '@/utils/masNavigation';
+import {
+  setPendingEventScreen,
+  takePendingEventScreen,
+} from '@/utils/eventNavigation';
+
+const STORES = [
+  {
+    nombre: 'masNavigation',
+    set: setPendingMasScreen as (s: string, p?: object) => void,
+    take: takePendingMasScreen as () => unknown,
+  },
+  {
+    nombre: 'eventNavigation',
+    set: setPendingEventScreen as (s: string, p?: object) => void,
+    take: takePendingEventScreen as () => unknown,
+  },
+];
+
+beforeEach(() => {
+  STORES.forEach((s) => s.take());
+});
+
+describe.each(STORES)('$nombre', ({ set, take }) => {
+  it('vacío devuelve null', () => {
+    expect(take()).toBeNull();
+  });
+
+  it('es de UN SOLO USO: el segundo take ya no lo ve', () => {
+    set('Calendario');
+    expect(take()).toEqual({ screen: 'Calendario', params: undefined });
+    expect(take()).toBeNull();
+  });
+
+  it('guarda los params tal cual', () => {
+    set('Calendario', { date: '2026-08-08' });
+    expect(take()).toEqual({
+      screen: 'Calendario',
+      params: { date: '2026-08-08' },
+    });
+  });
+
+  it('un set nuevo PISA al anterior (no se encolan destinos viejos)', () => {
+    set('Fotos');
+    set('Comunica', { x: 1 });
+    expect(take()).toEqual({ screen: 'Comunica', params: { x: 1 } });
+    expect(take()).toBeNull();
+  });
+});
+
+describe('los dos buzones son independientes', () => {
+  it('escribir en uno no contamina el otro', () => {
+    setPendingMasScreen('Calendario' as never);
+    expect(takePendingEventScreen()).toBeNull();
+    expect(takePendingMasScreen()).toEqual({
+      screen: 'Calendario',
+      params: undefined,
+    });
+
+    setPendingEventScreen('Evaluacion');
+    expect(takePendingMasScreen()).toBeNull();
+    expect(takePendingEventScreen()).toEqual({
+      screen: 'Evaluacion',
+      params: undefined,
+    });
+  });
+});

--- a/mcm-app/__tests__/songMediaFlow.test.tsx
+++ b/mcm-app/__tests__/songMediaFlow.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Cadena de multimedia del cantoral: hoja → reproductor flotante.
+ *
+ * Cubre lo que se rompió sin que ningún test se enterara: que los botones de
+ * reproducir de la hoja avisen de verdad a quien abre el reproductor, y que el
+ * reproductor monte el embed correcto (YouTube con `Referer`, Drive con la URL
+ * de `preview`).
+ */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { TouchableOpacity } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+jest.mock('react-native-webview', () => {
+  const ReactLocal = require('react');
+  return {
+    WebView: (props: Record<string, unknown>) =>
+      ReactLocal.createElement('MockWebView', props),
+  };
+});
+
+import SongMediaSheet from '@/components/song-media/SongMediaSheet';
+import FloatingMediaPlayer from '@/components/song-media/FloatingMediaPlayer';
+import type { SongMedia } from '@/types/songMedia';
+
+const INITIAL_METRICS = {
+  frame: { x: 0, y: 0, width: 390, height: 844 },
+  insets: { top: 47, left: 0, right: 0, bottom: 34 },
+};
+
+function Wrap({ children }: { children: React.ReactNode }) {
+  return (
+    <SafeAreaProvider initialMetrics={INITIAL_METRICS}>
+      {children}
+    </SafeAreaProvider>
+  );
+}
+
+const MEDIA: SongMedia = {
+  videoEmbed: 'https://www.youtube.com/embed/aaaaaaaaaaa',
+  youtubeLinks: [
+    { label: 'Otra versión', url: 'https://www.youtube.com/embed/bbbbbbbbbbb' },
+  ],
+  audioLinks: [
+    {
+      label: 'Pista',
+      url: 'https://drive.google.com/file/d/1234567890abcdef/view?usp=drive_link',
+    },
+  ],
+};
+
+/** Filas pulsables de la hoja, en orden de pantalla. */
+function pressableRows(tree: ReturnType<typeof create>) {
+  return tree.root
+    .findAllByType(TouchableOpacity)
+    .filter((node) => typeof node.props.onPress === 'function');
+}
+
+function renderSheet(onPlayMedia: jest.Mock) {
+  let tree!: ReturnType<typeof create>;
+  act(() => {
+    tree = create(
+      <Wrap>
+        <SongMediaSheet
+          visible
+          onClose={() => {}}
+          media={MEDIA}
+          songTitle="Canción"
+          onPlayMedia={onPlayMedia}
+        />
+      </Wrap>,
+    );
+  });
+  return tree;
+}
+
+describe('hoja de multimedia', () => {
+  it('el vídeo principal abre el reproductor con su URL de embed', () => {
+    const onPlayMedia = jest.fn();
+    const tree = renderSheet(onPlayMedia);
+
+    act(() => {
+      pressableRows(tree)[0].props.onPress();
+    });
+
+    expect(onPlayMedia).toHaveBeenCalledWith({
+      kind: 'youtube',
+      url: 'https://www.youtube.com/embed/aaaaaaaaaaa',
+      label: 'Canción',
+    });
+  });
+
+  it('el audio de Drive abre el reproductor con la URL de preview', () => {
+    const onPlayMedia = jest.fn();
+    const tree = renderSheet(onPlayMedia);
+    const rows = pressableRows(tree);
+
+    // Vídeo principal, vídeo alternativo, fila de audio, y dentro de esa fila
+    // el botón de "abrir fuera": la fila de audio es la tercera pulsable.
+    act(() => {
+      rows[2].props.onPress();
+    });
+
+    expect(onPlayMedia).toHaveBeenCalledWith({
+      kind: 'drive',
+      url: 'https://drive.google.com/file/d/1234567890abcdef/preview',
+      label: 'Pista',
+    });
+  });
+});
+
+describe('reproductor flotante', () => {
+  it('el vídeo se carga con la cabecera Referer que exige YouTube', () => {
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <Wrap>
+          <FloatingMediaPlayer
+            source={{
+              kind: 'youtube',
+              url: 'https://www.youtube.com/embed/aaaaaaaaaaa',
+              label: 'Canción',
+            }}
+            onClose={() => {}}
+          />
+        </Wrap>,
+      );
+    });
+
+    const webViews = tree.root.findAllByType('MockWebView' as never);
+    expect(webViews).toHaveLength(1);
+    expect(webViews[0].props.source).toEqual({
+      uri: 'https://www.youtube.com/embed/aaaaaaaaaaa?playsinline=1&autoplay=1&rel=0',
+      headers: { Referer: 'https://mcmespana.github.io/' },
+    });
+  });
+
+  it('el audio de Drive se carga tal cual, sin parámetros de YouTube', () => {
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <Wrap>
+          <FloatingMediaPlayer
+            source={{
+              kind: 'drive',
+              url: 'https://drive.google.com/file/d/1234567890abcdef/preview',
+              label: 'Pista',
+            }}
+            onClose={() => {}}
+          />
+        </Wrap>,
+      );
+    });
+
+    const webViews = tree.root.findAllByType('MockWebView' as never);
+    expect(webViews[0].props.source).toEqual({
+      uri: 'https://drive.google.com/file/d/1234567890abcdef/preview',
+    });
+  });
+
+  it('si el embed falla se ofrece abrirlo fuera', () => {
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <Wrap>
+          <FloatingMediaPlayer
+            source={{
+              kind: 'drive',
+              url: 'https://drive.google.com/file/d/1234567890abcdef/preview',
+              label: 'Pista',
+            }}
+            onClose={() => {}}
+          />
+        </Wrap>,
+      );
+    });
+
+    act(() => {
+      tree.root.findByType('MockWebView' as never).props.onError();
+    });
+
+    // `findAll` también devuelve los nodos host que heredan la prop, así que
+    // basta con que exista al menos uno.
+    expect(
+      tree.root.findAll(
+        (node) =>
+          typeof node.props?.accessibilityLabel === 'string' &&
+          node.props.accessibilityLabel.includes('abrir en Drive'),
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/mcm-app/__tests__/splitTabsForBar.test.ts
+++ b/mcm-app/__tests__/splitTabsForBar.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `splitTabsForBar` — el reparto barra/overflow del que depende TODA la
+ * navegación a tabs. No tenía tests propios y es la premisa de
+ * `utils/tabNavigation.ts`.
+ */
+import {
+  MAX_TAB_BAR_ITEMS,
+  TABS_CONFIG,
+  splitTabsForBar,
+} from '@/constants/tabsCatalog';
+
+const ALL_NAMES = TABS_CONFIG.map((t) => t.name);
+const names = (tabs: { name: string }[]) => tabs.map((t) => t.name);
+
+function subsets(list: string[]): Set<string>[] {
+  const out: Set<string>[] = [];
+  for (let mask = 0; mask < 1 << list.length; mask++) {
+    const set = new Set<string>();
+    list.forEach((n, i) => {
+      if (mask & (1 << i)) set.add(n);
+    });
+    out.push(set);
+  }
+  return out;
+}
+const ALL_SUBSETS = subsets(ALL_NAMES);
+
+describe('reparto', () => {
+  it('sin overflow si caben todos', () => {
+    const visible = new Set(ALL_NAMES.slice(0, MAX_TAB_BAR_ITEMS));
+    const { mainTabs, overflowTabs } = splitTabsForBar(visible);
+    expect(overflowTabs).toEqual([]);
+    expect(mainTabs).toHaveLength(MAX_TAB_BAR_ITEMS);
+  });
+
+  it('con overflow, "Más" va SIEMPRE el último de la barra', () => {
+    const { mainTabs } = splitTabsForBar(new Set(ALL_NAMES));
+    expect(names(mainTabs).at(-1)).toBe('mas');
+  });
+
+  it('el orden lo manda TABS_CONFIG, no el orden del perfil', () => {
+    const alReves = new Set([...ALL_NAMES].reverse());
+    expect(names(splitTabsForBar(alReves).mainTabs)).toEqual(
+      names(splitTabsForBar(new Set(ALL_NAMES)).mainTabs),
+    );
+  });
+
+  it('ignora nombres que no están en TABS_CONFIG', () => {
+    const conBasura = new Set([...ALL_NAMES, 'inventado', 'otro']);
+    const { mainTabs, overflowTabs } = splitTabsForBar(conBasura);
+    for (const name of [...names(mainTabs), ...names(overflowTabs)]) {
+      expect(ALL_NAMES).toContain(name);
+    }
+  });
+
+  it('perfil vacío → nada, sin reventar', () => {
+    expect(splitTabsForBar(new Set())).toEqual({
+      mainTabs: [],
+      overflowTabs: [],
+    });
+  });
+});
+
+describe('invariantes sobre los 256 perfiles posibles', () => {
+  it('barra + overflow = exactamente los tabs visibles, sin repetir ni perder', () => {
+    for (const visible of ALL_SUBSETS) {
+      const { mainTabs, overflowTabs } = splitTabsForBar(visible);
+      const juntos = [...names(mainTabs), ...names(overflowTabs)];
+      expect(new Set(juntos).size).toBe(juntos.length); // sin duplicados
+      // Con "mas" en el perfil no se pierde ninguno. Sin "mas" y con overflow,
+      // splitTabsForBar recorta a propósito (no hay dónde enseñarlos).
+      if (visible.has('mas') || visible.size <= MAX_TAB_BAR_ITEMS) {
+        expect(new Set(juntos)).toEqual(
+          new Set(ALL_NAMES.filter((n) => visible.has(n))),
+        );
+      }
+    }
+  });
+
+  it('la barra nunca excede el tope', () => {
+    for (const visible of ALL_SUBSETS) {
+      expect(splitTabsForBar(visible).mainTabs.length).toBeLessThanOrEqual(
+        MAX_TAB_BAR_ITEMS,
+      );
+    }
+  });
+
+  it('"mas" nunca cae en overflow', () => {
+    for (const visible of ALL_SUBSETS) {
+      expect(names(splitTabsForBar(visible).overflowTabs)).not.toContain('mas');
+    }
+  });
+
+  it('si hay overflow, la barra está llena (no se desperdicia hueco)', () => {
+    for (const visible of ALL_SUBSETS) {
+      const { mainTabs, overflowTabs } = splitTabsForBar(visible);
+      if (overflowTabs.length > 0) {
+        expect(mainTabs).toHaveLength(MAX_TAB_BAR_ITEMS);
+      }
+    }
+  });
+
+  it('es estable: dos llamadas con el mismo perfil dan lo mismo', () => {
+    for (const visible of ALL_SUBSETS) {
+      expect(names(splitTabsForBar(visible).mainTabs)).toEqual(
+        names(splitTabsForBar(new Set(visible)).mainTabs),
+      );
+    }
+  });
+
+  it('los tabs de la barra son siempre un prefijo del orden de TABS_CONFIG (+ "mas")', () => {
+    for (const visible of ALL_SUBSETS) {
+      if (!visible.has('mas')) continue;
+      const { mainTabs } = splitTabsForBar(visible);
+      const sinMas = names(mainTabs).filter((n) => n !== 'mas');
+      const esperados = ALL_NAMES.filter(
+        (n) => visible.has(n) && n !== 'mas',
+      ).slice(0, sinMas.length);
+      expect(sinMas).toEqual(esperados);
+    }
+  });
+});

--- a/mcm-app/__tests__/tabNavigation.test.ts
+++ b/mcm-app/__tests__/tabNavigation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Cómo se llega a un tab desde la Home.
+ *
+ * El bug que cubre: en iOS solo los tabs de la BARRA tienen ruta registrada
+ * (`IOSTabsLayout` crea un `NativeTabs.Trigger` por tab de la barra y nada más),
+ * y qué tabs caben depende del perfil y de si hay evento en curso. La Home lo
+ * decidía a ojo —`Platform.OS === 'ios'` y `href` fijos— así que sus botones
+ * llevaban al sitio equivocado, o a ninguno.
+ */
+import {
+  MAS_EVENT_HUB_SCREEN,
+  resolveEventScreenRoute,
+  resolveTabRoute,
+} from '@/utils/tabNavigation';
+
+const EVENT = { tabName: 'visitapapa', eventId: 'visitapapa' };
+
+/** 8 tabs = hay overflow: caben 5 + "Más" (MAX_TAB_BAR_ITEMS = 6). */
+const ALL_TABS = new Set([
+  'index',
+  'cancionero',
+  'contigo',
+  'comunica',
+  'visitapapa',
+  'calendario',
+  'fotos',
+  'mas',
+]);
+
+/** 6 tabs sin evento: todos caben en la barra, no hay overflow. */
+const NO_EVENT_TABS = new Set([
+  'index',
+  'cancionero',
+  'contigo',
+  'calendario',
+  'fotos',
+  'mas',
+]);
+
+describe('resolveTabRoute — Android y web', () => {
+  it('van directos a cualquier tab visible, esté o no en la barra', () => {
+    for (const platform of ['android', 'web']) {
+      expect(resolveTabRoute('calendario', ALL_TABS, { platform })).toEqual({
+        via: 'tab',
+        path: '/calendario',
+      });
+    }
+  });
+
+  it('conservan los params del destino', () => {
+    expect(
+      resolveTabRoute('calendario', ALL_TABS, {
+        platform: 'android',
+        params: { date: '2026-08-08' },
+      }),
+    ).toEqual({
+      via: 'tab',
+      path: '/calendario',
+      params: { date: '2026-08-08' },
+    });
+  });
+});
+
+describe('resolveTabRoute — iOS', () => {
+  const platform = 'ios';
+
+  it('con evento en curso, el calendario cae en overflow → entra por "Más"', () => {
+    expect(
+      resolveTabRoute('calendario', ALL_TABS, {
+        platform,
+        params: { date: '2026-08-08' },
+      }),
+    ).toEqual({
+      via: 'masScreen',
+      screen: 'Calendario',
+      params: { date: '2026-08-08' },
+    });
+  });
+
+  it('SIN evento el calendario está en la barra → va directo', () => {
+    // Este es el caso que fallaba: la Home entraba por "Más" siempre en iOS, y
+    // aquí aterrizaba en el tab equivocado.
+    expect(resolveTabRoute('calendario', NO_EVENT_TABS, { platform })).toEqual({
+      via: 'tab',
+      path: '/calendario',
+    });
+  });
+
+  it('el tab del evento va directo cuando cabe en la barra', () => {
+    expect(
+      resolveTabRoute('visitapapa', ALL_TABS, { platform, eventTab: EVENT }),
+    ).toEqual({ via: 'tab', path: '/visitapapa' });
+  });
+
+  it('el tab del evento fuera de los visibles entra por el hub de "Más"', () => {
+    // Pasa cuando el evento se ARCHIVA: `useVisibleTabs` quita su tab, pero
+    // seguimos queriendo llegar a sus pantallas (p. ej. la evaluación). Con el
+    // orden actual de TABS_CONFIG el tab del evento nunca cae en overflow
+    // —va en la posición 5 de 8, y a la barra entran las 5 primeras— así que
+    // este es el camino por el que se alcanza el hub.
+    const tabs = new Set([
+      'index',
+      'cancionero',
+      'contigo',
+      'comunica',
+      'calendario',
+      'fotos',
+      'mas',
+    ]);
+    expect(
+      resolveTabRoute('visitapapa', tabs, { platform, eventTab: EVENT }),
+    ).toEqual({
+      via: 'masScreen',
+      screen: MAS_EVENT_HUB_SCREEN,
+      params: { eventId: 'visitapapa' },
+    });
+  });
+
+  it('un tab que el perfil no muestra usa su espejo de "Más"', () => {
+    // La tarjeta de calendario de la Home sale de los calendarios suscritos, no
+    // de los tabs: puede haberla sin tab de calendario.
+    const tabs = new Set(['index', 'cancionero', 'mas']);
+    expect(resolveTabRoute('calendario', tabs, { platform })).toEqual({
+      via: 'masScreen',
+      screen: 'Calendario',
+    });
+  });
+
+  it('sin espejo posible se aterriza en la raíz de "Más", no en la nada', () => {
+    const tabs = new Set(['index', 'mas']);
+    expect(resolveTabRoute('cancionero', tabs, { platform })).toEqual({
+      via: 'masRoot',
+    });
+  });
+});
+
+describe('resolveEventScreenRoute', () => {
+  it('entra por el tab del evento cuando ese tab tiene ruta propia', () => {
+    expect(
+      resolveEventScreenRoute('Evaluacion', EVENT, ALL_TABS, 'ios'),
+    ).toEqual({ via: 'eventTab', path: '/visitapapa' });
+  });
+
+  it('entra por "Más" cuando el tab del evento ya no está visible (archivado)', () => {
+    const tabs = new Set([
+      'index',
+      'cancionero',
+      'contigo',
+      'comunica',
+      'calendario',
+      'fotos',
+      'mas',
+    ]);
+    expect(resolveEventScreenRoute('Evaluacion', EVENT, tabs, 'ios')).toEqual({
+      via: 'masScreen',
+      screen: 'Evaluacion',
+    });
+  });
+});

--- a/mcm-app/__tests__/tabNavigationInvariants.test.ts
+++ b/mcm-app/__tests__/tabNavigationInvariants.test.ts
@@ -1,0 +1,294 @@
+/**
+ * INVARIANTES de la navegación a tabs. No casos sueltos: barridos exhaustivos.
+ *
+ * La navegación de la Home falló porque dependía de una combinación —perfil ×
+ * plataforma × hay evento o no— que nadie había recorrido entera. Aquí se
+ * recorre entera: los 2^N subconjuntos de `TABS_CONFIG` en las tres
+ * plataformas, comprobando que **ningún destino alcanzable se queda sin
+ * camino**.
+ *
+ * Y se atan las dos listas que tienen que cuadrar con la realidad:
+ *   - todo espejo de `MAS_STACK_MIRROR` debe estar registrado en `mas.tsx`;
+ *   - todo tab que PUEDA caer en overflow debe tener espejo (si no, en iOS es
+ *     inalcanzable).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import {
+  MAS_EVENT_HUB_SCREEN,
+  MAS_STACK_MIRROR,
+  resolveEventScreenRoute,
+  resolveTabRoute,
+} from '@/utils/tabNavigation';
+import type { TabRoute } from '@/utils/tabNavigation';
+import {
+  MAX_TAB_BAR_ITEMS,
+  TABS_CONFIG,
+  splitTabsForBar,
+} from '@/constants/tabsCatalog';
+
+const PLATFORMS = ['ios', 'android', 'web'] as const;
+const ALL_NAMES = TABS_CONFIG.map((t) => t.name);
+const EVENT = { tabName: 'visitapapa', eventId: 'visitapapa' };
+
+/** Todos los subconjuntos de `names` (2^n). Con 8 tabs son 256. */
+function subsets(names: string[]): Set<string>[] {
+  const out: Set<string>[] = [];
+  for (let mask = 0; mask < 1 << names.length; mask++) {
+    const set = new Set<string>();
+    names.forEach((name, i) => {
+      if (mask & (1 << i)) set.add(name);
+    });
+    out.push(set);
+  }
+  return out;
+}
+
+const ALL_SUBSETS = subsets(ALL_NAMES);
+
+/** Fuente de `mas.tsx`, para comprobar qué pantallas registra de verdad. */
+const MAS_SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'app', '(tabs)', 'mas.tsx'),
+  'utf8',
+);
+const EVENT_SCREENS_SOURCE = fs.readFileSync(
+  path.join(__dirname, '..', 'app', 'screens', 'eventStackScreens.tsx'),
+  'utf8',
+);
+
+/** ¿`mas.tsx` registra esa pantalla (directamente o vía renderEventScreens)? */
+function masStackRegisters(screen: string): boolean {
+  if (MAS_SOURCE.includes(`name="${screen}"`)) return true;
+  return (
+    MAS_SOURCE.includes('renderEventScreens') &&
+    EVENT_SCREENS_SOURCE.includes(`name="${screen}"`)
+  );
+}
+
+describe('las dos listas cuadran con el código real', () => {
+  it('cada espejo de MAS_STACK_MIRROR está registrado en el stack de "Más"', () => {
+    for (const screen of Object.values(MAS_STACK_MIRROR)) {
+      expect({ screen, registrado: masStackRegisters(screen) }).toEqual({
+        screen,
+        registrado: true,
+      });
+    }
+  });
+
+  it('el hub de evento está registrado en el stack de "Más"', () => {
+    expect(masStackRegisters(MAS_EVENT_HUB_SCREEN)).toBe(true);
+  });
+
+  it('cada espejo apunta a un tab que existe en TABS_CONFIG', () => {
+    for (const tabName of Object.keys(MAS_STACK_MIRROR)) {
+      expect(ALL_NAMES).toContain(tabName);
+    }
+  });
+
+  it('TODO tab que pueda caer en overflow tiene espejo (o es el del evento)', () => {
+    // Es LA invariante: en iOS un tab de overflow no tiene ruta, así que sin
+    // espejo queda inalcanzable. Se comprueba sobre los 256 perfiles posibles.
+    const sinEspejo = new Set<string>();
+    for (const visible of ALL_SUBSETS) {
+      for (const tab of splitTabsForBar(visible).overflowTabs) {
+        const tieneEspejo =
+          MAS_STACK_MIRROR[tab.name] !== undefined ||
+          tab.name === EVENT.tabName;
+        if (!tieneEspejo) sinEspejo.add(tab.name);
+      }
+    }
+    expect([...sinEspejo]).toEqual([]);
+  });
+});
+
+describe('barrido exhaustivo: 256 perfiles × 3 plataformas', () => {
+  /** Un destino es alcanzable si el camino que devuelve existe de verdad. */
+  function esAlcanzable(
+    route: TabRoute,
+    visible: Set<string>,
+    platform: string,
+  ): boolean {
+    const { mainTabs } = splitTabsForBar(visible);
+    const tieneRuta = (name: string) =>
+      platform === 'ios'
+        ? mainTabs.some((t) => t.name === name)
+        : visible.has(name);
+
+    if (route.via === 'tab') return tieneRuta(route.path.slice(1));
+    // Por "Más": "Más" tiene que tener ruta Y la pantalla estar registrada.
+    if (!tieneRuta('mas')) return false;
+    return route.via === 'masRoot' ? true : masStackRegisters(route.screen);
+  }
+
+  it('sin "Más" en el perfil, el resolver no inventa: siempre intento directo', () => {
+    // splitTabsForBar avisa de que sin "mas" los tabs de overflow se pierden (no
+    // hay dónde enseñarlos). El resolver no puede arreglar eso, pero sí no
+    // empeorarlo: manda el push directo, que en Android/web sí funciona.
+    for (const platform of PLATFORMS) {
+      for (const visible of ALL_SUBSETS) {
+        if (visible.has('mas')) continue;
+        for (const tabName of visible) {
+          expect(
+            resolveTabRoute(tabName, visible, { platform, eventTab: EVENT }),
+          ).toEqual({ via: 'tab', path: `/${tabName}` });
+        }
+      }
+    }
+  });
+
+  it('con "Más" en el perfil, NINGÚN tab visible se queda sin camino', () => {
+    const fallos: string[] = [];
+    for (const platform of PLATFORMS) {
+      for (const visible of ALL_SUBSETS) {
+        if (!visible.has('mas')) continue;
+        for (const tabName of visible) {
+          if (tabName === 'index') continue;
+          const route = resolveTabRoute(tabName, visible, {
+            platform,
+            eventTab: EVENT,
+          });
+          if (!esAlcanzable(route, visible, platform)) {
+            fallos.push(`${platform} · ${tabName}`);
+          }
+        }
+      }
+    }
+    expect(fallos).toEqual([]);
+  });
+
+  it('el resolver NUNCA manda a "Más" cuando "Más" no tiene ruta', () => {
+    for (const platform of PLATFORMS) {
+      for (const visible of ALL_SUBSETS) {
+        const { mainTabs } = splitTabsForBar(visible);
+        const masTieneRuta =
+          platform === 'ios'
+            ? mainTabs.some((t) => t.name === 'mas')
+            : visible.has('mas');
+        if (masTieneRuta) continue;
+        for (const tabName of ALL_NAMES) {
+          const route = resolveTabRoute(tabName, visible, {
+            platform,
+            eventTab: EVENT,
+          });
+          expect(route.via).toBe('tab');
+        }
+      }
+    }
+  });
+
+  it('en Android y web SIEMPRE se va directo a un tab visible', () => {
+    for (const platform of ['android', 'web']) {
+      for (const visible of ALL_SUBSETS) {
+        for (const tabName of visible) {
+          expect(
+            resolveTabRoute(tabName, visible, { platform, eventTab: EVENT }),
+          ).toEqual({ via: 'tab', path: `/${tabName}` });
+        }
+      }
+    }
+  });
+
+  it('en iOS se va directo exactamente a los tabs de la barra, ni uno más', () => {
+    for (const visible of ALL_SUBSETS) {
+      if (!visible.has('mas')) continue;
+      const { mainTabs } = splitTabsForBar(visible);
+      const enBarra = new Set(mainTabs.map((t) => t.name));
+      for (const tabName of visible) {
+        const route = resolveTabRoute(tabName, visible, {
+          platform: 'ios',
+          eventTab: EVENT,
+        });
+        expect({ tabName, directo: route.via === 'tab' }).toEqual({
+          tabName,
+          directo: enBarra.has(tabName),
+        });
+      }
+    }
+  });
+
+  it('la barra nunca pasa de MAX_TAB_BAR_ITEMS (premisa del resolver)', () => {
+    for (const visible of ALL_SUBSETS) {
+      expect(splitTabsForBar(visible).mainTabs.length).toBeLessThanOrEqual(
+        MAX_TAB_BAR_ITEMS,
+      );
+    }
+  });
+});
+
+describe('params', () => {
+  const conEvento = new Set(ALL_NAMES);
+
+  it('viajan intactos por la vía directa', () => {
+    expect(
+      resolveTabRoute('cancionero', conEvento, {
+        platform: 'ios',
+        params: { q: 'gloria' },
+      }),
+    ).toEqual({ via: 'tab', path: '/cancionero', params: { q: 'gloria' } });
+  });
+
+  it('viajan intactos por la vía de "Más"', () => {
+    expect(
+      resolveTabRoute('calendario', conEvento, {
+        platform: 'ios',
+        params: { date: '2026-12-25' },
+      }),
+    ).toEqual({
+      via: 'masScreen',
+      screen: 'Calendario',
+      params: { date: '2026-12-25' },
+    });
+  });
+
+  it('sin params no se inventa la clave (evita re-renders y rutas raras)', () => {
+    const route = resolveTabRoute('calendario', conEvento, { platform: 'ios' });
+    expect(Object.prototype.hasOwnProperty.call(route, 'params')).toBe(false);
+  });
+
+  it('el eventId del hub no lo pisa un params homónimo del llamante', () => {
+    const tabs = new Set(ALL_NAMES.filter((n) => n !== EVENT.tabName));
+    const route = resolveTabRoute(EVENT.tabName, tabs, {
+      platform: 'ios',
+      eventTab: EVENT,
+      params: { foo: 'bar' },
+    });
+    expect(route).toEqual({
+      via: 'masScreen',
+      screen: MAS_EVENT_HUB_SCREEN,
+      params: { eventId: 'visitapapa', foo: 'bar' },
+    });
+  });
+});
+
+describe('resolveEventScreenRoute — barrido', () => {
+  it('siempre resuelve a un camino existente cuando hay "Más"', () => {
+    for (const platform of PLATFORMS) {
+      for (const visible of ALL_SUBSETS) {
+        if (!visible.has('mas')) continue;
+        const route = resolveEventScreenRoute(
+          'Evaluacion',
+          EVENT,
+          visible,
+          platform,
+        );
+        if (route.via === 'masScreen') {
+          expect(masStackRegisters(route.screen)).toBe(true);
+        } else {
+          expect(route.path).toBe(`/${EVENT.tabName}`);
+          expect(visible.has(EVENT.tabName)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('la pantalla pedida se conserva tal cual al ir por "Más"', () => {
+    const sinEvento = new Set(ALL_NAMES.filter((n) => n !== EVENT.tabName));
+    for (const screen of ['Evaluacion', 'Reflexiones', 'Horario', 'Grupos']) {
+      expect(resolveEventScreenRoute(screen, EVENT, sinEvento, 'ios')).toEqual({
+        via: 'masScreen',
+        screen,
+      });
+    }
+  });
+});

--- a/mcm-app/__tests__/useTabNavigation.test.tsx
+++ b/mcm-app/__tests__/useTabNavigation.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * `useTabNavigation` de punta a punta: qué `router.push` sale y qué destino
+ * pendiente se deja apuntado.
+ *
+ * El resolver ya está cubierto aparte; esto ata el CABLEADO, que es donde
+ * estaba el bug original: el camino se decidía bien pero se ejecutaba a mano en
+ * cada botón, y cada uno lo hacía distinto.
+ */
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+// Los nombres tienen que empezar por `mock` para que jest los deje entrar en
+// las factories de `jest.mock` (se evalúan antes que el resto del módulo).
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  router: { push: (...args: unknown[]) => mockPush(...args) },
+}));
+
+let mockVisibleTabs = new Set<string>();
+jest.mock('@/hooks/useVisibleTabs', () => ({
+  useVisibleTabs: () => mockVisibleTabs,
+}));
+
+let mockActiveEvent: { id: string; tabId?: string } = {
+  id: 'visitapapa',
+  tabId: 'visitapapa',
+};
+jest.mock('@/contexts/ActiveEventContext', () => ({
+  useActiveMeta: () => ({ activeEvent: mockActiveEvent }),
+}));
+
+let mockPlatform = 'ios';
+jest.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return mockPlatform;
+    },
+  },
+}));
+
+import { useTabNavigation } from '@/hooks/useTabNavigation';
+import { takePendingMasScreen } from '@/utils/masNavigation';
+import { takePendingEventScreen } from '@/utils/eventNavigation';
+
+const ALL = [
+  'index',
+  'cancionero',
+  'contigo',
+  'comunica',
+  'visitapapa',
+  'calendario',
+  'fotos',
+  'mas',
+];
+const SIN_EVENTO = ALL.filter((t) => t !== 'visitapapa' && t !== 'comunica');
+
+function render() {
+  let api!: ReturnType<typeof useTabNavigation>;
+  function Probe() {
+    api = useTabNavigation();
+    return null;
+  }
+  act(() => {
+    create(<Probe />);
+  });
+  return api;
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  takePendingMasScreen();
+  takePendingEventScreen();
+  mockPlatform = 'ios';
+  mockVisibleTabs = new Set(ALL);
+  mockActiveEvent = { id: 'visitapapa', tabId: 'visitapapa' };
+});
+
+describe('goToTab — iOS con evento (el calendario está en overflow)', () => {
+  it('deja el calendario apuntado en "Más" y navega a "Más"', () => {
+    render().goToTab('calendario');
+
+    expect(mockPush).toHaveBeenCalledWith('/mas');
+    expect(takePendingMasScreen()).toEqual({
+      screen: 'Calendario',
+      params: undefined,
+    });
+  });
+
+  it('arrastra la fecha hasta el destino pendiente', () => {
+    render().goToTab('calendario', { date: '2026-08-08' });
+
+    expect(mockPush).toHaveBeenCalledWith('/mas');
+    expect(takePendingMasScreen()).toEqual({
+      screen: 'Calendario',
+      params: { date: '2026-08-08' },
+    });
+  });
+
+  it('el tab del evento sí cabe en la barra: push directo y sin pendiente', () => {
+    render().goToTab('visitapapa');
+
+    expect(mockPush).toHaveBeenCalledWith('/visitapapa');
+    expect(takePendingMasScreen()).toBeNull();
+  });
+});
+
+describe('goToTab — iOS sin evento (el calendario cabe en la barra)', () => {
+  beforeEach(() => {
+    mockVisibleTabs = new Set(SIN_EVENTO);
+  });
+
+  it('va DIRECTO al calendario, sin pasar por "Más"', () => {
+    // El bug original: aquí se hacía push('/mas') y se aterrizaba en otro tab.
+    render().goToTab('calendario');
+
+    expect(mockPush).toHaveBeenCalledWith('/calendario');
+    expect(takePendingMasScreen()).toBeNull();
+  });
+
+  it('con fecha, la manda como params de la ruta', () => {
+    render().goToTab('calendario', { date: '2026-12-25' });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/calendario',
+      params: { date: '2026-12-25' },
+    });
+    expect(takePendingMasScreen()).toBeNull();
+  });
+});
+
+describe('goToTab — Android y web', () => {
+  it.each(['android', 'web'])('%s va directo aunque haya overflow', (os) => {
+    mockPlatform = os;
+    render().goToTab('calendario', { date: '2026-01-01' });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/calendario',
+      params: { date: '2026-01-01' },
+    });
+    expect(takePendingMasScreen()).toBeNull();
+  });
+});
+
+describe('goToTab — casos límite', () => {
+  it('un tab que el perfil no trae entra por su espejo de "Más"', () => {
+    mockVisibleTabs = new Set(['index', 'cancionero', 'mas']);
+    render().goToTab('calendario');
+
+    expect(mockPush).toHaveBeenCalledWith('/mas');
+    expect(takePendingMasScreen()).toEqual({
+      screen: 'Calendario',
+      params: undefined,
+    });
+  });
+
+  it('sin espejo posible aterriza en "Más" SIN destino pendiente', () => {
+    mockVisibleTabs = new Set(['index', 'mas']);
+    render().goToTab('cancionero');
+
+    expect(mockPush).toHaveBeenCalledWith('/mas');
+    expect(takePendingMasScreen()).toBeNull();
+  });
+
+  it('sin "Más" en el perfil no manda a "Más": intenta el directo', () => {
+    mockVisibleTabs = new Set(['index', 'cancionero']);
+    render().goToTab('calendario');
+
+    expect(mockPush).toHaveBeenCalledWith('/calendario');
+    expect(takePendingMasScreen()).toBeNull();
+  });
+
+  it('no deja pendientes cruzados: un goToTab directo no ensucia el store', () => {
+    const api = render();
+    api.goToTab('calendario'); // deja pendiente
+    takePendingMasScreen(); // alguien lo consume
+    api.goToTab('cancionero'); // directo
+
+    expect(mockPush).toHaveBeenLastCalledWith('/cancionero');
+    expect(takePendingMasScreen()).toBeNull();
+  });
+});
+
+describe('goToEventScreen', () => {
+  it('entra por el tab del evento cuando ese tab tiene ruta', () => {
+    render().goToEventScreen('Evaluacion', { eventId: 'visitapapa' });
+
+    expect(mockPush).toHaveBeenCalledWith('/visitapapa');
+    expect(takePendingEventScreen()).toEqual({
+      screen: 'Evaluacion',
+      params: { eventId: 'visitapapa' },
+    });
+    expect(takePendingMasScreen()).toBeNull();
+  });
+
+  it('con el evento archivado (tab fuera) entra por "Más"', () => {
+    mockVisibleTabs = new Set(SIN_EVENTO);
+    render().goToEventScreen('Evaluacion', { eventId: 'visitapapa' });
+
+    expect(mockPush).toHaveBeenCalledWith('/mas');
+    expect(takePendingMasScreen()).toEqual({
+      screen: 'Evaluacion',
+      params: { eventId: 'visitapapa' },
+    });
+    expect(takePendingEventScreen()).toBeNull();
+  });
+
+  it('sin evento activo no navega a ninguna parte', () => {
+    mockActiveEvent = { id: '', tabId: undefined };
+    render().goToEventScreen('Evaluacion');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(takePendingMasScreen()).toBeNull();
+    expect(takePendingEventScreen()).toBeNull();
+  });
+});

--- a/mcm-app/app/(tabs)/calendario.tsx
+++ b/mcm-app/app/(tabs)/calendario.tsx
@@ -23,8 +23,11 @@ import { useCalendarConfig } from '@/contexts/CalendarConfigContext';
 import ProgressWithMessage from '@/components/ProgressWithMessage';
 import OfflineBanner from '@/components/OfflineBanner';
 import { useLocalSearchParams } from 'expo-router';
-import { useRoute, useNavigation } from 'expo-router/react-navigation';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  useRoute,
+  useNavigation,
+  useHeaderHeight,
+} from 'expo-router/react-navigation';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { hexAlpha } from '@/utils/colorUtils';
 import { h } from '@/utils/haptics';
@@ -162,14 +165,18 @@ export function CalendarScreen() {
   const [subscribeOpen, setSubscribeOpen] = useState(false);
   const [detailsEvent, setDetailsEvent] = useState<CalendarEvent | null>(null);
 
-  // Header NATIVO: título "Calendario" + botón de calendarios (suscribirse) como
-  // bar item. Antes el botón vivía en el cuerpo, junto al switcher Mes/Agenda.
+  // Header NATIVO: solo el botón de calendarios (suscribirse) como bar item. El
+  // TÍTULO lo pone cada anfitrión, no esta pantalla: en el tab no hay título (la
+  // pestaña ya se llama Calendario y el texto se comía el sitio del conmutador
+  // Mes/Agenda, chocando además con este botón), y en el stack de "Más" sí,
+  // porque allí es una pantalla apilada con su back.
   const navigation = useNavigation();
-  const insets = useSafeAreaInsets();
+  // Altura REAL del header del anfitrión (incluye la barra de estado y baja a
+  // 32pt en horizontal), en vez de los 44 a ojo de antes.
+  const headerHeight = useHeaderHeight();
   const showSubscribe = !configsLoading && calendarConfigs.length > 0;
   useLayoutEffect(() => {
     navigation.setOptions({
-      title: 'Calendario',
       headerRight: showSubscribe
         ? () => (
             <TouchableOpacity
@@ -512,11 +519,13 @@ export function CalendarScreen() {
       style={[
         styles.container,
         { flex: 1 },
-        // Ya no hay header de navegación (`headerShown: false` en
-        // TABS_CONFIG): solo hace falta el hueco de la barra de estado, igual
-        // en las dos plataformas. Antes se reservaban 44pt extra para un
-        // header que en Android además era una barra opaca fija.
-        { paddingTop: insets.top },
+        // El header del stack es TRANSPARENTE en iOS (glass del sistema) en los
+        // dos anfitriones —el tab y el stack de "Más"—: el contenido pasa por
+        // debajo, así que hay que reservar su altura. Sin ella el conmutador
+        // Mes/Agenda se metía DEBAJO del header y chocaba con el botón de
+        // suscribirse. En Android y web el header es opaco y ya ocupa su sitio
+        // en el layout, así que aquí no se reserva nada.
+        { paddingTop: Platform.OS === 'ios' ? headerHeight : 0 },
       ]}
     >
       {offline && <OfflineBanner text="Mostrando datos sin conexión" />}
@@ -755,8 +764,9 @@ export function CalendarScreen() {
 }
 
 // Tab del calendario: envuelve la pantalla en un stack para tener header nativo
-// ("Calendario" + botón de calendarios). Reusa el mismo CalendarScreen que el
-// stack de "Más" (donde ya hay header propio).
+// (SIN título — solo el botón de calendarios, que CalendarScreen añade como bar
+// item). Reusa el mismo CalendarScreen que el stack de "Más", donde sí lleva
+// título porque allí es una pantalla apilada.
 const CalStack = createNativeStackNavigator();
 export default function CalendarioTab() {
   const scheme = useColorScheme();
@@ -781,7 +791,10 @@ export default function CalendarioTab() {
       <CalStack.Screen
         name="CalendarMain"
         component={CalendarScreen}
-        options={{ title: 'Calendario' }}
+        // Sin título: la pestaña ya se llama Calendario. `headerTitle: ''` deja
+        // la barra vacía (transparente en iOS) para que el botón de
+        // suscribirse conviva con el conmutador Mes/Agenda de debajo.
+        options={{ headerTitle: '' }}
       />
     </CalStack.Navigator>
   );

--- a/mcm-app/app/(tabs)/index.tsx
+++ b/mcm-app/app/(tabs)/index.tsx
@@ -14,7 +14,6 @@ import {
   TouchableOpacity,
   Pressable,
   Linking,
-  Platform,
   useWindowDimensions,
 } from 'react-native';
 import Animated, {
@@ -45,14 +44,13 @@ import { VersionDisplay } from '@/components/VersionDisplay';
 import { SecretMenuTrigger } from '@/components/SecretMenuTrigger';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import { useUserProfile } from '@/contexts/UserProfileContext';
-import { setPendingMasScreen } from '@/utils/masNavigation';
+import { useTabNavigation } from '@/hooks/useTabNavigation';
 import { localISO } from '@/utils/localDate';
 import { hexAlpha } from '@/utils/colorUtils';
 import ScreenHero from '@/components/ui/ScreenHero';
 import EmptyState from '@/components/ui/EmptyState';
 import GlassActionGroup from '@/components/ui/GlassActionGroup';
 import PressableScale from '@/components/ui/PressableScale';
-import { setPendingEventScreen } from '@/utils/eventNavigation';
 import {
   DEFAULT_APP_EVALUATION,
   DEFAULT_EVENT_EVALUATION,
@@ -192,6 +190,13 @@ interface QuickItem {
   icon: ComponentProps<typeof MaterialIcons>['name'];
   iconBg: string;
   iconColor: string;
+  /**
+   * Nombre del TAB al que lleva. El camino (directo o entrando por "Más") lo
+   * resuelve `goToTab`, que sabe si el tab está en la barra. Antes cada entrada
+   * llevaba un `href` fijo y acertaba solo con algunos perfiles.
+   */
+  tab?: string;
+  /** Ruta literal, para destinos que no son un tab (sub-rutas, "Más"…). */
   href?: string;
   dashed?: boolean;
 }
@@ -200,6 +205,9 @@ export default function Home() {
   const navigation = useNavigation();
   // Compacta la barra de pestañas flotante al scrollear y reserva su hueco.
   const { scrollRef, onScroll, contentPaddingBottom } = useTabScroll('index');
+  // Navegación a tabs que tiene en cuenta si el tab está en la barra o en el
+  // overflow de "Más" (ver utils/tabNavigation.ts).
+  const { goToTab, goToEventScreen } = useTabNavigation();
   const scheme = useColorScheme();
   const theme = Colors[scheme ?? 'light'];
   // Color neutro de los iconos en la cápsula glass (igual que EventActionButtons).
@@ -413,10 +421,6 @@ export default function Home() {
     (g) => g.events.length > 0,
   );
 
-  // ¿El perfil tiene Comunica como tab propia? Cambia a dónde apunta el botón
-  // de la Home (tab vs. pantalla dentro del stack de "Más").
-  const comunicaIsTab = resolved.tabs.includes('comunica');
-
   // Quick grid items — filtrados por la config del perfil resuelto
   const quickItems = useMemo<QuickItem[]>(() => {
     const visible = new Set(resolved.homeButtons);
@@ -427,9 +431,7 @@ export default function Home() {
         icon: 'forum',
         iconBg: scheme === 'dark' ? '#3A2200' : '#FFF0E0',
         iconColor: '#E08A3C',
-        // Con Comunica como tab propia vamos directos a la tab; si el perfil no
-        // la tiene, se sigue abriendo la pantalla dentro del stack de "Más".
-        href: comunicaIsTab ? '/comunica' : '/mas',
+        tab: 'comunica',
       },
       cancionero: {
         key: 'cancionero',
@@ -437,7 +439,7 @@ export default function Home() {
         icon: 'music-note',
         iconBg: scheme === 'dark' ? '#1A1A3A' : '#E8E0FF',
         iconColor: '#6366F1',
-        href: '/cancionero',
+        tab: 'cancionero',
       },
       visitapapa: {
         key: 'visitapapa',
@@ -445,7 +447,8 @@ export default function Home() {
         icon: 'church',
         iconBg: scheme === 'dark' ? '#332B00' : '#FFF8D6',
         iconColor: '#C9A800',
-        href: '/visitapapa',
+        // El tab del evento en curso; su nombre lo pone el perfil, no está fijo.
+        tab: activeTabId || 'visitapapa',
       },
       fotos: {
         key: 'fotos',
@@ -453,7 +456,7 @@ export default function Home() {
         icon: 'image',
         iconBg: scheme === 'dark' ? '#0A2A1A' : '#D5F5E3',
         iconColor: '#34D399',
-        href: '/mas',
+        tab: 'fotos',
       },
       evangelio: {
         key: 'evangelio',
@@ -478,14 +481,7 @@ export default function Home() {
       .filter((id) => visible.has(id) && catalog[id])
       .filter((id) => !(eventArchived && id === activeTabId))
       .map((id) => catalog[id]);
-  }, [
-    resolved.homeButtons,
-    scheme,
-    theme.icon,
-    comunicaIsTab,
-    eventArchived,
-    activeTabId,
-  ]);
+  }, [resolved.homeButtons, scheme, theme.icon, eventArchived, activeTabId]);
 
   // Hide the tab navigator header — we render our own
   useLayoutEffect(() => {
@@ -568,20 +564,16 @@ export default function Home() {
   };
 
   // Navega al calendario (opcionalmente saltando a una fecha concreta).
-  // En iOS `calendario` es un tab "overflow" SIN trigger nativo (solo caben 5
-  // en la barra), por lo que `router.push('/calendario')` no funciona: hay que
-  // alcanzarlo a través del stack de "Más" igual que hace el acceso de Fotos.
-  // En Android/Web `calendario` es un tab real, así que navegamos directo.
+  //
+  // El camino lo decide `goToTab` mirando si `calendario` está DE VERDAD en la
+  // barra (ver utils/tabNavigation.ts). Antes esto miraba solo `Platform.OS`
+  // === 'ios' y entraba SIEMPRE por "Más": cuando el calendario sí cabía en la
+  // barra —que depende del perfil y de si hay evento en curso— se aterrizaba en
+  // el tab equivocado, y si el perfil no tenía "Más" no se llegaba a ninguna
+  // parte.
   const navigateToCalendar = (date?: string) => {
     h.tap();
-    if (Platform.OS === 'ios') {
-      setPendingMasScreen('Calendario', date ? { date } : undefined);
-      router.push('/mas');
-    } else if (date) {
-      router.push({ pathname: '/calendario', params: { date } } as any);
-    } else {
-      router.push('/calendario');
-    }
+    goToTab('calendario', date ? { date } : undefined);
   };
 
   return (
@@ -773,7 +765,11 @@ export default function Home() {
                 ]}
                 onPress={() => {
                   h.tap();
-                  router.push('/visitapapa');
+                  // El tab del evento lo dice el perfil (`tabId`), y puede estar
+                  // en la barra o en overflow: antes esto era un '/visitapapa'
+                  // fijo que no llevaba a ninguna parte en cuanto el evento no
+                  // cabía en la barra.
+                  goToTab(activeTabId || 'visitapapa');
                 }}
                 accessibilityRole="button"
                 accessibilityLabel={activeEvent.title}
@@ -827,10 +823,10 @@ export default function Home() {
                 style={[styles.evalCta, { backgroundColor: colors.accent }]}
                 onPress={() => {
                   h.tap();
-                  setPendingEventScreen('Evaluacion', {
-                    eventId: activeEvent.id,
-                  });
-                  router.push(`/${activeTabId}` as any);
+                  // Entra por el tab del evento si tiene ruta propia y por
+                  // "Más" si está en overflow (allí están registradas las
+                  // mismas pantallas de evento).
+                  goToEventScreen('Evaluacion', { eventId: activeEvent.id });
                 }}
                 activeOpacity={0.9}
                 accessibilityRole="button"
@@ -1074,12 +1070,10 @@ export default function Home() {
                     accessibilityRole="button"
                     onPress={() => {
                       h.tap();
-                      if (item.key === 'comunica' && !comunicaIsTab) {
-                        setPendingMasScreen('Comunica');
-                      } else if (item.key === 'fotos') {
-                        setPendingMasScreen('Fotos');
-                      }
-                      if (item.href) router.push(item.href as any);
+                      // `goToTab` resuelve el camino según la barra real; los
+                      // destinos que no son un tab siguen con su ruta literal.
+                      if (item.tab) goToTab(item.tab);
+                      else if (item.href) router.push(item.href as any);
                     }}
                   >
                     <View

--- a/mcm-app/app/screens/MasHomeScreen.tsx
+++ b/mcm-app/app/screens/MasHomeScreen.tsx
@@ -15,8 +15,10 @@ import AppFeedbackModal from '@/components/AppFeedbackModal';
 import { MasStackParamList } from '../(tabs)/mas';
 import { useResolvedProfileConfig } from '@/hooks/useResolvedProfileConfig';
 import { useVisibleTabs } from '@/hooks/useVisibleTabs';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
 import { useAdminStatus } from '@/hooks/useAdminStatus';
 import { takePendingMasScreen } from '@/utils/masNavigation';
+import { MAS_EVENT_HUB_SCREEN, MAS_STACK_MIRROR } from '@/utils/tabNavigation';
 import PageContainer from '@/components/ui/PageContainer';
 import ScreenHero from '@/components/ui/ScreenHero';
 import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
@@ -108,6 +110,8 @@ export default function MasHomeScreen() {
   const useTwoColumns = layout.isWide;
   const resolved = useResolvedProfileConfig();
   const visibleTabs = useVisibleTabs();
+  const { activeEvent } = useActiveMeta();
+  const eventTabId = activeEvent.tabId;
   const { isAdmin } = useAdminStatus();
   const navigationItems = React.useMemo(() => {
     const items: NavigationItem[] = [];
@@ -118,18 +122,20 @@ export default function MasHomeScreen() {
     // todos, así que ahí no hay overflow que recoger.
     if (Platform.OS !== 'web') {
       const { overflowTabs } = splitTabsForBar(visibleTabs);
-      // Tabs cuyo screen está registrado en el stack de Más (no accesibles vía router.navigate en iOS)
-      const OVERFLOW_STACK_TARGETS: Partial<
-        Record<string, keyof MasStackParamList>
-      > = {
-        fotos: 'Fotos',
-        calendario: 'Calendario',
-      };
       for (const tab of overflowTabs) {
         // 'mas' nunca debería estar en overflow (splitTabsForBar lo garantiza),
         // pero filtramos defensivamente para no auto-referenciar esta pantalla.
         if (tab.name === 'mas') continue;
-        const stackTarget = OVERFLOW_STACK_TARGETS[tab.name];
+        // Espejos en el stack de "Más" — el MISMO mapa que usa `goToTab` desde
+        // la Home (`utils/tabNavigation.ts`). Tener dos listas era pedir que
+        // divergieran: un tab con espejo aquí y sin él allí (o al revés) es un
+        // botón que no lleva a ninguna parte en iOS, donde los tabs de overflow
+        // NO tienen ruta registrada.
+        const stackTarget = (MAS_STACK_MIRROR[tab.name] ??
+          // El tab del evento en curso no puede estar en el mapa (su nombre lo
+          // pone el perfil): su espejo es el hub genérico + su eventId.
+          (tab.name === eventTabId ? MAS_EVENT_HUB_SCREEN : undefined)) as
+          keyof MasStackParamList | undefined;
         items.push({
           label: tab.label,
           subtitle: tab.subtitle,
@@ -137,7 +143,10 @@ export default function MasHomeScreen() {
           materialIcon: tab.androidIcon,
           tintColor: tab.tintColor,
           ...(stackTarget
-            ? { target: stackTarget }
+            ? {
+                target: stackTarget,
+                ...(tab.name === eventTabId ? { eventId: activeEvent.id } : {}),
+              }
             : { routePath: `/${tab.name}` }),
         });
       }
@@ -153,7 +162,7 @@ export default function MasHomeScreen() {
     }
 
     return items;
-  }, [resolved.masItems, visibleTabs, isAdmin]);
+  }, [resolved.masItems, visibleTabs, isAdmin, eventTabId, activeEvent.id]);
 
   // Deep-link desde la Home: si hay una pantalla pendiente, navegar a ella
   useFocusEffect(
@@ -221,8 +230,12 @@ export default function MasHomeScreen() {
                 ]}
                 onPress={() => {
                   if (item.routePath) {
-                    // Overflow de tab: salta al tab sibling vía expo-router.
-                    // La ruta sigue existiendo aunque no tenga NativeTabs.Trigger.
+                    // Último recurso: saltar al tab sibling por expo-router.
+                    // OJO en iOS: un tab de overflow NO tiene ruta registrada
+                    // (IOSTabsLayout solo crea un NativeTabs.Trigger por tab de
+                    // la barra), así que esto solo funciona en Android/web. Por
+                    // eso lo normal es tener `target` — un espejo en este mismo
+                    // stack. Ver utils/tabNavigation.ts.
                     router.navigate(item.routePath as any);
                     return;
                   }

--- a/mcm-app/app/screens/SongDetailScreen.tsx
+++ b/mcm-app/app/screens/SongDetailScreen.tsx
@@ -257,6 +257,8 @@ export default function SongDetailScreen({
   const [showMediaSheet, setShowMediaSheet] = useState(false);
   const [floatingMedia, setFloatingMedia] =
     useState<FloatingMediaSource | null>(null);
+  // Fuente elegida en la hoja que espera a que la hoja termine de cerrarse.
+  const pendingMediaRef = useRef<FloatingMediaSource | null>(null);
 
   // Al cambiar de canción (swipe) se resetean los estados efímeros: se cierra
   // el cajón de multimedia —el reproductor flotante NO, que sobrevive porque es
@@ -656,9 +658,20 @@ export default function SongDetailScreen({
         onClose={() => setShowMediaSheet(false)}
         media={media}
         songTitle={_navScreenTitle}
+        // Al pulsar reproducir NO se abre el reproductor todavía: se apunta la
+        // fuente y se cierra la hoja. El reproductor nace cuando la hoja ya está
+        // desmontada (`onCloseComplete`), porque en iOS la hoja es un Modal en
+        // su propia ventana: aparecer por debajo de él dejaba el reproductor
+        // tapado y el WebView arrancando en una ventana que no se ve.
         onPlayMedia={(source) => {
+          pendingMediaRef.current = source;
           setShowMediaSheet(false);
-          setFloatingMedia(source);
+        }}
+        onCloseComplete={() => {
+          const pending = pendingMediaRef.current;
+          if (!pending) return;
+          pendingMediaRef.current = null;
+          setFloatingMedia(pending);
         }}
       />
       <FloatingMediaPlayer

--- a/mcm-app/components/contigo/HighlightableReading.tsx
+++ b/mcm-app/components/contigo/HighlightableReading.tsx
@@ -24,9 +24,13 @@ interface HighlightableReadingProps {
   text: string;
   /** Rangos subrayados (offsets sobre el texto canónico). */
   ranges?: HighlightRange[];
-  /** Modo subrayar: activa el reporte de selección para pintar. */
+  /** Modo subrayar: en Android cambia a TextInput para conocer los offsets. */
   penMode?: boolean;
-  /** Selección nativa actual (null si no hay o es vacía). */
+  /**
+   * Selección nativa actual (null si no hay o es vacía). Se reporta SIEMPRE que
+   * el texto sea un `TextInput` (en iOS, los dos modos), no solo en modo lápiz:
+   * así el botón de subrayar puede usar la selección que ya hubiera hecha.
+   */
   onSelectionChange?: (sel: ReadingSelection | null) => void;
   /**
    * "Subrayar" desde el menú NATIVO de selección, sin pasar por el modo lápiz.
@@ -66,10 +70,14 @@ interface HighlightableReadingProps {
  *
  * ## Por plataforma
  *
- * - **iOS**: `TextInput` de solo lectura en los dos modos.
+ * - **iOS**: `TextInput` de solo lectura en los dos modos. Como la capa es la
+ *   misma, la selección se conoce SIEMPRE: se puede seleccionar y tocar después
+ *   el botón de subrayar, sin tener que entrar antes en el modo lápiz.
  * - **Android**: `Text selectable` al leer (menú nativo de copiar sin riesgo de
  *   pegar dentro) y `TextInput` al subrayar (única forma de conocer los
- *   offsets exactos de la selección).
+ *   offsets exactos de la selección). Ahí el camino de "selecciono y luego toco
+ *   el lápiz" no puede funcionar —un `Text` no reporta offsets—; el atajo bueno
+ *   en Android es el ítem "Subrayar" del propio menú de selección.
  * - **Web**: `Text` seleccionable al leer (selección del navegador) y
  *   `TextInput` con `value` al subrayar — RNW no admite hijos en el textarea,
  *   así que ahí el color se ve al salir del modo subrayar.
@@ -97,13 +105,12 @@ export function HighlightableReading({
   // que crezca como un texto normal dentro del scroll.
   const [inputHeight, setInputHeight] = useState<number | undefined>(undefined);
 
-  // Al salir del modo subrayar (o desmontar), la selección deja de existir.
+  // Al desmontar, la selección deja de existir. (Al SALIR del modo lápiz no se
+  // toca: la selección es "pegajosa" a propósito, ver useReadingHighlights, y
+  // quien la limpia de verdad es `exitHighlightMode` en la pantalla.)
   const onSelRef = useRef(onSelectionChange);
   onSelRef.current = onSelectionChange;
-  useEffect(() => {
-    if (!penMode) onSelRef.current?.(null);
-    return () => onSelRef.current?.(null);
-  }, [penMode]);
+  useEffect(() => () => onSelRef.current?.(null), []);
 
   const textStyle = {
     color,
@@ -187,10 +194,17 @@ export function HighlightableReading({
         setInputHeight(Math.ceil(e.nativeEvent.contentSize.height))
       }
       onSelectionChange={(e) => {
-        if (!penMode) return;
+        // Se reporta SIEMPRE, también fuera del modo lápiz. Es lo que permite
+        // seleccionar primero y tocar el lápiz después: si solo escucháramos
+        // dentro del modo, la selección que ya había era invisible para JS y la
+        // barra salía pidiendo "selecciona un texto" hasta que la movías un pelo.
         const { start, end } = e.nativeEvent.selection;
+        // `end !== start`, no `end > start`: arrastrando de derecha a izquierda
+        // Android reporta los offsets al revés, y con el `>` la selección se
+        // descartaba como vacía (el Math.min/Math.max de al lado nunca llegaba
+        // a ejecutarse).
         onSelRef.current?.(
-          end > start
+          end !== start
             ? { start: Math.min(start, end), end: Math.max(start, end) }
             : null,
         );

--- a/mcm-app/components/song-media/FloatingMediaPlayer.tsx
+++ b/mcm-app/components/song-media/FloatingMediaPlayer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
+  ActivityIndicator,
   LayoutAnimation,
   Linking,
   Platform,
@@ -39,10 +40,13 @@ const YT_RED = '#FF3B30';
 const PLAYER_WIDTH = 208;
 // 16:9 → 208 * 9 / 16 ≈ 117 (igual que `.ytf-screen` del diseño).
 const VIDEO_HEIGHT = Math.round((PLAYER_WIDTH * 9) / 16);
-// Audio de Drive: barra de reproducción compacta, no necesita tanto alto
-// como el vídeo pero sí casi todo el ancho disponible (el player de Drive
-// se ve apretado en un ancho tan estrecho como el del PiP de vídeo).
-const AUDIO_HEIGHT = 64;
+// Audio de Drive: no necesita tanto alto como el vídeo, pero sí casi todo el
+// ancho disponible (el player de Drive se ve apretado en un ancho tan estrecho
+// como el del PiP de vídeo) y bastante más de 64pt: el iframe de `/preview` de
+// Drive pinta su propia cabecera encima de los controles, así que con 64 se veía
+// una franja negra SIN el botón de play — o sea, indistinguible de "no pasa
+// nada".
+const AUDIO_HEIGHT = 116;
 const SIDE_MARGIN = 14;
 
 /**
@@ -71,6 +75,15 @@ function isYouTubeWatchUrl(url: string): boolean {
 }
 
 /**
+ * URL para abrir un audio FUERA de la app. El embed de Drive es `/preview`, que
+ * fuera del iframe no siempre resuelve; `/view` es la página normal del fichero
+ * y la captura la app de Drive por universal link.
+ */
+function toDriveViewUrl(previewUrl: string): string {
+  return previewUrl.replace(/\/preview(\?.*)?$/, '/view');
+}
+
+/**
  * Reproductor flotante multimedia (estilo PiP de iOS) que se superpone a la
  * letra sin taparla del todo y se puede arrastrar por la pantalla. Reproduce
  * vídeos de YouTube (embed con Referer real) y audios de Google Drive
@@ -90,6 +103,12 @@ export default function FloatingMediaPlayer({
   // Se apoya sobre la barra de pestañas flotante, que ya incluye el inset.
   const tabBarClearance = useTabBarClearance();
   const [fullscreen, setFullscreen] = useState(false);
+  // Estado de carga del embed. Sin esto, un embed que tarda o que falla se ve
+  // como un rectángulo negro y no hay forma de distinguir "cargando" de "roto"
+  // ni salida posible: ahora se avisa y se ofrece abrirlo fuera.
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>(
+    'loading',
+  );
 
   // Drag (arrastre) + animación de entrada.
   const panX = useSharedValue(0);
@@ -113,6 +132,16 @@ export default function FloatingMediaPlayer({
       panX.value = startX.value + e.translationX;
       panY.value = startY.value + e.translationY;
     });
+
+  // Fuente nueva → vuelta a "cargando". Se ajusta DURANTE el render (el patrón
+  // que documenta React para "cambiar estado cuando cambia una prop") en vez de
+  // en el efecto de abajo: así no hay un render intermedio mostrando el estado
+  // de la fuente anterior.
+  const [lastUrl, setLastUrl] = useState(source?.url);
+  if (source?.url !== lastUrl) {
+    setLastUrl(source?.url);
+    setLoadState('loading');
+  }
 
   // Al abrir una nueva fuente: reset de posición + animación de entrada.
   useEffect(() => {
@@ -167,6 +196,19 @@ export default function FloatingMediaPlayer({
     setFullscreen((f) => !f);
   }, []);
 
+  /** Abre la fuente fuera de la app: YouTube o Drive, según el tipo. */
+  const openOutside = useCallback(() => {
+    if (!source) return;
+    h.tap();
+    if (source.kind === 'youtube') {
+      void openInYouTube(extractYouTubeId(source.url));
+      return;
+    }
+    Linking.openURL(toDriveViewUrl(source.url)).catch(() => {
+      /* sin Drive ni navegador no hay nada que hacer */
+    });
+  }, [source, openInYouTube]);
+
   if (!source) return null;
 
   const isVideo = source.kind === 'youtube';
@@ -204,6 +246,8 @@ export default function FloatingMediaPlayer({
         allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
         allowFullScreen
         title={source.label}
+        onLoad={() => setLoadState('ready')}
+        onError={() => setLoadState('error')}
       />
     ) : (
       <WebView
@@ -221,6 +265,12 @@ export default function FloatingMediaPlayer({
         javaScriptEnabled
         domStorageEnabled
         setSupportMultipleWindows={false}
+        // Una vez que el embed ha cargado ya no se degrada a error: algunos
+        // subrecursos del player de YouTube/Drive devuelven 4xx sin que la
+        // reproducción se vea afectada.
+        onLoadEnd={() => setLoadState((s) => (s === 'error' ? s : 'ready'))}
+        onError={() => setLoadState((s) => (s === 'ready' ? s : 'error'))}
+        onHttpError={() => setLoadState((s) => (s === 'ready' ? s : 'error'))}
         onShouldStartLoadWithRequest={(req) => {
           // Cualquier intento de salir del embed hacia la página de vídeo
           // (p.ej. tocar el logo o el "Ver en YouTube" del propio player) se
@@ -239,19 +289,23 @@ export default function FloatingMediaPlayer({
       <Text style={styles.barLabel} numberOfLines={1}>
         {source.label}
       </Text>
-      {isVideo && (
-        <TouchableOpacity
-          onPress={() => {
-            h.tap();
-            void openInYouTube(videoId);
-          }}
-          style={styles.barBtn}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          accessibilityLabel="Abrir en la app de YouTube"
-        >
-          <MaterialIcons name="smart-display" size={13} color={YT_RED} />
-        </TouchableOpacity>
-      )}
+      {/* Salida a la app externa: YouTube para vídeo, Drive para audio. El
+          audio no la tenía, así que si el embed de Drive no arrancaba no había
+          ninguna forma de llegar a la pista. */}
+      <TouchableOpacity
+        onPress={openOutside}
+        style={styles.barBtn}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityLabel={
+          isVideo ? 'Abrir en la app de YouTube' : 'Abrir en Google Drive'
+        }
+      >
+        <MaterialIcons
+          name={isVideo ? 'smart-display' : 'open-in-new'}
+          size={isVideo ? 13 : 14}
+          color={isVideo ? YT_RED : '#fff'}
+        />
+      </TouchableOpacity>
       {isVideo && (
         <TouchableOpacity
           onPress={toggleFullscreen}
@@ -315,6 +369,31 @@ export default function FloatingMediaPlayer({
       >
         <View style={fullscreen ? styles.fsVideoInner : styles.videoFill}>
           {videoSurface}
+          {/* Cargando / no se pudo cargar. Va ENCIMA del embed (no en su lugar)
+              para no desmontarlo: si termina de cargar, el overlay se va y la
+              reproducción sigue. */}
+          {loadState !== 'ready' && (
+            <View style={styles.stateOverlay} pointerEvents="box-none">
+              {loadState === 'loading' ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <TouchableOpacity
+                  onPress={openOutside}
+                  style={styles.errorBtn}
+                  accessibilityLabel={
+                    isVideo
+                      ? 'No se pudo cargar aquí: abrir en YouTube'
+                      : 'No se pudo cargar aquí: abrir en Drive'
+                  }
+                >
+                  <MaterialIcons name="open-in-new" size={16} color="#fff" />
+                  <Text style={styles.errorText} numberOfLines={2}>
+                    No se pudo cargar aquí.{'\n'}Toca para abrirlo fuera.
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          )}
         </View>
       </View>
     </Animated.View>
@@ -374,6 +453,25 @@ const styles = StyleSheet.create({
   },
   videoFill: {
     flex: 1,
+  },
+  stateOverlay: {
+    ...StyleSheet.absoluteFill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.55)',
+  },
+  errorBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  errorText: {
+    fontSize: 11,
+    fontWeight: '600',
+    lineHeight: 15,
+    color: '#fff',
   },
   fsVideoArea: {
     flex: 1,

--- a/mcm-app/components/song-media/SongMediaSheet.tsx
+++ b/mcm-app/components/song-media/SongMediaSheet.tsx
@@ -28,6 +28,13 @@ interface SongMediaSheetProps {
   songTitle?: string;
   /** Abre el reproductor flotante con la fuente indicada (vídeo o audio). */
   onPlayMedia: (source: FloatingMediaSource) => void;
+  /**
+   * Se llama cuando la hoja ya está DESMONTADA del todo (no solo cerrándose).
+   * Es el gancho para mostrar el reproductor: en iOS la hoja es un `Modal` de
+   * verdad, presentado en su propia ventana, así que cualquier cosa que aparezca
+   * mientras sigue montado nace tapada.
+   */
+  onCloseComplete?: () => void;
 }
 
 const YT_RED = '#FF3B30';
@@ -52,6 +59,7 @@ export default function SongMediaSheet({
   media,
   songTitle,
   onPlayMedia,
+  onCloseComplete,
 }: SongMediaSheetProps) {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
@@ -195,7 +203,12 @@ export default function SongMediaSheet({
   };
 
   return (
-    <BottomSheet visible={visible} onClose={onClose} title="Multimedia y ficha">
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      onCloseComplete={onCloseComplete}
+      title="Multimedia y ficha"
+    >
       <ScrollView
         style={{ maxHeight: SCREEN_HEIGHT * 0.62 }}
         showsVerticalScrollIndicator={false}

--- a/mcm-app/eslint.config.js
+++ b/mcm-app/eslint.config.js
@@ -18,12 +18,15 @@ module.exports = defineConfig([
       // console internamente (excepción abajo). Migración completada (0
       // console.* en el código), así que ya bloquea como error.
       'no-console': 'error',
-      // Señala archivos nuevos demasiado grandes SIN bloquear los legacy
-      // (es 'warn', no 'error'). Ver docs/planes/PLAN_CALIDAD.md §0.1: cuando
-      // la Fase 1 termine de trocear los gigantes, subir a 'error' con max 800.
+      // Techo de tamaño de archivo. Subido de 400 a 1000 el 2026-08-08: con
+      // agentes de IA leyendo y editando el código, un archivo largo pero
+      // coherente cuesta menos que la misma lógica repartida en seis ficheros
+      // que hay que reconstruir mentalmente. Los gigantes que ya había se
+      // quedan como están; el aviso ahora solo salta cuando un archivo se va
+      // DE VERDAD de las manos. Sigue siendo 'warn', no 'error'.
       'max-lines': [
         'warn',
-        { max: 400, skipBlankLines: true, skipComments: true },
+        { max: 1000, skipBlankLines: true, skipComments: true },
       ],
     },
   },

--- a/mcm-app/hooks/useReadingHighlights.ts
+++ b/mcm-app/hooks/useReadingHighlights.ts
@@ -91,14 +91,32 @@ export function useReadingHighlights(
     sel: ReadingSelection;
   } | null>(null);
 
-  // "Pegajosa": nos quedamos con la ÚLTIMA selección no vacía. Al tocar un chip
-  // de color, iOS puede colapsar la selección nativa antes de que llegue el
-  // onPress — si la vaciáramos aquí, el color no tendría a qué aplicarse.
+  // "Pegajosa": nos quedamos con la ÚLTIMA selección no vacía. Dos motivos:
+  //  1. Al tocar un chip de color, iOS puede colapsar la selección nativa antes
+  //     de que llegue el onPress — si la vaciáramos aquí, el color no tendría a
+  //     qué aplicarse.
+  //  2. El texto reporta su selección TAMBIÉN fuera del modo lápiz, así que al
+  //     tocar el botón de subrayar ya sabemos qué había seleccionado aunque el
+  //     propio toque en el botón haya deshecho la selección nativa.
+  //
+  // Si la selección no ha cambiado devolvemos el MISMO objeto: arrastrar las
+  // asas dispara el evento decenas de veces y así no se re-renderiza de más.
   const onSelectionChange = useMemo(
     () =>
       bySource(
         (source) => (sel: ReadingSelection | null) =>
-          setActiveSel((prev) => (sel ? { source, sel } : prev)),
+          setActiveSel((prev) => {
+            if (!sel) return prev;
+            if (
+              prev &&
+              prev.source === source &&
+              prev.sel.start === sel.start &&
+              prev.sel.end === sel.end
+            ) {
+              return prev;
+            }
+            return { source, sel };
+          }),
       ),
     [],
   );

--- a/mcm-app/hooks/useTabNavigation.ts
+++ b/mcm-app/hooks/useTabNavigation.ts
@@ -1,0 +1,89 @@
+// hooks/useTabNavigation.ts
+// Navegación a tabs que NO se equivoca de camino. Ver `utils/tabNavigation.ts`
+// para el porqué (en iOS los tabs de overflow no tienen ruta registrada).
+
+import { useCallback } from 'react';
+import { Platform } from 'react-native';
+import { router } from 'expo-router';
+
+import { useVisibleTabs } from '@/hooks/useVisibleTabs';
+import { useActiveMeta } from '@/contexts/ActiveEventContext';
+import { setPendingMasScreen } from '@/utils/masNavigation';
+import { setPendingEventScreen } from '@/utils/eventNavigation';
+import {
+  resolveEventScreenRoute,
+  resolveTabRoute,
+} from '@/utils/tabNavigation';
+
+export interface TabNavigation {
+  /** Va al tab indicado, entrando por "Más" si allí no tiene ruta propia. */
+  goToTab: (tabName: string, params?: Record<string, unknown>) => void;
+  /**
+   * Va a una pantalla del stack del evento en curso (Evaluación, Reflexiones…),
+   * por su tab si lo tiene o por "Más" si está en overflow.
+   */
+  goToEventScreen: (screen: string, params?: Record<string, unknown>) => void;
+}
+
+export function useTabNavigation(): TabNavigation {
+  const visibleTabs = useVisibleTabs();
+  const { activeEvent } = useActiveMeta();
+  const eventTab = activeEvent.tabId
+    ? { tabName: activeEvent.tabId, eventId: activeEvent.id }
+    : undefined;
+  const eventTabName = eventTab?.tabName;
+  const eventId = eventTab?.eventId;
+
+  const goToTab = useCallback(
+    (tabName: string, params?: Record<string, unknown>) => {
+      const route = resolveTabRoute(tabName, visibleTabs, {
+        platform: Platform.OS,
+        params,
+        ...(eventTabName && eventId
+          ? { eventTab: { tabName: eventTabName, eventId } }
+          : {}),
+      });
+
+      if (route.via === 'tab') {
+        if (route.params) {
+          router.push({ pathname: route.path, params: route.params } as never);
+        } else {
+          router.push(route.path as never);
+        }
+        return;
+      }
+
+      // Por el stack de "Más": se apunta el destino y MasHomeScreen lo consume
+      // al enfocarse (`utils/masNavigation.ts`).
+      if (route.via === 'masScreen') {
+        setPendingMasScreen(route.screen as never, route.params);
+      }
+      router.push('/mas');
+    },
+    [visibleTabs, eventTabName, eventId],
+  );
+
+  const goToEventScreen = useCallback(
+    (screen: string, params?: Record<string, unknown>) => {
+      if (!eventTabName || !eventId) return;
+      const route = resolveEventScreenRoute(
+        screen,
+        { tabName: eventTabName, eventId },
+        visibleTabs,
+        Platform.OS,
+      );
+      if (route.via === 'eventTab') {
+        setPendingEventScreen(screen, params);
+        router.push(route.path as never);
+        return;
+      }
+      setPendingMasScreen(route.screen as never, params);
+      router.push('/mas');
+    },
+    [visibleTabs, eventTabName, eventId],
+  );
+
+  return { goToTab, goToEventScreen };
+}
+
+export default useTabNavigation;

--- a/mcm-app/modules/highlight-menu/android/src/main/java/expo/modules/highlightmenu/HighlightMenuView.kt
+++ b/mcm-app/modules/highlight-menu/android/src/main/java/expo/modules/highlightmenu/HighlightMenuView.kt
@@ -39,6 +39,7 @@ class HighlightMenuView(context: Context, appContext: AppContext) :
   var menuEnabled: Boolean = true
 
   private var attachedTextView: TextView? = null
+  private var attachedCallback: HighlightActionModeCallback? = null
 
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     super.onLayout(changed, l, t, r, b)
@@ -47,17 +48,46 @@ class HighlightMenuView(context: Context, appContext: AppContext) :
   }
 
   override fun onDetachedFromWindow() {
-    attachedTextView?.customSelectionActionModeCallback = null
-    attachedTextView = null
+    detach()
     super.onDetachedFromWindow()
   }
 
+  /** Devuelve al TextView el callback que tuviera antes del nuestro. */
+  private fun detach() {
+    val textView = attachedTextView
+    val callback = attachedCallback
+    if (textView != null && textView.customSelectionActionModeCallback === callback) {
+      textView.customSelectionActionModeCallback = callback?.original
+    }
+    attachedTextView = null
+    attachedCallback = null
+  }
+
   private fun attachIfNeeded() {
-    if (attachedTextView != null) return
     val textView = findTextView(this) ?: return
-    textView.customSelectionActionModeCallback =
-      HighlightActionModeCallback(textView, textView.customSelectionActionModeCallback)
+
+    // Ya enganchado a ESTE TextView y con nuestro callback en su sitio.
+    if (textView === attachedTextView &&
+      textView.customSelectionActionModeCallback === attachedCallback
+    ) {
+      return
+    }
+
+    // Llegar aquí significa que el TextView cambió o que alguien reasignó el
+    // callback (React Native lo hace al recrear el Text/TextInput). Sin el
+    // reintento, el ítem del menú desaparecía al remontarse el texto —cambio de
+    // día, de fuente, de modo— y no volvía.
+    detach()
+
+    val previous = textView.customSelectionActionModeCallback
+    // Nunca encadenar callbacks nuestros: si el que hay ya es uno nuestro, nos
+    // quedamos con el original que él envolvía.
+    val original =
+      if (previous is HighlightActionModeCallback) previous.original else previous
+    val callback = HighlightActionModeCallback(textView, original)
+    textView.customSelectionActionModeCallback = callback
     attachedTextView = textView
+    attachedCallback = callback
   }
 
   private fun findTextView(view: View): TextView? {
@@ -75,7 +105,7 @@ class HighlightMenuView(context: Context, appContext: AppContext) :
    */
   private inner class HighlightActionModeCallback(
     private val target: TextView,
-    private val original: ActionMode.Callback?,
+    val original: ActionMode.Callback?,
   ) : ActionMode.Callback {
 
     override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {

--- a/mcm-app/modules/highlight-menu/index.ts
+++ b/mcm-app/modules/highlight-menu/index.ts
@@ -7,7 +7,10 @@
 //
 // Ver `docs/funcionalidades/SUBRAYADO.md`.
 
-export { default as HighlightMenuView } from './src/HighlightMenuView';
+export {
+  default as HighlightMenuView,
+  isHighlightMenuAvailable,
+} from './src/HighlightMenuView';
 export type {
   HighlightMenuViewProps,
   HighlightRequest,

--- a/mcm-app/modules/highlight-menu/ios/HighlightMenuView.swift
+++ b/mcm-app/modules/highlight-menu/ios/HighlightMenuView.swift
@@ -54,16 +54,38 @@ final class HighlightMenuView: ExpoView {
   deinit {
     // Devolver el delegate original: si esta vista se va y dejamos el proxy
     // puesto, el text view quedaría hablando con un objeto muerto.
+    detach()
+  }
+
+  /// Suelta el text view al que estuviéramos enganchados, devolviéndole su
+  /// delegate original si el nuestro sigue puesto.
+  private func detach() {
     if let textView = attachedTextView, textView.delegate === proxy {
       textView.delegate = proxy?.original
     }
+    attachedTextView = nil
+    proxy = nil
   }
 
   private func attachIfNeeded() {
-    guard attachedTextView == nil, let textView = Self.findTextView(in: self) else { return }
+    guard let textView = Self.findTextView(in: self) else { return }
+
+    // Ya enganchado a ESTE text view y con el proxy todavía en su sitio.
+    if textView === attachedTextView, let proxy = proxy, textView.delegate === proxy {
+      return
+    }
+
+    // Llegar aquí con algo enganchado significa que el text view cambió o que
+    // React Native se REASIGNÓ el delegate (lo hace al recrear o reconfigurar
+    // el TextInput). Sin este reintento, el ítem del menú desaparecía en cuanto
+    // el texto se volvía a montar —cambio de día, de fuente, de modo— y no
+    // volvía hasta reiniciar la app.
+    detach()
 
     let proxy = TextViewDelegateProxy()
-    proxy.original = textView.delegate
+    // Nunca encadenar proxies: si el delegate que hay ya es uno nuestro (de una
+    // vista que se está desmontando), nos quedamos con SU original.
+    proxy.original = (textView.delegate as? TextViewDelegateProxy)?.original ?? textView.delegate
     proxy.makeMenu = { [weak self] range, base in
       guard let self = self, self.menuEnabled, range.length > 0 else { return base }
       let action = UIAction(

--- a/mcm-app/modules/highlight-menu/src/HighlightMenuView.tsx
+++ b/mcm-app/modules/highlight-menu/src/HighlightMenuView.tsx
@@ -1,10 +1,33 @@
-import { requireNativeView } from 'expo';
+import { requireNativeView, requireOptionalNativeModule } from 'expo';
 import * as React from 'react';
+import { View } from 'react-native';
 
 import type { HighlightMenuViewProps } from './HighlightMenu.types';
 
-const NativeView = requireNativeView<HighlightMenuViewProps>('HighlightMenu');
+/**
+ * ¿Está el módulo nativo DENTRO de este binario?
+ *
+ * Hace falta preguntarlo porque el ítem del menú es código nativo y no viaja
+ * por OTA: un bundle nuevo puede caer sobre un binario viejo. Y si el módulo no
+ * está, `requireNativeView` NO lanza — devuelve un componente cuyo nombre de
+ * vista nativa no existe, así que React Native lo sustituye por su placeholder
+ * de "componente sin implementar". Como esta vista ENVUELVE el texto de la
+ * lectura, eso se llevaría por delante el render del texto.
+ *
+ * Con el módulo ausente devolvemos un `View` pelado: se pierde el ítem del menú
+ * (que sin nativo no puede existir) y NADA más — el modo lápiz sigue entero.
+ */
+export const isHighlightMenuAvailable =
+  requireOptionalNativeModule('HighlightMenu') != null;
+
+const NativeView = isHighlightMenuAvailable
+  ? requireNativeView<HighlightMenuViewProps>('HighlightMenu')
+  : null;
 
 export default function HighlightMenuView(props: HighlightMenuViewProps) {
+  if (!NativeView) {
+    const { style, children } = props;
+    return <View style={style}>{children}</View>;
+  }
   return <NativeView {...props} />;
 }

--- a/mcm-app/modules/highlight-menu/src/HighlightMenuView.web.tsx
+++ b/mcm-app/modules/highlight-menu/src/HighlightMenuView.web.tsx
@@ -3,6 +3,9 @@ import { View } from 'react-native';
 
 import type { HighlightMenuViewProps } from './HighlightMenu.types';
 
+/** En web nunca hay módulo nativo, así que el ítem del menú no existe. */
+export const isHighlightMenuAvailable = false;
+
 /**
  * En web no hay menú nativo de selección que personalizar: la vista es un
  * contenedor transparente y el subrayado se hace con el modo lápiz de siempre.

--- a/mcm-app/utils/tabNavigation.ts
+++ b/mcm-app/utils/tabNavigation.ts
@@ -79,7 +79,24 @@ export function resolveTabRoute(
     ...(params && { params }),
   };
 
+  const { mainTabs } = splitTabsForBar(visibleTabs);
+
+  /**
+   * ¿Ese tab tiene ruta registrada AQUÍ? En iOS solo los de la barra
+   * (`NativeTabs.Trigger`); en Android y web, todos los visibles del perfil.
+   */
+  const hasRoute = (name: string) =>
+    platform === 'ios'
+      ? mainTabs.some((tab) => tab.name === name)
+      : visibleTabs.has(name);
+
   const viaMas = (): TabRoute => {
+    // Entrar por "Más" exige que "Más" TENGA ruta: si el perfil no lo trae, o no
+    // cabe en la barra en iOS, `router.push('/mas')` es otro no-op. En ese caso
+    // el intento directo es lo mejor que hay — en Android/web funciona, y en iOS
+    // no hay ningún camino, así que no se pierde nada.
+    if (!hasRoute('mas')) return direct;
+
     const mirror = MAS_STACK_MIRROR[tabName];
     if (mirror)
       return { via: 'masScreen', screen: mirror, ...(params && { params }) };
@@ -93,15 +110,11 @@ export function resolveTabRoute(
     return { via: 'masRoot' };
   };
 
-  // El perfil no muestra ese tab: no hay ruta que pushear ni en Android/web.
-  // Aun así el espejo de "Más" puede existir (mas.tsx registra Fotos,
-  // Calendario y Comunica siempre), y es mejor eso que quedarse quieto.
-  if (!visibleTabs.has(tabName)) return viaMas();
-
-  if (platform !== 'ios') return direct;
-
-  const { mainTabs } = splitTabsForBar(visibleTabs);
-  return mainTabs.some((tab) => tab.name === tabName) ? direct : viaMas();
+  // Un tab sin ruta aquí puede ser de overflow (iOS) o directamente no estar en
+  // el perfil (evento archivado, calendario apagado…). En los dos casos el
+  // espejo de "Más" es la salida: `mas.tsx` registra Fotos, Calendario, Comunica
+  // y las pantallas de evento SIEMPRE, mire el perfil lo que mire.
+  return hasRoute(tabName) ? direct : viaMas();
 }
 
 /**

--- a/mcm-app/utils/tabNavigation.ts
+++ b/mcm-app/utils/tabNavigation.ts
@@ -1,0 +1,125 @@
+// utils/tabNavigation.ts
+// Cómo llegar a un TAB desde cualquier sitio (la Home, sobre todo).
+//
+// ## El problema que resuelve
+//
+// En **iOS** el navegador de pestañas es `NativeTabs`, y `IOSTabsLayout` solo
+// registra un `NativeTabs.Trigger` por cada tab que cabe en la barra
+// (`splitTabsForBar`, tope `MAX_TAB_BAR_ITEMS`). Los que se quedan fuera **no
+// tienen ruta**: `router.push('/calendario')` no hace absolutamente nada.
+// En **Android y web** están registrados TODOS los tabs visibles del perfil
+// (solo la barra está recortada), así que allí el push directo siempre vale.
+//
+// Y qué tabs caben depende del perfil y de si hay un evento en curso, que es
+// justo lo que hacía que la Home fallara de forma intermitente: decidía "voy
+// directo o paso por Más" con heurísticas de su cosecha —`Platform.OS === 'ios'`,
+// `resolved.tabs.includes(...)`, o directamente un `href` fijo— en vez de
+// preguntar si el tab está DE VERDAD en la barra. Cuando no acertaba, el botón
+// no llevaba a ninguna parte.
+//
+// ## La regla
+//
+// 1. ¿El tab tiene ruta propia aquí (Android/web siempre, iOS solo si está en la
+//    barra)? → se va directo.
+// 2. Si no, hay que entrar por el stack de "Más", que registra pantallas espejo
+//    de los tabs que pueden quedar en overflow.
+//
+// Por el ORDEN de `TABS_CONFIG` (index, cancionero, contigo, comunica, evento,
+// calendario, fotos, mas), el overflow solo puede contener `comunica`, el tab
+// del evento, `calendario` y `fotos` — los cuatro con espejo en "Más". Si algún
+// día se reordena y cae ahí un tab sin espejo, se aterriza en la raíz de "Más"
+// (`masRoot`) en vez de no hacer nada.
+
+import { splitTabsForBar } from '@/constants/tabsCatalog';
+
+/**
+ * Tabs con pantalla ESPEJO en el stack de "Más" (`app/(tabs)/mas.tsx`). Es la
+ * única fuente de verdad: la consumen el resolver y las tarjetas de overflow de
+ * `MasHomeScreen`.
+ */
+export const MAS_STACK_MIRROR: Readonly<Record<string, string>> = {
+  fotos: 'Fotos',
+  calendario: 'Calendario',
+  comunica: 'Comunica',
+};
+
+/** Pantalla hub de un evento dentro del stack de "Más" (necesita `eventId`). */
+export const MAS_EVENT_HUB_SCREEN = 'JubileoHome';
+
+export type TabRoute =
+  /** Ruta propia: `router.push(path)`. */
+  | { via: 'tab'; path: string; params?: Record<string, unknown> }
+  /** Por el stack de "Más", a una pantalla concreta. */
+  | { via: 'masScreen'; screen: string; params?: Record<string, unknown> }
+  /** Por el stack de "Más", sin destino: la tarjeta está en su portada. */
+  | { via: 'masRoot' };
+
+export interface ResolveTabRouteOptions {
+  /** `Platform.OS`. iOS es el único que recorta las rutas registradas. */
+  platform: string;
+  /** Params para el destino (p. ej. `{ date }` del calendario). */
+  params?: Record<string, unknown>;
+  /**
+   * Tab del evento en curso y su id. Sin esto, un tab de evento en overflow no
+   * se puede resolver: su espejo en "Más" es el hub genérico, que necesita saber
+   * de QUÉ evento hablamos.
+   */
+  eventTab?: { tabName: string; eventId: string };
+}
+
+/** Cómo llegar al tab `tabName` desde esta plataforma y este perfil. */
+export function resolveTabRoute(
+  tabName: string,
+  visibleTabs: ReadonlySet<string>,
+  { platform, params, eventTab }: ResolveTabRouteOptions,
+): TabRoute {
+  const direct: TabRoute = {
+    via: 'tab',
+    path: `/${tabName}`,
+    ...(params && { params }),
+  };
+
+  const viaMas = (): TabRoute => {
+    const mirror = MAS_STACK_MIRROR[tabName];
+    if (mirror)
+      return { via: 'masScreen', screen: mirror, ...(params && { params }) };
+    if (eventTab?.tabName === tabName) {
+      return {
+        via: 'masScreen',
+        screen: MAS_EVENT_HUB_SCREEN,
+        params: { eventId: eventTab.eventId, ...params },
+      };
+    }
+    return { via: 'masRoot' };
+  };
+
+  // El perfil no muestra ese tab: no hay ruta que pushear ni en Android/web.
+  // Aun así el espejo de "Más" puede existir (mas.tsx registra Fotos,
+  // Calendario y Comunica siempre), y es mejor eso que quedarse quieto.
+  if (!visibleTabs.has(tabName)) return viaMas();
+
+  if (platform !== 'ios') return direct;
+
+  const { mainTabs } = splitTabsForBar(visibleTabs);
+  return mainTabs.some((tab) => tab.name === tabName) ? direct : viaMas();
+}
+
+/**
+ * Cómo llegar a una pantalla del stack de un EVENTO (Evaluación, Reflexiones…).
+ * Si el tab del evento tiene ruta propia se entra por él; si está en overflow se
+ * entra por "Más", que registra las mismas pantallas de evento.
+ */
+export function resolveEventScreenRoute(
+  screen: string,
+  eventTab: { tabName: string; eventId: string },
+  visibleTabs: ReadonlySet<string>,
+  platform: string,
+): { via: 'eventTab'; path: string } | { via: 'masScreen'; screen: string } {
+  const route = resolveTabRoute(eventTab.tabName, visibleTabs, {
+    platform,
+    eventTab,
+  });
+  return route.via === 'tab'
+    ? { via: 'eventTab', path: route.path }
+    : { via: 'masScreen', screen };
+}


### PR DESCRIPTION
## Summary

Comprehensive fix and test coverage for tab navigation routing. The previous fix resolved the immediate issue of incorrect routing paths, but left a gap: if the resolved path was "enter via Más" but "Más" itself had no route (not in the profile or off-screen in iOS), `router.push('/mas')` would be a no-op and the button would still do nothing.

Now `resolveTabRoute` validates that "Más" is actually reachable before routing through it, falling back to direct navigation (which works on Android/web and was impossible anyway on iOS without a route).

## Key Changes

**Core fixes:**
- `utils/tabNavigation.ts` (new): Unified routing resolver that checks actual bar layout via `splitTabsForBar`, not heuristics. Validates "Más" is reachable before routing through it.
- `hooks/useTabNavigation.ts` (new): Single source for `goToTab()` and `goToEventScreen()` navigation, replacing scattered `router.push()` calls across the app.
- `app/(tabs)/index.tsx`: Home buttons now use `goToTab()` instead of hardcoded `href` or manual `router.push()` calls. Fixes: calendar card, event cards, event banner, activity evaluation CTA, and photos access.
- `app/screens/MasHomeScreen.tsx`: Overflow cards now use `MAS_STACK_MIRROR` (single source of truth) instead of local `OVERFLOW_STACK_TARGETS`.

**Validation & cleanup:**
- `components/song-media/FloatingMediaPlayer.tsx`: Added loading state indicator and proper Drive preview URL handling (`/preview` → `/view` for external opens).
- `components/contigo/HighlightableReading.tsx`: Selection now reported outside pen mode so the highlight button can use pre-existing selections.
- `modules/highlight-menu/` (iOS/Android/web): Proper cleanup of native delegates/callbacks on detach to prevent dangling references.
- `app/(tabs)/calendario.tsx`: Fixed header height calculation.

**Test coverage: +50 tests across 4 new files** (256 profiles × 3 platforms exhaustively):
- `__tests__/tabNavigationInvariants.test.ts` (16 tests): Exhaustive sweep of all 2^8 = 256 possible tab profiles on iOS/Android/web. Validates no visible tab is left without a path, and ties two critical invariants to real code: every `MAS_STACK_MIRROR` entry is registered in `mas.tsx`, and every tab that can overflow has a mirror (or is the event tab).
- `__tests__/useTabNavigation.test.tsx` (14 tests): Hook wiring with mocked router — verifies correct `push()` calls and pending navigation state.
- `__tests__/tabNavigation.test.ts` (9 tests): Core resolver logic for different platforms and overflow scenarios.
- `__tests__/splitTabsForBar.test.ts` (11 tests): Bar/overflow split logic (was untested, is the premise of everything).
- `__tests__/pendingNavigation.test.ts` (9 tests): Pending navigation mailboxes contract (single-use, new overwrites old, independent).
- `__tests__/songMediaFlow.test.tsx` (3 tests): Media sheet → floating player flow.
- `__tests__/highlightSelection.test.tsx` (3 tests): Selection reporting outside pen mode.

**Documentation:**
- `CHANGELOG.md`: Two entries (the previous fix + this one with full test suite).
- `docs/funcionalidades/SUBRAYADO.md`: Clarified selection stickiness and pen mode behavior.
- `docs/desarrollo/TABS_MAINTENANCE.md`: Added warning about iOS overflow tabs having no route.
- `docs/desarrollo/BUILD_AGOSTO_2026.md`: Clarified `.easignore` anchoring rules.

## Test Results

Suite: 60 files, **551 tests** in green (before: 56 files / 501 tests).

All 256 profile × 3 platform combinations verified: no visible tab is left without a re

https://claude.ai/code/session_0152Yos6pB1BvxH6BwaFWbvu