### PR TITLE
Inicio de sesión con Google en Android, al nivel de iOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Cómo funciona cada sistema de la app, de principio a fin.
 
 | Documento | Qué cubre |
 | --------- | --------- |
+| [LOGIN.md](funcionalidades/LOGIN.md) | Inicio de sesión con Google y Apple en iOS, Android y web: arquitectura, variables de entorno, **huellas SHA-1 de Android** y diagnóstico de errores |
 | [NOTIFICACIONES.md](funcionalidades/NOTIFICACIONES.md) | Sistema de notificaciones push: cliente implementado, backend, plan de pruebas |
 | [EVENTOS.md](funcionalidades/EVENTOS.md) | Sistema de eventos (Jubileo, encuentros, retiros…): paths de Firebase y cómo añadir un evento nuevo |
 | [ENCUESTAS.md](funcionalidades/ENCUESTAS.md) | Sistema de encuestas y evaluaciones (guía funcional) |

--- a/docs/desarrollo/BUILD_AGOSTO_2026.md
+++ b/docs/desarrollo/BUILD_AGOSTO_2026.md
@@ -164,6 +164,35 @@ lo lances y te vayas: quédate los dos primeros minutos.
 Para comprobarlo antes de compilar: `npx eas-cli credentials` → iOS → el perfil
 → tienen que salir **dos** targets, la app y `MCMNotificationService`.
 
+### 2.6 Huellas SHA-1 de Android (para el inicio de sesión con Google)
+
+Esta build es la primera que trae **login con Google en Android**. El código ya
+está, pero Google identifica la app por la pareja `com.mcmespana.mcmapp` +
+**huella SHA-1 del certificado que firma el binario**, y esa pareja hay que
+darla de alta a mano. Si falta, el botón falla con *"El inicio de sesión no
+está disponible ahora mismo"* (`DEVELOPER_ERROR`).
+
+Son **dos momentos distintos**:
+
+1. **Antes del build de desarrollo** — huella del keystore de EAS:
+   `npx eas-cli credentials -p android` → Keystore → copiar el `SHA1
+   Fingerprint`.
+2. **Después de subir el AAB a la Play Console** — huella de Play App Signing,
+   que es distinta porque Google vuelve a firmar el paquete: Play Console →
+   Prueba y lanzamiento → Configuración → **Firma de aplicaciones** → SHA-1 de
+   la clave de firma **y** de la clave de carga.
+
+Las dos se pegan en Firebase Console → Configuración del proyecto → Tus apps →
+app Android → **Añadir huella digital**. Después, descargar el
+`google-services.json` actualizado y volver a subirlo a la variable de entorno
+`GOOGLE_SERVICES_JSON` de EAS.
+
+> ⚠️ Registrar solo la primera huella hace que el login funcione en tu móvil de
+> pruebas **y falle para todo el que instale desde la tienda**. Las dos.
+
+Paso a paso completo y tabla de diagnóstico:
+[`docs/funcionalidades/LOGIN.md`](../funcionalidades/LOGIN.md).
+
 ---
 
 ## 3. Antes de compilar — comprobaciones en frío
@@ -277,6 +306,20 @@ npx eas-cli submit -p android --latest
 - [ ] Re-tapea la pestaña activa: vuelve a la raíz / sube el scroll.
 - [ ] **Pasando por el onboarding**: completa el onboarding y mira la barra al
       llegar a Inicio — las etiquetas tienen que verse enteras, no cortadas.
+
+**Inicio de sesión en Android** (nuevo — antes salía "próximamente"; hace falta
+haber registrado la huella SHA-1, §2.6):
+
+- [ ] Más → tu cuenta: se ven **el botón de Google y solo ese** (Apple no
+      existe en Android).
+- [ ] "Continuar con Google" → sale el selector de cuentas del sistema; al
+      elegir una, la tarjeta muestra nombre, correo y "via Google".
+- [ ] **Cancela** el selector → **no** aparece ningún mensaje de error.
+- [ ] Cierra sesión y vuelve a entrar sin reiniciar la app.
+- [ ] Mata la app y ábrela: la sesión **sigue puesta**.
+- [ ] Onboarding con perfil monitor o miembro → ahora aparece el paso de login
+      (antes se saltaba en Android) y el indicador marca 3 pasos.
+- [ ] "Eliminar cuenta" → pide confirmación y la borra.
 
 **Notificaciones — canales de Android** (hace falta un Android **real**, no
 emulador, y mandar pushes desde el Panel):

--- a/docs/funcionalidades/LOGIN.md
+++ b/docs/funcionalidades/LOGIN.md
@@ -1,0 +1,161 @@
+# Inicio de sesión (Google y Apple)
+
+> Cómo funciona el login en las tres plataformas y **qué hay que configurar
+> fuera del código** para que Android funcione. Si vienes buscando "por qué en
+> Android sale error al entrar con Google", ve directo a §4.
+
+---
+
+## 1. Qué ofrece cada plataforma
+
+| Plataforma | Google | Apple | Cómo |
+| --- | :---: | :---: | --- |
+| **iOS** | ✅ | ✅ | `@react-native-google-signin/google-signin` + `expo-apple-authentication`, ambos nativos |
+| **Android** | ✅ | ❌ | `@react-native-google-signin/google-signin` (nativo). Apple no existe como proveedor nativo en Android y **no se pinta el botón** |
+| **Web** | ✅ | ✅ | `signInWithPopup` de Firebase para los dos |
+
+En todos los casos el resultado es el mismo: una credencial que se canjea en
+**Firebase Authentication** con `signInWithCredential`, y de ahí sale la sesión
+que usa el resto de la app (`users/{uid}` en RTDB, sync de CONTIGO, etc.).
+
+Apple **no** está disponible en Android a propósito: ofrecerlo obligaría a
+montar el flujo web de Apple (Service ID + secreto JWT firmado + callback en un
+servidor), y Apple solo lo exige en iOS. Google cubre el 100 % del caso de uso
+en Android.
+
+---
+
+## 2. Piezas de código
+
+```
+utils/authErrors.ts             ← traduce TODOS los códigos de error a los propios (puro, testeado)
+utils/platformAuth.ts           ← implementación web (popups de Firebase)
+utils/platformAuth.native.ts    ← implementación iOS + Android
+contexts/AuthContext.tsx        ← estado de sesión, signIn/signOut/deleteAccount
+components/SocialLoginSection.tsx ← la UI (botones, tarjeta de cuenta, borrar cuenta)
+app/onboarding.tsx              ← paso de login del onboarding (perfiles monitor y miembro)
+```
+
+Tests: `__tests__/authErrors.test.ts` y `__tests__/platformAuthNative.test.ts`.
+
+### Detalles que importan
+
+- **El módulo nativo se carga en perezoso** (`require` dentro de la función).
+  Si el binario no lo incluye —Expo Go, o un dev client sin recompilar—, la app
+  arranca igual y el fallo solo aparece, con mensaje, al pulsar el botón.
+- **La configuración se garantiza antes del `signIn()`**
+  (`ensureGoogleSignInConfigured`). No depende de que el efecto de arranque de
+  `AuthContext` haya terminado: si el usuario pulsa rápido, igualmente se
+  configura primero.
+- **`webClientId` es obligatorio en Android.** Es el que pide el `idToken` que
+  luego valida Firebase. Sin él el login fallaría en silencio, así que el
+  código lo comprueba y lanza un error explícito.
+- **Los errores llegan normalizados** (`AuthError` con `code`), y la UI decide
+  el mensaje con `authErrorMessage()`. Una cancelación del usuario no muestra
+  ningún toast.
+
+---
+
+## 3. Variables de entorno
+
+| Variable | Para qué | Dónde |
+| --- | --- | --- |
+| `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` | Pide el `idToken` que valida Firebase. **Obligatoria en Android e iOS** | `eas.json` (los cuatro perfiles) y `.env.local` |
+| `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` | Client ID de tipo iOS + el `iosUrlScheme` del config plugin | `eas.json` y `.env.local` |
+| `GOOGLE_SERVICES_JSON` | `google-services.json` de Android (FCM + Firebase). Variable de tipo **fichero** en EAS | EAS |
+
+Ya están puestas en `eas.json`, no hay que tocarlas.
+
+---
+
+## 4. Lo único que hay que configurar para Android: las huellas SHA-1
+
+Android no usa un "client ID de Android" en el código: Google identifica la app
+por la pareja **`nombre de paquete` + `huella SHA-1` del certificado que firma
+el APK/AAB**. Si esa pareja no está registrada, `signIn()` falla con
+`DEVELOPER_ERROR` (código 10) — que en la app se ve como *"El inicio de sesión
+no está disponible ahora mismo"*.
+
+El paquete es `com.mcmespana.mcmapp`. Las huellas hay que darlas de alta a mano.
+
+### 4.1 Sacar las huellas
+
+Hay **tres** certificados distintos y conviene registrar los tres:
+
+```bash
+# Desde mcm-app/ — huella del keystore que gestiona EAS
+# (firma los builds de development y preview, y es la clave de subida del AAB)
+npx eas-cli credentials -p android
+```
+
+Elige el perfil, entra en **Keystore** y copia el `SHA1 Fingerprint`.
+
+La tercera —y la más importante para la gente que instala desde la tienda— sale
+de la **Play Console**, porque Google Play vuelve a firmar el AAB con su propia
+clave:
+
+> Play Console → tu app → **Prueba y lanzamiento → Configuración → Firma de
+> aplicaciones** → copia el **SHA-1 del certificado de la clave de firma de la
+> app** (y, ya de paso, el del **certificado de la clave de carga**).
+
+### 4.2 Registrarlas en Firebase
+
+> Firebase Console → ⚙️ **Configuración del proyecto** → pestaña **General** →
+> sección **Tus apps** → la app Android `com.mcmespana.mcmapp` → **Añadir
+> huella digital** → pegar cada SHA-1 (una por una).
+
+Al guardar cada huella, Firebase crea sola la credencial OAuth de tipo Android
+en el proyecto de Google Cloud. No hay que entrar en Google Cloud a mano.
+
+### 4.3 Descargar el `google-services.json` actualizado
+
+En esa misma pantalla, botón **`google-services.json`**. Ese fichero se sube a
+EAS como variable de entorno de tipo fichero:
+
+> [expo.dev](https://expo.dev) → proyecto `mcm-app` → **Environment variables**
+> → `GOOGLE_SERVICES_JSON` → subir el fichero nuevo.
+
+Y se deja también en `mcm-app/google-services.json` para desarrollo local (está
+en `.gitignore`, nunca se commitea).
+
+### 4.4 Comprobar que Google está activo como proveedor
+
+> Firebase Console → **Authentication → Sign-in method** → **Google** debe
+> estar habilitado.
+
+Ya lo está (es lo que usa iOS), pero si algún día sale
+`auth/operation-not-allowed`, es esto.
+
+---
+
+## 5. Probar que funciona
+
+1. Build de desarrollo de Android:
+   `npm run eas:build:android -- --profile development`
+2. Instalar en el móvil y entrar en **Más → tu cuenta** (o rehacer el
+   onboarding eligiendo perfil monitor/miembro).
+3. Casos que hay que ver:
+   - **Entrar con Google** → aparece el selector de cuentas del sistema, se
+     elige una y la tarjeta pasa a mostrar nombre, correo y "via Google".
+   - **Cancelar** el selector → no sale ningún mensaje de error (es lo correcto).
+   - **Cerrar sesión** y volver a entrar → funciona sin reiniciar la app.
+   - **Cerrar y abrir la app** → la sesión sigue puesta (persistencia en
+     AsyncStorage).
+   - **Eliminar cuenta** → pide confirmación, borra `users/{uid}` y la cuenta.
+   - **Sin botón de Apple**: en Android solo debe verse el de Google.
+
+---
+
+## 6. Diagnóstico rápido
+
+| Lo que ve el usuario | Causa casi segura | Arreglo |
+| --- | --- | --- |
+| *"El inicio de sesión no está disponible ahora mismo"* | `DEVELOPER_ERROR` (10): la huella SHA-1 de ese build no está en Firebase | §4.1 y §4.2. Ojo: la huella del build de la tienda **no** es la del build de desarrollo |
+| Funciona en el APK de desarrollo pero no desde Google Play | Falta la huella de **Play App Signing** | §4.1, el SHA-1 de la Play Console |
+| *"Necesitas Google Play Services actualizado"* | Dispositivo sin Play Services (Huawei, emulador sin Google APIs) | No tiene arreglo por nuestra parte |
+| *"Esta versión de la app no admite el inicio de sesión"* | El binario instalado no trae el módulo nativo (OTA sobre un binario viejo) | Instalar un build nuevo |
+| *"Ese correo ya tiene cuenta con otro método"* | La misma dirección se registró antes con Apple | Entrar con el proveedor original |
+| Se abre el selector, se elige cuenta y no pasa nada | Falta `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` en el perfil de build | §3 |
+
+Los errores reales quedan en el log (`logger.error('[AuthContext] …')`) y, si
+Sentry está configurado, también allí.

--- a/mcm-app/.env.example
+++ b/mcm-app/.env.example
@@ -14,10 +14,14 @@ EXPO_PUBLIC_FIREBASE_APP_ID=your_app_id
 EXPO_PUBLIC_CORS_PROXY_URL=
 
 # Google Sign-In OAuth (obtener en console.cloud.google.com)
-# Web Client ID: usado en todas las plataformas para validar tokens
+# Web Client ID: OBLIGATORIO en iOS y Android — es el que pide el idToken que
+# valida Firebase. Sin él, en Android el login no puede crear sesión.
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=your_web_client_id.apps.googleusercontent.com
 # iOS Client ID: solo necesario en builds iOS (EAS)
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=your_ios_client_id.apps.googleusercontent.com
+# Android NO lleva client ID en el código: Google identifica la app por
+# `com.mcmespana.mcmapp` + la huella SHA-1 del certificado que firma el binario,
+# registrada en Firebase. Ver docs/funcionalidades/LOGIN.md §4.
 
 # Sentry — crash reporting (opcional)
 # Sin DSN la app no reporta NADA: Sentry queda apagado y todo funciona igual.

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,59 @@
 
 ---
 
+## 2026-08-08 23:15 — Inicio de sesión en Android: Google nativo, ya de verdad
+
+Android llevaba desde el 5 de junio con el cartel de **"Inicio de sesión
+próximamente"**: los botones estaban ocultos y el onboarding se saltaba el paso
+de login entero. Se acabó — **entrar con Google funciona en Android** igual que
+en iOS, y de paso la capa de auth queda mejor en las tres plataformas.
+
+**Lo que se ha hecho:**
+
+- **Fuera el aviso de "próximamente"**: `SocialLoginSection` pinta el botón de
+  Google en Android, y el onboarding vuelve a incluir el paso de login para los
+  perfiles monitor y miembro (el indicador de pasos vuelve a marcar 3).
+- **Apple no se pinta en Android** (no existe como proveedor nativo allí). La
+  disponibilidad se pregunta de verdad con `isAppleSignInAvailable()` en lugar
+  de deducirla de la plataforma, así que un iOS antiguo sin Apple Sign-In
+  tampoco vería un botón que no funciona.
+- **`utils/authErrors.ts` (nuevo)**: una sola tabla que traduce los códigos de
+  las tres capas —`12501`/`10`/`7` del módulo nativo de Google,
+  `ERR_REQUEST_CANCELED` de Apple, `auth/...` de Firebase— a códigos propios
+  con mensaje de usuario. Antes cualquier fallo era un genérico "No se pudo
+  iniciar sesión"; ahora el toast dice si falta conexión, si falta Google Play
+  Services, o si ese correo ya tiene cuenta con otro proveedor. Y una
+  cancelación sigue sin mostrar nada, que no es un error.
+- **La configuración de Google se garantiza antes del `signIn()`**
+  (`ensureGoogleSignInConfigured`), en vez de depender de que el efecto de
+  arranque de `AuthContext` hubiera terminado. En Android eso importa: sin
+  `webClientId` aplicado no llega `idToken` y Firebase no puede crear la
+  sesión. Si la variable falta directamente en el build, ahora falla con un
+  error explícito en lugar de en silencio.
+- **Carga perezosa del módulo nativo con `require`** en vez de `import()`
+  dinámico: mismo comportamiento en la app (Metro no hace code splitting) y
+  además testeable. Si el binario no trae el módulo, el mensaje es "actualiza
+  la app" en lugar de un fallo mudo.
+- **Logo real de Google** (SVG en sus cuatro colores) sustituyendo la "G" de
+  texto azul, y feedback háptico al entrar/fallar.
+- **28 tests nuevos** (`authErrors.test.ts`, `platformAuthNative.test.ts`):
+  suite en 579.
+
+**Configuración pendiente fuera del código:** hay que registrar en Firebase las
+huellas **SHA-1** del keystore de EAS y de Play App Signing, o Android falla con
+`DEVELOPER_ERROR`. Paso a paso en
+`docs/funcionalidades/LOGIN.md` (nuevo) y resumen en el §2.6 del documento de
+build de agosto.
+
+- Archivos: `utils/authErrors.ts` (nuevo), `utils/platformAuth.native.ts`,
+  `utils/platformAuth.ts`, `contexts/AuthContext.tsx`,
+  `components/SocialLoginSection.tsx`, `app/onboarding.tsx`,
+  `__tests__/authErrors.test.ts`, `__tests__/platformAuthNative.test.ts`,
+  `docs/funcionalidades/LOGIN.md`, `docs/desarrollo/BUILD_AGOSTO_2026.md`.
+- **Sin paquetes nativos nuevos**: todo lo que usa ya estaba en el binario.
+
+---
+
 ## 2026-08-08 20:25 — Navegación a tabs: un hueco más y 50 tests nuevos
 
 Repaso del arreglo anterior. **Un hueco real que quedaba**: si el camino

--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -24,6 +24,12 @@
       qué variables configurar y dónde, el checklist de pruebas completo y el
       orden de publicación. No se duplica aquí para que no haya dos listas que
       se contradigan.
+- [ ] **Huellas SHA-1 de Android en Firebase** (§2.6 de ese documento) — el
+      login con Google en Android ya está en el código, pero sin registrar la
+      huella del keystore de EAS **y** la de Play App Signing, el botón falla
+      con `DEVELOPER_ERROR`. Son dos momentos: la primera antes del build de
+      desarrollo, la segunda después de subir el AAB a la Play Console. Detalle
+      y diagnóstico en `docs/funcionalidades/LOGIN.md`.
 
 Es lo que desbloquea el resto: la rama `claude/compact-tabs-bar-uxxaoz` lleva
 SDK 57, barra flotante, Reanimated 4, NSE de iOS, Sentry, analítica, icono de

--- a/mcm-app/__tests__/authErrors.test.ts
+++ b/mcm-app/__tests__/authErrors.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests de `utils/authErrors.ts` — la tabla que traduce los códigos de las
+ * tres capas (módulo nativo de Google, expo-apple-authentication y Firebase)
+ * a los códigos propios que consume la UI.
+ *
+ * Es la pieza que decide si un fallo de login se cuenta como "el usuario
+ * canceló" (silencio) o como error de verdad (toast), así que los códigos
+ * concretos importan: `12501` es la cancelación de Android y `10` el
+ * DEVELOPER_ERROR que sale cuando falta la huella SHA-1 en Firebase.
+ */
+import {
+  AUTH_ERROR,
+  AuthError,
+  authErrorCode,
+  authErrorMessage,
+  isCancelledAuthError,
+  toAuthError,
+} from '@/utils/authErrors';
+
+/** Error al estilo de los módulos nativos: `Error` + propiedad `code`. */
+const coded = (code: string | number, message = 'boom') =>
+  Object.assign(new Error(message), { code });
+
+describe('authErrorCode', () => {
+  it('trata como cancelación los códigos de Android, iOS, Apple y Firebase', () => {
+    const cancelCodes = [
+      '12501', // GoogleSignInStatusCodes.SIGN_IN_CANCELLED (Android)
+      'SIGN_IN_CANCELLED',
+      'ERR_CANCELED', // Google Sign-In iOS
+      'ERR_REQUEST_CANCELED', // expo-apple-authentication
+      'auth/popup-closed-by-user', // Firebase web
+      'auth/cancelled-popup-request',
+      'auth/user-cancelled',
+    ];
+    for (const code of cancelCodes) {
+      expect(authErrorCode(coded(code))).toBe(AUTH_ERROR.CANCELLED);
+      expect(isCancelledAuthError(coded(code))).toBe(true);
+    }
+  });
+
+  it('mapea DEVELOPER_ERROR (SHA-1 sin registrar) a error de configuración', () => {
+    expect(authErrorCode(coded('10'))).toBe(AUTH_ERROR.MISCONFIGURED);
+    expect(authErrorCode(coded('DEVELOPER_ERROR'))).toBe(
+      AUTH_ERROR.MISCONFIGURED,
+    );
+    expect(authErrorCode(coded('12500'))).toBe(AUTH_ERROR.MISCONFIGURED);
+  });
+
+  it('reconoce Play Services y red', () => {
+    expect(authErrorCode(coded('PLAY_SERVICES_NOT_AVAILABLE'))).toBe(
+      AUTH_ERROR.PLAY_SERVICES,
+    );
+    expect(authErrorCode(coded('2'))).toBe(AUTH_ERROR.PLAY_SERVICES);
+    expect(authErrorCode(coded('7'))).toBe(AUTH_ERROR.NETWORK);
+    expect(authErrorCode(coded('auth/network-request-failed'))).toBe(
+      AUTH_ERROR.NETWORK,
+    );
+  });
+
+  it('reconoce el choque de proveedores en el mismo correo', () => {
+    expect(
+      authErrorCode(coded('auth/account-exists-with-different-credential')),
+    ).toBe(AUTH_ERROR.ACCOUNT_EXISTS);
+  });
+
+  it('acepta códigos numéricos además de cadenas', () => {
+    expect(authErrorCode(coded(10))).toBe(AUTH_ERROR.MISCONFIGURED);
+    expect(authErrorCode(coded(12501))).toBe(AUTH_ERROR.CANCELLED);
+  });
+
+  it('cae a cancelación si solo el mensaje lo delata', () => {
+    expect(authErrorCode(new Error('The user canceled the request'))).toBe(
+      AUTH_ERROR.CANCELLED,
+    );
+  });
+
+  it('devuelve UNKNOWN para lo que no reconoce', () => {
+    expect(authErrorCode(coded('SOMETHING_ELSE', 'vaya'))).toBe(
+      AUTH_ERROR.UNKNOWN,
+    );
+    expect(authErrorCode(null)).toBe(AUTH_ERROR.UNKNOWN);
+    expect(authErrorCode(undefined)).toBe(AUTH_ERROR.UNKNOWN);
+    expect(authErrorCode('un string suelto')).toBe(AUTH_ERROR.UNKNOWN);
+  });
+
+  it('respeta el código de un AuthError ya normalizado', () => {
+    const err = new AuthError(AUTH_ERROR.GOOGLE_UNAVAILABLE, 'sin módulo');
+    expect(authErrorCode(err)).toBe(AUTH_ERROR.GOOGLE_UNAVAILABLE);
+  });
+});
+
+describe('toAuthError', () => {
+  it('envuelve el error original conservando la causa', () => {
+    const original = coded('10');
+    const wrapped = toAuthError(original);
+    expect(wrapped).toBeInstanceOf(AuthError);
+    expect(wrapped.code).toBe(AUTH_ERROR.MISCONFIGURED);
+    expect(wrapped.cause).toBe(original);
+  });
+
+  it('no vuelve a envolver un AuthError', () => {
+    const err = new AuthError(AUTH_ERROR.CANCELLED, 'cancelado');
+    expect(toAuthError(err)).toBe(err);
+  });
+});
+
+describe('authErrorMessage', () => {
+  it('da un mensaje distinto y no vacío para cada código', () => {
+    const messages = Object.values(AUTH_ERROR).map((code) =>
+      authErrorMessage(new AuthError(code, '')),
+    );
+    for (const message of messages) {
+      expect(message.length).toBeGreaterThan(0);
+    }
+    expect(new Set(messages).size).toBe(messages.length);
+  });
+
+  it('menciona Play Services cuando falta en el dispositivo', () => {
+    expect(authErrorMessage(coded('PLAY_SERVICES_NOT_AVAILABLE'))).toMatch(
+      /Play Services/i,
+    );
+  });
+
+  it('cae al mensaje genérico si el error es desconocido', () => {
+    expect(authErrorMessage(coded('???'))).toBe('No se pudo iniciar sesión');
+  });
+});

--- a/mcm-app/__tests__/platformAuthNative.test.ts
+++ b/mcm-app/__tests__/platformAuthNative.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests de `utils/platformAuth.native.ts` — el flujo de login nativo, con
+ * foco en **Android**, que es donde estuvo apagado hasta agosto de 2026.
+ *
+ * Lo que se cubre y por qué:
+ * - En Android sin `webClientId` no llega `idToken` y Firebase no puede crear
+ *   sesión: tiene que fallar con un error de configuración explícito, no en
+ *   silencio.
+ * - `hasPlayServices` solo se llama en Android (en iOS es un no-op).
+ * - La configuración se aplica ANTES del `signIn()` aunque nadie haya llamado
+ *   a `configureGoogleSignIn()` en el arranque.
+ * - Cancelaciones y DEVELOPER_ERROR salen ya normalizados como `AuthError`.
+ * - Apple no se ofrece en Android.
+ *
+ * El módulo nativo se importa de forma perezosa dentro de las funciones, así
+ * que basta con `jest.mock` del paquete.
+ */
+import { AUTH_ERROR } from '@/utils/authErrors';
+
+const mockConfigure = jest.fn();
+const mockSignIn = jest.fn();
+const mockSignOut = jest.fn();
+const mockHasPlayServices = jest.fn().mockResolvedValue(true);
+
+jest.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSignin: {
+    configure: (...args: unknown[]) => mockConfigure(...args),
+    signIn: (...args: unknown[]) => mockSignIn(...args),
+    signOut: (...args: unknown[]) => mockSignOut(...args),
+    hasPlayServices: (...args: unknown[]) => mockHasPlayServices(...args),
+  },
+}));
+
+const mockSignInWithCredential = jest.fn();
+const mockGoogleCredential = jest.fn((token: string) => ({
+  providerId: 'google.com',
+  token,
+}));
+
+jest.mock('firebase/auth', () => ({
+  GoogleAuthProvider: { credential: (t: string) => mockGoogleCredential(t) },
+  OAuthProvider: class {
+    credential(params: unknown) {
+      return { providerId: 'apple.com', params };
+    }
+  },
+  signInWithCredential: (...args: unknown[]) =>
+    mockSignInWithCredential(...args),
+  updateProfile: jest.fn(),
+}));
+
+const mockAppleIsAvailable = jest.fn().mockResolvedValue(true);
+const mockAppleSignInAsync = jest.fn();
+
+jest.mock('expo-apple-authentication', () => ({
+  isAvailableAsync: () => mockAppleIsAvailable(),
+  signInAsync: (...args: unknown[]) => mockAppleSignInAsync(...args),
+  AppleAuthenticationScope: { FULL_NAME: 0, EMAIL: 1 },
+}));
+
+const WEB_CLIENT_ID = 'web-client-id.apps.googleusercontent.com';
+const IOS_CLIENT_ID = 'ios-client-id.apps.googleusercontent.com';
+
+/** Recarga el módulo con la plataforma y el entorno pedidos. */
+async function loadPlatformAuth(
+  os: 'ios' | 'android',
+  env: Record<string, string | undefined> = {
+    EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: WEB_CLIENT_ID,
+    EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: IOS_CLIENT_ID,
+  },
+) {
+  jest.resetModules();
+  // `react-native` reexporta Platform desde este módulo con `.default`.
+  jest.doMock('react-native/Libraries/Utilities/Platform', () => ({
+    __esModule: true,
+    default: {
+      OS: os,
+      select: (obj: Record<string, unknown>) => obj[os] ?? obj.default,
+    },
+  }));
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  // `require` y no `import()`: bajo Jest el import dinámico no se transforma
+  // a CommonJS y revienta con "--experimental-vm-modules".
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@/utils/platformAuth.native') as typeof import('@/utils/platformAuth.native');
+}
+
+const fakeAuth = {} as never;
+
+/** Devuelve el error lanzado por `fn`, fallando el test si no lanza. */
+async function captureError(fn: () => Promise<unknown>) {
+  try {
+    await fn();
+  } catch (err) {
+    return err as { code?: string; message?: string };
+  }
+  throw new Error('Se esperaba un error y no lo hubo');
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockHasPlayServices.mockResolvedValue(true);
+  mockSignInWithCredential.mockResolvedValue({
+    user: { uid: 'u1', displayName: 'Ana', reload: jest.fn() },
+  });
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('doGoogleSignIn — Android', () => {
+  it('configura con el webClientId y canjea el idToken en Firebase', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({
+      type: 'success',
+      data: { idToken: 'id-token-123' },
+    });
+
+    await auth.doGoogleSignIn(fakeAuth);
+
+    expect(mockConfigure).toHaveBeenCalledTimes(1);
+    expect(mockConfigure).toHaveBeenCalledWith(
+      expect.objectContaining({ webClientId: WEB_CLIENT_ID }),
+    );
+    // El iosClientId no viaja a la config de Android.
+    expect(mockConfigure.mock.calls[0][0]).not.toHaveProperty('iosClientId');
+    expect(mockGoogleCredential).toHaveBeenCalledWith('id-token-123');
+    expect(mockSignInWithCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('comprueba Google Play Services antes de abrir el selector', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({
+      type: 'success',
+      data: { idToken: 'tok' },
+    });
+
+    await auth.doGoogleSignIn(fakeAuth);
+
+    expect(mockHasPlayServices).toHaveBeenCalledWith({
+      showPlayServicesUpdateDialog: true,
+    });
+  });
+
+  it('configura aunque nadie haya llamado antes a configureGoogleSignIn', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({
+      type: 'success',
+      data: { idToken: 'tok' },
+    });
+
+    await auth.doGoogleSignIn(fakeAuth);
+
+    expect(mockConfigure).toHaveBeenCalled();
+    expect(mockConfigure.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSignIn.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('solo configura una vez aunque se entre varias veces', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({
+      type: 'success',
+      data: { idToken: 'tok' },
+    });
+
+    await auth.configureGoogleSignIn();
+    await auth.doGoogleSignIn(fakeAuth);
+    await auth.doGoogleSignIn(fakeAuth);
+
+    expect(mockConfigure).toHaveBeenCalledTimes(1);
+  });
+
+  it('falla con error de configuración si no hay webClientId en el build', async () => {
+    const auth = await loadPlatformAuth('android', {
+      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: undefined,
+      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: undefined,
+    });
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.MISCONFIGURED);
+    expect(mockConfigure).not.toHaveBeenCalled();
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+
+  it('normaliza la cancelación por objeto ({ type: "cancelled" })', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({ type: 'cancelled', data: null });
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.CANCELLED);
+    expect(mockSignInWithCredential).not.toHaveBeenCalled();
+  });
+
+  it('normaliza la cancelación lanzada como 12501', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockRejectedValue(
+      Object.assign(new Error('cancelled'), { code: '12501' }),
+    );
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.CANCELLED);
+  });
+
+  it('convierte DEVELOPER_ERROR en error de configuración', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockRejectedValue(
+      Object.assign(new Error('DEVELOPER_ERROR'), { code: '10' }),
+    );
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.MISCONFIGURED);
+  });
+
+  it('avisa de que faltan Play Services', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockHasPlayServices.mockRejectedValue(
+      Object.assign(new Error('no play services'), {
+        code: 'PLAY_SERVICES_NOT_AVAILABLE',
+      }),
+    );
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.PLAY_SERVICES);
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+
+  it('trata la falta de idToken como configuración incorrecta', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignIn.mockResolvedValue({ type: 'success', data: { idToken: null } });
+
+    const err = await captureError(() => auth.doGoogleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.MISCONFIGURED);
+    expect(mockSignInWithCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe('doGoogleSignIn — iOS', () => {
+  it('manda también el iosClientId y se salta hasPlayServices', async () => {
+    const auth = await loadPlatformAuth('ios');
+    mockSignIn.mockResolvedValue({
+      type: 'success',
+      data: { idToken: 'tok' },
+    });
+
+    await auth.doGoogleSignIn(fakeAuth);
+
+    expect(mockConfigure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webClientId: WEB_CLIENT_ID,
+        iosClientId: IOS_CLIENT_ID,
+      }),
+    );
+    expect(mockHasPlayServices).not.toHaveBeenCalled();
+  });
+});
+
+describe('Apple Sign-In', () => {
+  it('no está disponible en Android', async () => {
+    const auth = await loadPlatformAuth('android');
+    await expect(auth.isAppleSignInAvailable()).resolves.toBe(false);
+
+    const err = await captureError(() => auth.doAppleSignIn(fakeAuth));
+    expect(err.code).toBe(AUTH_ERROR.APPLE_UNSUPPORTED);
+    expect(mockAppleSignInAsync).not.toHaveBeenCalled();
+  });
+
+  it('sigue funcionando en iOS', async () => {
+    const auth = await loadPlatformAuth('ios');
+    mockAppleSignInAsync.mockResolvedValue({
+      identityToken: 'apple-token',
+      fullName: null,
+    });
+
+    await expect(auth.isAppleSignInAvailable()).resolves.toBe(true);
+    await auth.doAppleSignIn(fakeAuth);
+
+    expect(mockSignInWithCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('normaliza la cancelación de Apple (ERR_REQUEST_CANCELED)', async () => {
+    const auth = await loadPlatformAuth('ios');
+    mockAppleSignInAsync.mockRejectedValue(
+      Object.assign(new Error('The user canceled'), {
+        code: 'ERR_REQUEST_CANCELED',
+      }),
+    );
+
+    const err = await captureError(() => auth.doAppleSignIn(fakeAuth));
+
+    expect(err.code).toBe(AUTH_ERROR.CANCELLED);
+  });
+});
+
+describe('doGoogleSignOut', () => {
+  it('cierra la sesión nativa sin propagar errores', async () => {
+    const auth = await loadPlatformAuth('android');
+    mockSignOut.mockRejectedValue(new Error('boom'));
+
+    await expect(auth.doGoogleSignOut()).resolves.toBeUndefined();
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+});

--- a/mcm-app/app/onboarding.tsx
+++ b/mcm-app/app/onboarding.tsx
@@ -1729,11 +1729,10 @@ export default function OnboardingScreen() {
     go('delegation');
   };
 
-  // Monitor y miembro van al paso de login antes del éxito.
-  // En Android el login está temporalmente deshabilitado (proveedores nativos
-  // en reparación), así que saltamos este paso por completo.
+  // Monitor y miembro van al paso de login antes del éxito. Desde agosto de
+  // 2026 también en Android (Google Sign-In nativo ya funciona allí).
   const needsLoginStep = (p: OnboardingProfileId | null) =>
-    Platform.OS !== 'android' && (p === 'monitor' || p === 'miembro');
+    p === 'monitor' || p === 'miembro';
 
   const handleFinishToSuccess = () => {
     if (needsLoginStep(profileType)) {

--- a/mcm-app/components/SocialLoginSection.tsx
+++ b/mcm-app/components/SocialLoginSection.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { MaterialIcons } from '@expo/vector-icons';
+import Svg, { Path } from 'react-native-svg';
 import { useAuth, type AuthUser } from '@/contexts/AuthContext';
 import { useUserProfile } from '@/contexts/UserProfileContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -22,6 +23,9 @@ import { radii } from '@/constants/uiStyles';
 import spacing from '@/constants/spacing';
 import { writeUserOnLogin } from '@/utils/authHelpers';
 import { useToast } from '@/contexts/AppToastContext';
+import { authErrorMessage } from '@/utils/authErrors';
+import { isAppleSignInAvailable } from '@/utils/platformAuth';
+import { h } from '@/utils/haptics';
 
 /** Pide confirmación para eliminar la cuenta. Multiplataforma: usa Alert en
  *  nativo y window.confirm en web. Devuelve true si el usuario confirma. */
@@ -160,6 +164,26 @@ export default function SocialLoginSection({
   const { toast } = useToast();
   const [signingIn, setSigningIn] = useState<'google' | 'apple' | null>(null);
   const [deleting, setDeleting] = useState(false);
+  // Apple solo existe en iPhone/iPad y en web (popup de Firebase). En Android
+  // el botón no se pinta: el proveedor no está disponible y ofrecerlo sería
+  // un callejón sin salida.
+  const [appleAvailable, setAppleAvailable] = useState(
+    () => Platform.OS !== 'android',
+  );
+
+  useEffect(() => {
+    let alive = true;
+    isAppleSignInAvailable()
+      .then((available) => {
+        if (alive) setAppleAvailable(available);
+      })
+      .catch(() => {
+        if (alive) setAppleAvailable(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   // Auto-fill name from auth if local profile name is empty
   useEffect(() => {
@@ -186,30 +210,36 @@ export default function SocialLoginSection({
   };
 
   const handleGoogleSignIn = async () => {
+    if (signingIn) return;
     setSigningIn('google');
     try {
       const authUser = await signInWithGoogle();
       if (authUser) {
         persistLogin(authUser, 'google');
+        h.formSuccess();
         toast.show({ variant: 'success', label: 'Sesión iniciada con Google' });
       }
-    } catch {
-      toast.show({ variant: 'danger', label: 'No se pudo iniciar sesión' });
+    } catch (err) {
+      h.error();
+      toast.show({ variant: 'danger', label: authErrorMessage(err) });
     } finally {
       setSigningIn(null);
     }
   };
 
   const handleAppleSignIn = async () => {
+    if (signingIn) return;
     setSigningIn('apple');
     try {
       const authUser = await signInWithApple();
       if (authUser) {
         persistLogin(authUser, 'apple');
+        h.formSuccess();
         toast.show({ variant: 'success', label: 'Sesión iniciada con Apple' });
       }
-    } catch {
-      toast.show({ variant: 'danger', label: 'No se pudo iniciar sesión' });
+    } catch (err) {
+      h.error();
+      toast.show({ variant: 'danger', label: authErrorMessage(err) });
     } finally {
       setSigningIn(null);
     }
@@ -372,36 +402,6 @@ export default function SocialLoginSection({
     );
   }
 
-  // ── Android: inicio de sesión "próximamente" ──────────────────────
-  // El login con proveedores nativos está temporalmente deshabilitado en
-  // Android mientras se repara. Mostramos un aviso en lugar de los botones.
-  if (Platform.OS === 'android') {
-    const csBg = onDarkBackground
-      ? 'rgba(255,255,255,0.10)'
-      : scheme === 'dark'
-        ? 'rgba(255,255,255,0.06)'
-        : hexAlpha(brandColors.primary, '10');
-    const csIcon = onDarkBackground
-      ? 'rgba(255,255,255,0.85)'
-      : brandColors.primary;
-    const csTitle = onDarkBackground ? '#fff' : theme.text;
-    const csBody = onDarkBackground ? 'rgba(255,255,255,0.75)' : theme.icon;
-    return (
-      <View style={styles.container}>
-        <View style={[styles.comingSoonCard, { backgroundColor: csBg }]}>
-          <MaterialIcons name="schedule" size={26} color={csIcon} />
-          <Text style={[styles.comingSoonTitle, { color: csTitle }]}>
-            Inicio de sesión próximamente
-          </Text>
-          <Text style={[styles.comingSoonBody, { color: csBody }]}>
-            Estamos preparando el acceso con cuenta en Android. Mientras tanto
-            puedes seguir usando la app con normalidad. ¡Muy pronto!
-          </Text>
-        </View>
-      </View>
-    );
-  }
-
   // ── Estado: no autenticado ─────────────────────────────────────────
   const googleBg = onDarkBackground ? 'rgba(255,255,255,0.12)' : theme.card;
   const googleBorder = onDarkBackground
@@ -471,57 +471,57 @@ export default function SocialLoginSection({
         </Text>
       </TouchableOpacity>
 
-      {/* Apple — iOS y web (Android ya salió antes con su aviso propio) */}
-      <TouchableOpacity
-        style={[
-          styles.socialBtn,
-          styles.appleBtn,
-          !onDarkBackground && scheme === 'dark'
-            ? { borderColor: 'rgba(255,255,255,0.18)' }
-            : null,
-          ...(signingIn && signingIn !== 'apple' ? [styles.btnDisabled] : []),
-        ]}
-        onPress={handleAppleSignIn}
-        disabled={!!signingIn}
-        accessibilityRole="button"
-        accessibilityLabel="Continuar con Apple"
-      >
-        {signingIn === 'apple' ? (
-          <ActivityIndicator size="small" color="#fff" />
-        ) : (
-          <MaterialIcons name="apple" size={20} color="#fff" />
-        )}
-        <Text style={[styles.socialBtnLabel, { color: '#fff' }]}>
-          Continuar con Apple
-        </Text>
-      </TouchableOpacity>
+      {/* Apple — solo donde el proveedor existe (iOS y web) */}
+      {appleAvailable ? (
+        <TouchableOpacity
+          style={[
+            styles.socialBtn,
+            styles.appleBtn,
+            !onDarkBackground && scheme === 'dark'
+              ? { borderColor: 'rgba(255,255,255,0.18)' }
+              : null,
+            ...(signingIn && signingIn !== 'apple' ? [styles.btnDisabled] : []),
+          ]}
+          onPress={handleAppleSignIn}
+          disabled={!!signingIn}
+          accessibilityRole="button"
+          accessibilityLabel="Continuar con Apple"
+        >
+          {signingIn === 'apple' ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <MaterialIcons name="apple" size={20} color="#fff" />
+          )}
+          <Text style={[styles.socialBtnLabel, { color: '#fff' }]}>
+            Continuar con Apple
+          </Text>
+        </TouchableOpacity>
+      ) : null}
     </View>
   );
 }
 
-/** Icono "G" de Google (SVG en colores oficiales, sin assets externos). */
+/** Logo "G" de Google en sus cuatro colores oficiales (SVG, sin assets). */
 function GoogleIcon({ size = 20 }: { size?: number }) {
   return (
-    <View
-      style={{
-        width: size,
-        height: size,
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Text
-        style={{
-          fontSize: size * 0.9,
-          fontWeight: '700',
-          color: '#4285F4',
-          lineHeight: size,
-          includeFontPadding: false,
-        }}
-      >
-        G
-      </Text>
-    </View>
+    <Svg width={size} height={size} viewBox="0 0 24 24">
+      <Path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <Path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <Path
+        fill="#FBBC05"
+        d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.06H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.94l3.66-2.84z"
+      />
+      <Path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+      />
+    </Svg>
   );
 }
 
@@ -533,24 +533,6 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     alignItems: 'center',
   } as ViewStyle,
-  comingSoonCard: {
-    alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 18,
-    borderRadius: radii.md,
-  } as ViewStyle,
-  comingSoonTitle: {
-    fontSize: 15,
-    fontWeight: '700',
-    textAlign: 'center',
-  } as TextStyle,
-  comingSoonBody: {
-    fontSize: 13,
-    lineHeight: 18,
-    fontWeight: '500',
-    textAlign: 'center',
-  } as TextStyle,
   hintCard: {
     flexDirection: 'row',
     alignItems: 'flex-start',

--- a/mcm-app/contexts/AuthContext.tsx
+++ b/mcm-app/contexts/AuthContext.tsx
@@ -20,6 +20,7 @@ import {
   doGoogleSignOut,
 } from '@/utils/platformAuth';
 import { deleteUserData } from '@/utils/authHelpers';
+import { isCancelledAuthError } from '@/utils/authErrors';
 
 /** Resultado de un intento de eliminación de cuenta. */
 export type DeleteAccountResult = 'success' | 'cancelled' | 'error';
@@ -137,11 +138,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       };
     } catch (err: any) {
       // El usuario canceló el flujo — no es un error real
-      const cancelled =
-        err?.code === 'auth/cancelled-popup-request' ||
-        err?.code === 'auth/popup-closed-by-user' ||
-        err?.code === 'ERR_CANCELED';
-      if (cancelled) return null;
+      if (isCancelledAuthError(err)) return null;
       // Error real: propagar para que la UI muestre feedback (toast) en vez
       // de fallar en silencio.
       logger.error('[AuthContext] signInWithGoogle:', err);
@@ -162,9 +159,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         provider: 'apple',
       };
     } catch (err: any) {
-      const cancelled =
-        err?.code === 'ERR_CANCELED' || String(err?.message).includes('cancel');
-      if (cancelled) return null;
+      if (isCancelledAuthError(err)) return null;
       logger.error('[AuthContext] signInWithApple:', err);
       throw err;
     }
@@ -208,12 +203,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             await doGoogleSignIn(auth);
           }
         } catch (reauthErr: any) {
-          const cancelled =
-            reauthErr?.code === 'ERR_CANCELED' ||
-            reauthErr?.code === 'auth/popup-closed-by-user' ||
-            reauthErr?.code === 'auth/cancelled-popup-request' ||
-            String(reauthErr?.message ?? '').includes('cancel');
-          return cancelled ? 'cancelled' : 'error';
+          return isCancelledAuthError(reauthErr) ? 'cancelled' : 'error';
         }
         try {
           await runDelete();

--- a/mcm-app/utils/authErrors.ts
+++ b/mcm-app/utils/authErrors.ts
@@ -1,0 +1,155 @@
+/**
+ * Normalización de errores de login (Google / Apple) para las tres
+ * plataformas.
+ *
+ * Cada capa lanza sus propios códigos: el módulo nativo de Google usa enteros
+ * de `CommonStatusCodes` como cadena ("10", "7", "12501"), expo-apple-
+ * authentication usa `ERR_REQUEST_CANCELED`, y Firebase usa `auth/...`. Aquí
+ * se traducen TODOS a un puñado de códigos propios (`AuthErrorCode`) para que
+ * la UI decida qué decir sin repetir la tabla en cada pantalla.
+ *
+ * Es un módulo puro a propósito (sin imports nativos): así se puede testear y
+ * se puede importar desde web, iOS y Android.
+ */
+
+export const AUTH_ERROR = {
+  /** El usuario cerró el selector de cuenta: no es un fallo. */
+  CANCELLED: 'ERR_CANCELED',
+  /** El binario no incluye el módulo nativo (Expo Go / dev client viejo). */
+  GOOGLE_UNAVAILABLE: 'ERR_GOOGLE_UNAVAILABLE',
+  /** Falta configuración: SHA-1 sin registrar, client ID ausente, etc. */
+  MISCONFIGURED: 'ERR_AUTH_MISCONFIGURED',
+  /** Google Play Services ausente o desactualizado (solo Android). */
+  PLAY_SERVICES: 'ERR_PLAY_SERVICES',
+  /** Sin conexión o la petición al proveedor no llegó. */
+  NETWORK: 'ERR_AUTH_NETWORK',
+  /** Ya hay un login en curso (doble toque). */
+  IN_PROGRESS: 'ERR_AUTH_IN_PROGRESS',
+  /** Ese correo ya existe con otro proveedor. */
+  ACCOUNT_EXISTS: 'ERR_ACCOUNT_EXISTS',
+  /** Apple Sign-In no existe en esta plataforma. */
+  APPLE_UNSUPPORTED: 'ERR_APPLE_UNSUPPORTED',
+  /** Cualquier otra cosa. */
+  UNKNOWN: 'ERR_AUTH_UNKNOWN',
+} as const;
+
+export type AuthErrorCode = (typeof AUTH_ERROR)[keyof typeof AUTH_ERROR];
+
+/** Error de login ya normalizado. Conserva la causa original para el log. */
+export class AuthError extends Error {
+  readonly code: AuthErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: AuthErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AuthError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Códigos nativos/Firebase → código propio.
+ *
+ * Los números son los de `CommonStatusCodes` de Google Play Services, que el
+ * módulo Android reporta como cadena.
+ */
+const CODE_MAP: Record<string, AuthErrorCode> = {
+  // ── Cancelaciones ──────────────────────────────────────────────────
+  '12501': AUTH_ERROR.CANCELLED, // GoogleSignInStatusCodes.SIGN_IN_CANCELLED
+  SIGN_IN_CANCELLED: AUTH_ERROR.CANCELLED,
+  ERR_CANCELED: AUTH_ERROR.CANCELLED,
+  ERR_REQUEST_CANCELED: AUTH_ERROR.CANCELLED, // expo-apple-authentication
+  'auth/popup-closed-by-user': AUTH_ERROR.CANCELLED,
+  'auth/cancelled-popup-request': AUTH_ERROR.CANCELLED,
+  'auth/user-cancelled': AUTH_ERROR.CANCELLED,
+
+  // ── Configuración ──────────────────────────────────────────────────
+  '10': AUTH_ERROR.MISCONFIGURED, // DEVELOPER_ERROR — huella SHA-1 sin registrar
+  DEVELOPER_ERROR: AUTH_ERROR.MISCONFIGURED,
+  '12500': AUTH_ERROR.MISCONFIGURED, // SIGN_IN_FAILED
+  'auth/operation-not-allowed': AUTH_ERROR.MISCONFIGURED,
+  'auth/invalid-credential': AUTH_ERROR.MISCONFIGURED,
+  'auth/unauthorized-domain': AUTH_ERROR.MISCONFIGURED,
+  'auth/invalid-api-key': AUTH_ERROR.MISCONFIGURED,
+
+  // ── Play Services ──────────────────────────────────────────────────
+  PLAY_SERVICES_NOT_AVAILABLE: AUTH_ERROR.PLAY_SERVICES,
+  '2': AUTH_ERROR.PLAY_SERVICES, // SERVICE_VERSION_UPDATE_REQUIRED
+  '9': AUTH_ERROR.PLAY_SERVICES, // SERVICE_INVALID
+
+  // ── Red ────────────────────────────────────────────────────────────
+  '7': AUTH_ERROR.NETWORK, // NETWORK_ERROR
+  NETWORK_ERROR: AUTH_ERROR.NETWORK,
+  'auth/network-request-failed': AUTH_ERROR.NETWORK,
+  'auth/timeout': AUTH_ERROR.NETWORK,
+
+  // ── Otros ──────────────────────────────────────────────────────────
+  ASYNC_OP_IN_PROGRESS: AUTH_ERROR.IN_PROGRESS,
+  IN_PROGRESS: AUTH_ERROR.IN_PROGRESS,
+  'auth/account-exists-with-different-credential': AUTH_ERROR.ACCOUNT_EXISTS,
+  'auth/too-many-requests': AUTH_ERROR.NETWORK,
+};
+
+/** Mensajes de cara al usuario. Cortos: caben en un toast. */
+const MESSAGES: Record<AuthErrorCode, string> = {
+  [AUTH_ERROR.CANCELLED]: 'Has cancelado el inicio de sesión',
+  [AUTH_ERROR.GOOGLE_UNAVAILABLE]:
+    'Esta versión de la app no admite el inicio de sesión. Actualízala.',
+  [AUTH_ERROR.MISCONFIGURED]:
+    'El inicio de sesión no está disponible ahora mismo. Inténtalo más tarde.',
+  [AUTH_ERROR.PLAY_SERVICES]:
+    'Necesitas Google Play Services actualizado para entrar con Google',
+  [AUTH_ERROR.NETWORK]:
+    'Sin conexión. Comprueba tu internet e inténtalo otra vez.',
+  [AUTH_ERROR.IN_PROGRESS]: 'Ya hay un inicio de sesión en marcha',
+  [AUTH_ERROR.ACCOUNT_EXISTS]:
+    'Ese correo ya tiene cuenta con otro método. Entra con el que usaste la primera vez.',
+  [AUTH_ERROR.APPLE_UNSUPPORTED]:
+    'Entrar con Apple solo está disponible en iPhone, iPad y web',
+  [AUTH_ERROR.UNKNOWN]: 'No se pudo iniciar sesión',
+};
+
+/** Extrae el código de un error de cualquier capa (nativo, Firebase, propio). */
+function rawCode(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+    if (typeof code === 'number') return String(code);
+  }
+  return '';
+}
+
+/**
+ * Traduce cualquier error de login al código propio correspondiente. Si el
+ * error ya viene normalizado (`AuthError`) se respeta su código.
+ */
+export function authErrorCode(err: unknown): AuthErrorCode {
+  if (err instanceof AuthError) return err.code;
+  const code = rawCode(err);
+  const mapped = CODE_MAP[code];
+  if (mapped) return mapped;
+  // Algunos SDK solo dejan rastro de la cancelación en el mensaje.
+  const message = String(
+    (err as { message?: unknown })?.message ?? '',
+  ).toLowerCase();
+  if (message.includes('cancel')) return AUTH_ERROR.CANCELLED;
+  return AUTH_ERROR.UNKNOWN;
+}
+
+/** Convierte cualquier error en un `AuthError` con código y mensaje útiles. */
+export function toAuthError(err: unknown): AuthError {
+  if (err instanceof AuthError) return err;
+  const code = authErrorCode(err);
+  return new AuthError(code, MESSAGES[code], err);
+}
+
+/** `true` si el usuario simplemente cerró el diálogo: no hay que avisar. */
+export function isCancelledAuthError(err: unknown): boolean {
+  return authErrorCode(err) === AUTH_ERROR.CANCELLED;
+}
+
+/** Mensaje listo para el toast a partir de un error de cualquier capa. */
+export function authErrorMessage(err: unknown): string {
+  return MESSAGES[authErrorCode(err)];
+}

--- a/mcm-app/utils/platformAuth.native.ts
+++ b/mcm-app/utils/platformAuth.native.ts
@@ -1,11 +1,12 @@
-// Native implementation: uses @react-native-google-signin/google-signin and
-// expo-apple-authentication.
+// Implementación nativa (iOS + Android): usa
+// @react-native-google-signin/google-signin y expo-apple-authentication.
 //
 // IMPORTANTE: el módulo nativo @react-native-google-signin/google-signin se
-// importa de forma PEREZOSA (dynamic import) para que la app no se caiga al
-// arrancar en un binario que todavía no incluye el módulo nativo (Expo Go o
-// un dev client sin recompilar). El error solo aparecerá —de forma
-// controlada— si el usuario intenta iniciar sesión con Google.
+// carga de forma PEREZOSA para que la app no se caiga al arrancar en un
+// binario que todavía no incluye el módulo nativo (Expo Go o un dev client sin
+// recompilar). El error solo aparecerá —de forma controlada— si el usuario
+// intenta iniciar sesión con Google.
+import { Platform } from 'react-native';
 import { logger } from '@/utils/logger';
 import {
   GoogleAuthProvider,
@@ -14,35 +15,92 @@ import {
   updateProfile,
 } from 'firebase/auth';
 import type { Auth, UserCredential } from 'firebase/auth';
+import { AUTH_ERROR, AuthError, toAuthError } from '@/utils/authErrors';
 
-// Carga perezosa y cacheada del módulo nativo de Google Sign-In.
-let _googleSigninPromise: Promise<
-  typeof import('@react-native-google-signin/google-signin')
-> | null = null;
-
-async function getGoogleSignin() {
-  if (!_googleSigninPromise) {
-    _googleSigninPromise = import('@react-native-google-signin/google-signin');
+// Carga perezosa del módulo nativo de Google Sign-In. Es un `require` dentro
+// de la función (y no un `import` arriba) a propósito: Metro no hace code
+// splitting, así que lo único que importa es CUÁNDO se evalúa el módulo, y
+// así no se evalúa hasta el primer intento de login.
+function getGoogleSignin() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@react-native-google-signin/google-signin') as
+      typeof import('@react-native-google-signin/google-signin') | undefined;
+    if (!mod?.GoogleSignin) throw new Error('GoogleSignin no exportado');
+    return mod.GoogleSignin;
+  } catch (err) {
+    throw new AuthError(
+      AUTH_ERROR.GOOGLE_UNAVAILABLE,
+      'El módulo nativo de Google Sign-In no está en este binario',
+      err,
+    );
   }
-  const mod = await _googleSigninPromise;
-  return mod.GoogleSignin;
 }
 
+/** Igual que arriba, para expo-apple-authentication. */
+function getAppleAuthentication() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('expo-apple-authentication') as typeof import('expo-apple-authentication');
+}
+
+/**
+ * `GoogleSignin.configure()` es síncrono pero deja una promesa interna que
+ * `signIn()` espera. Aun así lo envolvemos en una promesa cacheada propia
+ * para que un toque en el botón ANTES de que termine el efecto de arranque
+ * no se salte la configuración (en Android, sin `webClientId` no hay
+ * `idToken` y el login falla en silencio).
+ */
+let _configuredPromise: Promise<void> | null = null;
+
+async function configureOnce(): Promise<void> {
+  const GoogleSignin = getGoogleSignin();
+
+  const webClientId = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID;
+  const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID;
+
+  // El `webClientId` es el que pide el idToken que después valida Firebase.
+  // En Android es imprescindible: sin él `signIn()` devuelve usuario pero sin
+  // token, y Firebase no puede crear la sesión.
+  if (!webClientId) {
+    throw new AuthError(
+      AUTH_ERROR.MISCONFIGURED,
+      'Falta EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID en el build',
+    );
+  }
+
+  GoogleSignin.configure({
+    webClientId,
+    // Solo iOS lo usa; en Android se ignora, pero no lo mandamos si no está
+    // definido para no ensuciar la config nativa con `undefined`.
+    ...(Platform.OS === 'ios' && iosClientId ? { iosClientId } : {}),
+    offlineAccess: false,
+    scopes: ['profile', 'email'],
+  });
+}
+
+/** Configura Google Sign-In una sola vez; reintenta si la anterior falló. */
+export function ensureGoogleSignInConfigured(): Promise<void> {
+  if (!_configuredPromise) {
+    _configuredPromise = configureOnce().catch((err) => {
+      _configuredPromise = null;
+      throw err;
+    });
+  }
+  return _configuredPromise;
+}
+
+/**
+ * Configuración de arranque (la llama `AuthContext` al montar). No propaga:
+ * si el binario no trae el módulo nativo, la app tiene que seguir arrancando
+ * igual y el fallo se verá —con mensaje— al pulsar el botón.
+ */
 export async function configureGoogleSignIn(): Promise<void> {
   try {
-    const GoogleSignin = await getGoogleSignin();
-    GoogleSignin.configure({
-      webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
-      iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-      offlineAccess: false,
-      scopes: ['profile', 'email'],
-    });
+    await ensureGoogleSignInConfigured();
   } catch (err) {
-    // El módulo nativo no está disponible en este binario — se degrada en
-    // silencio; el botón de Google fallará con un mensaje controlado.
     if (__DEV__) {
       logger.warn(
-        '[platformAuth] Google Sign-In nativo no disponible en este binario:',
+        '[platformAuth] Google Sign-In no se pudo configurar al arrancar:',
         err,
       );
     }
@@ -50,82 +108,106 @@ export async function configureGoogleSignIn(): Promise<void> {
 }
 
 export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
-  const GoogleSignin = await getGoogleSignin();
-  await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
-  let response;
   try {
-    response = await GoogleSignin.signIn();
-  } catch (err: any) {
-    // En Android, cerrar el selector de cuenta lanza SIGN_IN_CANCELLED.
-    // Lo normalizamos a ERR_CANCELED para que la capa superior (AuthContext)
-    // lo trate como cancelación y NO muestre un toast de error.
-    if (
-      err?.code === '12501' || // statusCodes.SIGN_IN_CANCELLED (Android)
-      err?.code === 'SIGN_IN_CANCELLED' ||
-      err?.code === 'ERR_CANCELED'
-    ) {
-      const cancelled: any = new Error('Google Sign-In cancelado');
-      cancelled.code = 'ERR_CANCELED';
-      throw cancelled;
+    await ensureGoogleSignInConfigured();
+    const GoogleSignin = getGoogleSignin();
+
+    // Solo Android: en iOS la llamada es un no-op que devuelve true.
+    if (Platform.OS === 'android') {
+      await GoogleSignin.hasPlayServices({
+        showPlayServicesUpdateDialog: true,
+      });
     }
-    throw err;
+
+    // A partir de v13 una cancelación NO lanza: devuelve
+    // `{ type: 'cancelled', data: null }`. En versiones/rutas antiguas sí
+    // lanzaba (`12501` en Android, `ERR_CANCELED` en iOS) — `toAuthError`
+    // normaliza ambos casos al mismo código.
+    const response = await GoogleSignin.signIn();
+    if (response?.type === 'cancelled') {
+      throw new AuthError(AUTH_ERROR.CANCELLED, 'Google Sign-In cancelado');
+    }
+
+    const idToken = response.data?.idToken;
+    if (!idToken) {
+      // Pasa cuando el `webClientId` no corresponde al proyecto de Firebase.
+      throw new AuthError(
+        AUTH_ERROR.MISCONFIGURED,
+        'Google Sign-In: no se recibió idToken',
+      );
+    }
+
+    const credential = GoogleAuthProvider.credential(idToken);
+    return await signInWithCredential(auth, credential);
+  } catch (err) {
+    throw toAuthError(err);
   }
-  // En @react-native-google-signin v13+ una cancelación NO lanza: devuelve
-  // `{ type: 'cancelled', data: null }`. La detectamos para no tratarla como
-  // un fallo real.
-  if (response?.type === 'cancelled') {
-    const cancelled: any = new Error('Google Sign-In cancelado');
-    cancelled.code = 'ERR_CANCELED';
-    throw cancelled;
+}
+
+/** `true` si el dispositivo puede usar "Continuar con Apple". */
+export async function isAppleSignInAvailable(): Promise<boolean> {
+  if (Platform.OS !== 'ios') return false;
+  try {
+    return await getAppleAuthentication().isAvailableAsync();
+  } catch {
+    return false;
   }
-  if (!response.data?.idToken) {
-    throw new Error('Google Sign-In: no se recibió idToken');
-  }
-  const credential = GoogleAuthProvider.credential(response.data.idToken);
-  return await signInWithCredential(auth, credential);
 }
 
 export async function doAppleSignIn(auth: Auth): Promise<UserCredential> {
-  const AppleAuthentication = await import('expo-apple-authentication');
-  const appleCredential = await AppleAuthentication.signInAsync({
-    requestedScopes: [
-      AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
-      AppleAuthentication.AppleAuthenticationScope.EMAIL,
-    ],
-  });
-
-  if (!appleCredential.identityToken) {
-    throw new Error('Apple Sign-In: no se recibió identityToken');
-  }
-
-  const provider = new OAuthProvider('apple.com');
-  const oauthCredential = provider.credential({
-    idToken: appleCredential.identityToken,
-  });
-  const result = await signInWithCredential(auth, oauthCredential);
-
-  // Apple solo envía el nombre en el primer login — actualizar perfil Firebase si falta
-  if (!result.user.displayName && appleCredential.fullName) {
-    const name = [
-      appleCredential.fullName.givenName,
-      appleCredential.fullName.familyName,
-    ]
-      .filter(Boolean)
-      .join(' ');
-    if (name) {
-      await updateProfile(result.user, { displayName: name });
-      // Reload to get the updated displayName
-      await result.user.reload();
+  try {
+    if (Platform.OS !== 'ios') {
+      throw new AuthError(
+        AUTH_ERROR.APPLE_UNSUPPORTED,
+        'Apple Sign-In no está disponible en esta plataforma',
+      );
     }
-  }
 
-  return result;
+    const AppleAuthentication = getAppleAuthentication();
+    const appleCredential = await AppleAuthentication.signInAsync({
+      requestedScopes: [
+        AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+        AppleAuthentication.AppleAuthenticationScope.EMAIL,
+      ],
+    });
+
+    if (!appleCredential.identityToken) {
+      throw new AuthError(
+        AUTH_ERROR.MISCONFIGURED,
+        'Apple Sign-In: no se recibió identityToken',
+      );
+    }
+
+    const provider = new OAuthProvider('apple.com');
+    const oauthCredential = provider.credential({
+      idToken: appleCredential.identityToken,
+    });
+    const result = await signInWithCredential(auth, oauthCredential);
+
+    // Apple solo envía el nombre en el primer login — actualizar perfil Firebase si falta
+    if (!result.user.displayName && appleCredential.fullName) {
+      const name = [
+        appleCredential.fullName.givenName,
+        appleCredential.fullName.familyName,
+      ]
+        .filter(Boolean)
+        .join(' ');
+      if (name) {
+        await updateProfile(result.user, { displayName: name });
+        // Reload to get the updated displayName
+        await result.user.reload();
+      }
+    }
+
+    return result;
+  } catch (err) {
+    throw toAuthError(err);
+  }
 }
 
 export async function doGoogleSignOut(): Promise<void> {
   try {
-    const GoogleSignin = await getGoogleSignin();
-    await GoogleSignin.signOut();
+    await getGoogleSignin().signOut();
   } catch {
     // Ignorar errores al cerrar sesión de Google
   }

--- a/mcm-app/utils/platformAuth.ts
+++ b/mcm-app/utils/platformAuth.ts
@@ -5,23 +5,41 @@ import {
   OAuthProvider,
 } from 'firebase/auth';
 import type { Auth, UserCredential } from 'firebase/auth';
+import { toAuthError } from '@/utils/authErrors';
 
 export async function configureGoogleSignIn(): Promise<void> {
   // No-op on web — Google Sign-In is handled by Firebase signInWithPopup
 }
 
+export async function ensureGoogleSignInConfigured(): Promise<void> {
+  // No-op on web — see above
+}
+
 export async function doGoogleSignIn(auth: Auth): Promise<UserCredential> {
-  const provider = new GoogleAuthProvider();
-  provider.addScope('profile');
-  provider.addScope('email');
-  return await signInWithPopup(auth, provider);
+  try {
+    const provider = new GoogleAuthProvider();
+    provider.addScope('profile');
+    provider.addScope('email');
+    return await signInWithPopup(auth, provider);
+  } catch (err) {
+    throw toAuthError(err);
+  }
+}
+
+/** En web el flujo de Apple es el popup de Firebase: siempre disponible. */
+export async function isAppleSignInAvailable(): Promise<boolean> {
+  return true;
 }
 
 export async function doAppleSignIn(auth: Auth): Promise<UserCredential> {
-  const provider = new OAuthProvider('apple.com');
-  provider.addScope('email');
-  provider.addScope('name');
-  return await signInWithPopup(auth, provider);
+  try {
+    const provider = new OAuthProvider('apple.com');
+    provider.addScope('email');
+    provider.addScope('name');
+    return await signInWithPopup(auth, provider);
+  } catch (err) {
+    throw toAuthError(err);
+  }
 }
 
 export async function doGoogleSignOut(): Promise<void> {


### PR DESCRIPTION
Android llevaba desde junio con el cartel de "Inicio de sesión próximamente":
botones ocultos y el paso de login del onboarding saltado por completo. Ahora
entrar con Google funciona igual que en iOS.

- SocialLoginSection pinta el botón de Google en Android y el onboarding
  recupera su paso de login para monitor y miembro.
- Apple deja de asumirse por plataforma: se pregunta con
  isAppleSignInAvailable(), así que en Android no se pinta un botón sin salida.
- utils/authErrors.ts (nuevo): una sola tabla traduce los códigos de las tres
  capas (12501/10/7 del módulo nativo, ERR_REQUEST_CANCELED de Apple, auth/*
  de Firebase) a códigos propios con mensaje de usuario. Antes todo fallo era
  un genérico "No se pudo iniciar sesión"; ahora distingue falta de conexión,
  Play Services y correo ya registrado con otro proveedor. Cancelar sigue sin
  mostrar nada.
- La configuración de Google se garantiza antes del signIn() en vez de
  depender del efecto de arranque de AuthContext: en Android, sin webClientId
  aplicado no llega idToken y la sesión no se creaba. Si la variable falta en
  el build, el error es explícito.
- Carga perezosa del módulo nativo con require en vez de import() dinámico:
  mismo comportamiento en Metro y además testeable.
- Logo real de Google (SVG a cuatro colores) y feedback háptico.
- 28 tests nuevos (authErrors, platformAuth.native): suite en 579.

Configuración pendiente fuera del código: registrar en Firebase las huellas
SHA-1 del keystore de EAS y de Play App Signing, o Android falla con
DEVELOPER_ERROR. Paso a paso en docs/funcionalidades/LOGIN.md y resumen en el
§2.6 del documento de build de agosto.

Sin paquetes nativos nuevos.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BVfkUTfJp8KC8AAyRwxpcY