### PR TITLE
⚡ Bolt: Optimize FotosScreen FlatList rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-07-08 - [Split useMemo for O(1) state updates]
 **Learning:** [Combining large dataset processing (O(N log N) sorting and O(N) mapping) with frequently changing scalar dependencies (like `selectedSongs.length`) inside a single `useMemo` causes massive unnecessary re-computations when the scalar value changes.]
 **Action:** [Always split such `useMemo` hooks. Compute and memoize the expensive heavy-lifting using only the large dataset as a dependency, then use a second, lightweight `useMemo` to combine the pre-computed array with the scalar state.]
+## 2026-08-10 - [Extracting renderItem from React Native FlatList]
+**Learning:** [In-lining a `renderItem` function directly in a React Native `FlatList` creates a new function reference on every re-render of the parent component, forcing all list items to re-render unnecessarily, degrading performance significantly on long lists.]
+**Action:** [Always extract `renderItem` and any child event handlers (like `onPress`) outside the `FlatList` component call and wrap them with `React.useCallback` with correct dependencies.]

--- a/mcm-app/app/(tabs)/fotos.tsx
+++ b/mcm-app/app/(tabs)/fotos.tsx
@@ -86,7 +86,9 @@ export function FotosScreen() {
   const { displayedAlbums, allAlbumsLoaded, loadMoreAlbums } =
     useAlbumPagination(sortedAlbums);
 
-  const handleAlbumPress = async (albumUrl: string) => {
+  // ⚡ Bolt Optimization: Memoize the press handler to prevent re-creating the function
+  // on every render, which in turn prevents re-rendering all AlbumCard items in the list.
+  const handleAlbumPress = React.useCallback(async (albumUrl: string) => {
     const supported = await Linking.canOpenURL(albumUrl);
     if (supported) {
       try {
@@ -102,7 +104,7 @@ export function FotosScreen() {
       logger.warn(`Don't know how to open this URL: ${albumUrl}`);
       Alert.alert('Invalid Link', `Esta URL es un poco raruna: ${albumUrl}`);
     }
-  };
+  }, []);
 
   const renderFooter = () => {
     if (allAlbumsLoaded) {
@@ -129,6 +131,21 @@ export function FotosScreen() {
         ? styles.albumCardContainerTwoColumns
         : styles.albumCardContainerOneColumn;
 
+  // ⚡ Bolt Optimization: Extract renderItem and memoize it to prevent re-renders of the FlatList.
+  // This ensures that when the parent component re-renders (e.g., due to scroll events),
+  // the FlatList doesn't unnecessarily re-render all of its items.
+  const renderItem = React.useCallback(
+    ({ item }: { item: Album }) => (
+      <View style={columnContainerStyle}>
+        <AlbumCard
+          album={item}
+          onPress={() => handleAlbumPress(item.albumUrl)}
+        />
+      </View>
+    ),
+    [columnContainerStyle, handleAlbumPress],
+  );
+
   if (loading && displayedAlbums.length === 0) {
     return <ProgressWithMessage message="Cargando álbumes..." />;
   }
@@ -147,15 +164,14 @@ export function FotosScreen() {
         onScroll={onScroll}
         scrollEventThrottle={16}
         data={displayedAlbums}
-        renderItem={({ item }) => (
-          <View style={columnContainerStyle}>
-            <AlbumCard
-              album={item}
-              onPress={() => handleAlbumPress(item.albumUrl)}
-            />
-          </View>
-        )}
+        renderItem={renderItem}
         keyExtractor={(item) => item.id}
+        // ⚡ Bolt Optimization: Virtualization props added to improve performance.
+        // Impact: Reduces initial render time and memory usage by only rendering
+        // a small subset of items initially and limiting batch sizes.
+        initialNumToRender={6}
+        maxToRenderPerBatch={8}
+        windowSize={5}
         // SIN título: la pestaña ya se llama Fotos y las portadas se explican
         // solas, así que un hero de dos líneas solo robaba una pantalla entera
         // de álbumes. El `TabScreenWrapper` con `edges={['top']}` ya deja el


### PR DESCRIPTION
💡 **What:** 
- Extracted `renderItem` and `handleAlbumPress` from the inline `Animated.FlatList` declaration and memoized them using `React.useCallback`.
- Added virtualization props (`initialNumToRender={6}`, `maxToRenderPerBatch={8}`, `windowSize={5}`) to the `Animated.FlatList`.
- Added inline documentation explaining the optimizations.

🎯 **Why:** 
- Inline `renderItem` functions cause React to create a new function reference on every re-render of the parent `FotosScreen` (e.g. during scroll). This forces all rendered items to needlessly re-evaluate.
- Missing virtualization props mean the FlatList renders the default (often excessive) number of items upfront, increasing initial memory pressure and layout calculations.

📊 **Impact:** 
- Eliminates unnecessary O(N) re-renders of list items during scroll events.
- Reduces initial render time and memory footprint by constraining the initial batch of rendered photos.

🔬 **Measurement:** 
- Run `npm run test --prefix mcm-app` to verify functionality.
- Observe smoother scrolling and faster initial tab load times for the 'Fotos' tab.

---
*PR created automatically by Jules for task [10261629054101627595](https://jules.google.com/task/10261629054101627595) started by @mcmespana*