### PR TITLE
Rediseño de «Tu selección»: las playlists cuelgan de un coro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ npm run eas:build:android -- --profile production   # Android para Play Store
 | Notificaciones push (sistema completo) | `docs/funcionalidades/NOTIFICACIONES.md` |
 | Contrato de notificaciones con el panel | `docs/contratos/NOTIFICACIONES_CONTRATO.md` |
 | Eventos (Jubileo, encuentros, retiros…) | `docs/funcionalidades/EVENTOS.md` |
+| Coros y playlists compartidas | `docs/funcionalidades/COROS.md` |
 | Encuestas/evaluaciones | `docs/funcionalidades/ENCUESTAS.md` + `docs/contratos/ENCUESTAS_CONTRATO.md` |
 | Sistema de perfiles (App ↔ Panel) | `docs/contratos/PANEL_PERFILES.md` |
 | Seguridad y reglas Firebase | `docs/SEGURIDAD.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Cómo funciona cada sistema de la app, de principio a fin.
 | [NOTIFICACIONES.md](funcionalidades/NOTIFICACIONES.md) | Sistema de notificaciones push: cliente implementado, backend, plan de pruebas |
 | [EVENTOS.md](funcionalidades/EVENTOS.md) | Sistema de eventos (Jubileo, encuentros, retiros…): paths de Firebase y cómo añadir un evento nuevo |
 | [ENCUESTAS.md](funcionalidades/ENCUESTAS.md) | Sistema de encuestas y evaluaciones (guía funcional) |
+| [COROS.md](funcionalidades/COROS.md) | Coros, playlists compartidas y coro en vivo: `/choirs`, importar «la última», actualizar vs subir nueva, contraseña y caducidad de 24 h |
 | [ARREGLOS.md](funcionalidades/ARREGLOS.md) | Directiva `{arr:}` del cantoral (anotaciones de arreglos) + prompt del generador ChordPro |
 | [SUBRAYADO.md](funcionalidades/SUBRAYADO.md) | Subrayado de las lecturas de Contigo: rangos, componente de texto nativo y qué falta (build nativa) para el ítem "Subrayar" del menú del sistema |
 | [CANAL_PREVIEW.md](funcionalidades/CANAL_PREVIEW.md) | Modo tester ("Laboratorio Alpha"): cómo un dispositivo recibe los OTA de `preview` en vez de los de `production`, y cómo comprobarlo |

--- a/docs/SEGURIDAD.md
+++ b/docs/SEGURIDAD.md
@@ -71,7 +71,8 @@ o borra el bloque: el resto sigue funcionando.
 | `/app/feedback`                      |    —    | Sí (reportar bug)                               | Usuario                 |
 | `/app/evaluations/<id>`              | Por id  | Sí (encuesta de la app)                         | Usuario                 |
 | `/playlistShares/<code>`             | Por código | Sí (compartir playlist)                      | Usuario                 |
-| `/choirSessions/<code>`              | Por código | Sí (coro en vivo)                            | Usuario                 |
+| `/choirSessions/<clave>`             | Por clave  | Sí (coro en vivo; clave = id de coro o código) | Usuario               |
+| `/choirs/<choirId>`                  | Pública    | Sí (crear coro y subirle playlists)          | Usuario                 |
 | `/users/<uid>/**`                    | Solo dueño (auth) | Solo dueño (auth)                     | Usuario autenticado     |
 
 Notas:
@@ -79,6 +80,13 @@ Notas:
 - **Raíz no enumerable**: en `pushTokens`, `playlistShares` y `choirSessions` la
   raíz tiene `.read: false`; solo se accede a un nodo concreto si conoces su
   id/código. Así nadie puede listar todos los tokens ni todas las playlists.
+- **`choirs` SÍ es enumerable, a propósito**: la app necesita listar los coros
+  para que cada uno elija el suyo. Lo que se publica ahí es el nombre del coro
+  y el índice de sus playlists (nombre, fecha, código), nunca el contenido —
+  las canciones siguen en `/playlistShares/<code>`, que no es enumerable. La
+  escritura es por coro (`$choirId`), nunca en la raíz, así que nadie puede
+  borrar el directorio entero de una sentada. Ver
+  `docs/funcionalidades/COROS.md`.
 - **`notifications` es solo-lectura**: ningún cliente puede crear/borrar
   notificaciones; solo el panel con Admin SDK.
 

--- a/docs/funcionalidades/COROS.md
+++ b/docs/funcionalidades/COROS.md
@@ -1,0 +1,189 @@
+# COROS.md — Coros, playlists compartidas y coro en vivo
+
+> Rediseño de agosto de 2026. Sustituye al modelo anterior, en el que todo
+> giraba alrededor de un **código de 4 dígitos** que había que memorizar,
+> dictar y volver a inventarse cada vez.
+
+## La idea en una frase
+
+**Las playlists cuelgan de un coro.** Eliges tu coro una vez («Coro
+Consolación Castellón») y a partir de ahí importar la lista del domingo es un
+toque, subir la tuya es otro, y el coro en vivo se entra por el nombre del
+coro, no por un número.
+
+Los códigos y los QR **siguen existiendo** como opción secundaria: para el
+que no está en ningún coro, para un ensayo puntual, o para compartir por
+WhatsApp una lista suelta.
+
+---
+
+## Modelo de datos (Firebase RTDB)
+
+```
+/choirs/{choirId}                       ← el coro (el índice, ligero)
+  v: 1
+  name: "Coro Consolación Castellón"
+  nameKey: "coro-consolacion-castellon" ← para detectar duplicados al crear
+  createdAt, updatedAt
+  createdBy: { deviceId, name? }        ← quién lo creó (para el panel)
+  playlists:
+    "1234":                             ← clave = código de la playlist
+      name: "Eucaristía domingo 7 ago"
+      createdAt, updatedAt              ← `updatedAt` ORDENA la lista
+      songCount: 12
+      by: "David"                       ← quien la subió (si tiene nombre)
+      ownerDeviceId: "..."              ← para no pedirle contraseña al dueño
+
+/playlistShares/{code}                  ← el CONTENIDO (sin duplicar)
+  v: 2, songs: [...], name, createdAt, updatedAt, expiresAt (+6 meses)
+  choirId?, choirName?, by?, ownerDeviceId?
+
+/choirSessions/{choirId | code}         ← coro EN VIVO (tiempo real)
+  master: { deviceId, name?, lastSeen }
+  choirId?, choirName?
+  playlist: [...], current: {...} | null
+  createdAt, startedAt, updatedAt, lastActivity
+  expiresAt = startedAt + 24 h          ← NO se estira al publicar
+```
+
+**El contenido no se duplica**: `/choirs` es solo un índice para poder pintar
+el histórico de un coro con una lectura ligera. Las canciones siguen viviendo
+en `/playlistShares/{code}`, igual que antes, así que **todos los códigos y QR
+antiguos siguen funcionando**.
+
+### `choirId`: por qué tiene esa forma
+
+Es el nombre en slug más un sufijo aleatorio: `consolacion-castellon-4f2a`
+(ver `utils/choirIds.ts`). Se lee en una URL, es una clave válida de RTDB y —lo
+importante— **siempre lleva un guion**, así que nunca se puede confundir con un
+código de 4 dígitos. Gracias a eso `/choirSessions/<clave>` puede guardar
+indistintamente sesiones de coro (clave = id del coro) y sesiones sueltas
+(clave = 4 dígitos) sin ambigüedad.
+
+---
+
+## Flujos en la app
+
+Todo pasa por la hoja del coro (`components/playlist/ChoirSheet.tsx`), a un
+toque desde el icono de coro de la cabecera de «Tu selección».
+
+| Paso     | Qué hace |
+| -------- | -------- |
+| `choose` | Lista de coros existentes + «Crear un coro nuevo» |
+| `create` | Nombre del coro (avisa si ya existe uno igual, ignorando acentos) |
+| `home`   | **Importar la última** (acción destacada), ver histórico, guardar, y el estado del coro en vivo |
+| `browse` | Histórico: nombre, fecha relativa, nº de canciones y el código en pequeñito |
+| `save`   | **Actualizar «X»** vs **subir como nueva** |
+
+### Importar
+
+- **Importar la última**: un toque desde el coro. No hay que abrir la lista ni
+  saber cómo se llama.
+- **Desde un enlace** (`?p=1234`, `?coro=<id>`) o un QR: **reemplaza
+  directamente** la selección y deja un toast de **10 segundos con «Deshacer»**
+  que restaura tanto las canciones como el enlace con la nube. Venir de un
+  enlace y encontrarte un diálogo de tres botones antes de ver nada era la peor
+  parte del flujo anterior.
+- **Desde un archivo `.mcm`**: es el único sitio donde se sigue preguntando
+  «reemplazar o añadir», porque un archivo suele ser un trozo de repertorio que
+  quieres juntar con lo tuyo.
+
+### Guardar (el caso «he cambiado 3 canciones»)
+
+La app **recuerda el enlace** entre tu selección y su copia en la nube
+(`hooks/usePlaylistLink.ts`, persistido): código, coro, nombre y una **firma**
+de la lista (`playlistSignature`). Con eso:
+
+- La cabecera dice «☁️ Guardada en Coro X · hace 2 h» o «✏️ Cambios sin guardar
+  en «Eucaristía 7 ago»», y al tocarla lleva directo a guardar.
+- Al guardar hay dos opciones explícitas: **Actualizar «X»** (machaca la del
+  coro, conserva código y fecha de creación) o **Subir como nueva** (código
+  nuevo automático, sin elegirlo a mano).
+
+### Contraseña (`coco`)
+
+Una sola contraseña para todo lo que sea machacar algo de otra persona:
+
+| Situación | ¿Pide contraseña? |
+| --------- | ----------------- |
+| Actualizar una playlist que subiste **desde este dispositivo** | No |
+| Actualizar la playlist de otra persona (o la tuya desde otro móvil) | **Sí** |
+| Subir sobre un código ocupado | **Sí** |
+| Tomar el mando del coro en vivo siendo **el mismo usuario** (mismo `deviceId`, o mismo nombre de perfil desde otro dispositivo) | No |
+| Tomar el mando a **otra persona** | **Sí** |
+
+La regla es la que pidió el usuario: *cualquiera* puede machacar o modificar
+si sabe la contraseña. Lo que antes no se podía hacer de ninguna manera (subir
+desde el ordenador e ir a actualizarlo desde el móvil) ahora se puede.
+
+### Vaciar
+
+Un botón «Vaciar» en la propia cabecera de la lista (además del menú). No
+pregunta: vacía y deja 10 s de «Deshacer».
+
+### Coro en vivo
+
+- Se entra por el coro: **Dirigir yo** / **Unirme · dirige Juan**.
+- La sesión **se cierra sola 24 h después de empezar**. Publicar canciones no
+  estira ese plazo.
+- Tomar el mando reinicia el contador (empiezan otras 24 h) y la playlist del
+  nuevo líder pasa a ser la de la sesión.
+- Unirse reemplaza tu lista por la del líder, con los mismos 10 s de deshacer.
+
+---
+
+## Enlaces y QR
+
+| URL | Qué hace |
+| --- | -------- |
+| `https://mcm.expo.app/playlist?p=1234` | Importa esa playlist concreta |
+| `https://mcm.expo.app/playlist?coro=<choirId>` | Importa **la última** playlist del coro. No caduca: el mismo QR pegado en la carpeta sirve todos los domingos |
+| `https://mcm.expo.app/coro?coro=<choirId>` | Se une a la sesión en vivo de ese coro |
+| `https://mcm.expo.app/coro?c=1234` | Sesión suelta por código (formato antiguo, sigue valiendo) |
+| `mcmapp://playlist?d=<payload>` | Playlist offline embebida en el propio QR |
+
+El escáner (`utils/qrScan.ts`) reconoce los cinco y avisa cuando enseñas el QR
+del flujo equivocado.
+
+---
+
+## Panel de administración (lo que falta fuera de este repo)
+
+El nodo `/choirs` está pensado para poder gestionarse desde `mcmpanel`:
+
+- **Listar coros** con `name`, `createdAt`, `createdBy.deviceId/name` y número
+  de playlists.
+- **Borrar un coro** (`remove /choirs/{id}`). El contenido de sus playlists
+  sigue en `/playlistShares` hasta que caduca a los 6 meses.
+- **Renombrar** un coro (`name` + `nameKey`, que debe recalcularse con las
+  mismas reglas de `choirNameKey`: sin acentos, minúsculas, guiones).
+- **Retocar playlists**: cambiar `name` y, sobre todo, `updatedAt` — que es lo
+  que ordena el histórico y decide cuál es «la última».
+
+Se esperan **5-10 coros**, así que la lista se lee entera sin paginar.
+
+## Reglas de seguridad
+
+En `mcm-app/database.rules.json`:
+
+- `/choirs` es de **lectura pública y enumerable** (hay que poder listarlos) y
+  de escritura por coro (`$choirId`), nunca en la raíz.
+- `/playlistShares` y `/choirSessions` no cambian: raíz no enumerable, acceso
+  por clave.
+
+Es el mismo nivel de confianza que ya tenían las playlists compartidas: sin
+login, grupo pequeño y conocido. Ver `docs/SEGURIDAD.md`.
+
+## Archivos principales
+
+| Archivo | Qué es |
+| ------- | ------ |
+| `utils/choirIds.ts` | Id/slug/nombre de un coro (lógica pura) |
+| `utils/playlistSync.ts` | Firma de la playlist, orden del histórico, fechas relativas |
+| `services/choirDirectoryService.ts` | CRUD de `/choirs` y su índice de playlists |
+| `services/cloudPlaylistService.ts` | Contenido en `/playlistShares` + `allocateFreeCode` |
+| `services/choirSessionService.ts` | Sesión en vivo, caducidad de 24 h, identidad del líder |
+| `hooks/usePlaylistSharing.ts` | Todos los flujos (importar, guardar, dirigir, deshacer, contraseña) |
+| `hooks/useMyChoir.ts` / `hooks/usePlaylistLink.ts` | Estado persistido |
+| `components/playlist/ChoirSheet.tsx` | La hoja de coro con sus pasos |
+| `app/playlist.tsx` / `app/coro.tsx` | Pantallas puente de los deep links |

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,40 @@
 
 ---
 
+## 2026-08-12 19:40 — Rediseño de «Tu selección»: las playlists cuelgan de un coro
+
+- **Concepto nuevo: el coro es la entidad**. Se crea un coro («Coro Consolación
+  Castellón»), se elige una vez en el dispositivo y a partir de ahí las
+  playlists cuelgan de él. Importar la del domingo es **un toque** («Importar la
+  última»); el histórico enseña nombre, fecha y el código en pequeñito. Los
+  códigos y QR pasan a ser una opción secundaria, y todos los antiguos siguen
+  funcionando (el contenido sigue en `/playlistShares/<code>`).
+- **Nuevo nodo `/choirs/<choirId>`** con el índice de playlists del coro y
+  `createdBy`, para que el panel pueda borrar coros y retocar nombres/fechas.
+  Reglas de RTDB añadidas (lectura pública enumerable, escritura por coro).
+- **Actualizar una playlist ya subida** deja de ser imposible: la app recuerda
+  el enlace con la nube (código + coro + firma de la lista) y ofrece
+  «Actualizar «X»» o «Subir como nueva». La cabecera dice si hay **cambios sin
+  guardar**. Cualquiera puede machacar la de otra persona con la contraseña
+  `coco`; si la subiste tú desde ese dispositivo, sin contraseña.
+- **Importar ya no interroga**: venir de un enlace, un QR o el coro reemplaza la
+  selección y deja **10 s de «Deshacer»** (canciones y enlace). El diálogo de
+  «reemplazar / añadir» se queda solo para los archivos `.mcm`. **Vaciar** pasa
+  a la cabecera, sin confirmación y con deshacer.
+- **Coro en vivo por coro, no por código**: se entra por el nombre del coro,
+  la sesión **caduca sola a las 24 h** desde que empezó (antes 2 semanas, y se
+  estiraba sola) y se puede tomar el mando — sin contraseña si eres el mismo
+  usuario desde otro dispositivo, con `coco` si es de otra persona.
+- **Enlaces nuevos**: `/playlist?coro=<id>` (importa siempre la última) y
+  `/coro?coro=<id>` (sesión en vivo). Reconocidos también por el escáner de QR.
+- Archivos: `utils/choirIds.ts`, `utils/playlistSync.ts`,
+  `services/choirDirectoryService.ts`, `services/choirSessionService.ts`,
+  `services/cloudPlaylistService.ts`, `hooks/usePlaylistSharing.ts`,
+  `hooks/useMyChoir.ts`, `hooks/usePlaylistLink.ts`,
+  `components/playlist/ChoirSheet.tsx`, `components/playlist/PlaylistHeaderBar.tsx`,
+  `app/screens/SelectedSongsScreen.tsx`, `app/playlist.tsx`, `app/coro.tsx`,
+  `database.rules.json`. Documentación: `docs/funcionalidades/COROS.md`.
+
 ## 2026-08-09 16:40 — Menú "..." del cantoral, eventos pasados y raya de sección
 
 - **El menú "..." del cantoral ya no se traga las opciones.** Cada opción es

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,22 @@
 
 ---
 
+## 2026-08-12 20:35 — Menú de la playlist: opciones vivas, orden por uso y arreglos
+
+- **Solo se ofrece lo que se puede hacer**: con la lista vacía siguen visibles
+  las de importar, el hub del coro y el enlace del coro (que no depende de tu
+  selección) — antes ese enlace desaparecía sin motivo. Vaciar, exportar, subir
+  y compartir siguen ocultándose.
+- **Orden por frecuencia real**: Mi coro → Exportar y compartir → Coro en vivo →
+  Códigos y QR → Archivo → Vaciar (Archivo baja, que es lo más raro de usar).
+- **Arreglo**: en una sesión en vivo que cuelga de un coro ya no se ofrece
+  «cambiar el código» — la clave *es* el coro, así que cambiarla la desataba de
+  él y el resto del coro no la encontraba. Su QR usa ahora `?coro=<id>`.
+- **Un toque menos**: si abres «guardar» sin tener coro elegido, después de
+  elegirlo la hoja vuelve a guardar en vez de dejarte en el inicio.
+- Archivos: `app/screens/SelectedSongsScreen.tsx`,
+  `components/playlist/ChoirSheet.tsx`.
+
 ## 2026-08-12 19:40 — Rediseño de «Tu selección»: las playlists cuelgan de un coro
 
 - **Concepto nuevo: el coro es la entidad**. Se crea un coro («Coro Consolación

--- a/mcm-app/__tests__/choirDirectoryService.test.ts
+++ b/mcm-app/__tests__/choirDirectoryService.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests de `services/choirDirectoryService.ts` — el directorio de coros del
+ * que cuelgan las playlists.
+ *
+ * Firebase RTDB está mockeado en `__mocks__/firebase.ts` (mapeado en
+ * jest.config.js); aquí controlamos las respuestas por llamada con
+ * `mockResolvedValueOnce`.
+ */
+import { get, set, update, remove } from 'firebase/database';
+import {
+  choirLatestPlaylist,
+  choirPlaylists,
+  createChoir,
+  deleteChoir,
+  fetchChoir,
+  listChoirs,
+  removeChoirPlaylist,
+  upsertChoirPlaylist,
+} from '@/services/choirDirectoryService';
+
+const snapshot = (value: unknown) => ({
+  exists: () => value !== null && value !== undefined,
+  val: () => value,
+});
+
+const CHOIR_ID = 'consolacion-castellon-4f2a';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('validación del id (getRef indirecto)', () => {
+  it.each([['1234'], ['sinGuion'], ['']])('rechaza el id «%s»', async (id) => {
+    await expect(fetchChoir(id)).rejects.toThrow(/inválido/i);
+  });
+});
+
+describe('listChoirs', () => {
+  it('sin coros → lista vacía', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(snapshot(null));
+    await expect(listChoirs()).resolves.toEqual([]);
+  });
+
+  it('ordena por nombre y rellena los huecos del nodo', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(
+      snapshot({
+        'zeta-0001': { name: 'Zeta', createdAt: 1 },
+        'alfa-0002': { name: 'Alfa', createdAt: 2, playlists: {} },
+      }),
+    );
+    const choirs = await listChoirs();
+    expect(choirs.map((c) => c.name)).toEqual(['Alfa', 'Zeta']);
+    // Un coro sin `playlists` en Firebase no puede reventar la pantalla.
+    expect(choirs[1].playlists).toEqual({});
+    expect(choirs[1].nameKey).toBe('zeta');
+  });
+
+  it('hidrata las entradas de playlist con su código como clave', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(
+      snapshot({
+        [CHOIR_ID]: {
+          name: 'Consolación',
+          playlists: {
+            '1234': { name: 'Domingo', updatedAt: 200, songCount: 5 },
+            '5678': { name: 'Vigilia', createdAt: 100 },
+          },
+        },
+      }),
+    );
+    const [choir] = await listChoirs();
+    const entries = choirPlaylists(choir);
+    expect(entries.map((e) => e.code)).toEqual(['1234', '5678']);
+    // Sin `updatedAt` propio se cae a `createdAt`, para no ordenar por 0.
+    expect(entries[1].updatedAt).toBe(100);
+    expect(choirLatestPlaylist(choir)?.code).toBe('1234');
+  });
+});
+
+describe('createChoir', () => {
+  it('rechaza nombres demasiado cortos sin tocar Firebase', async () => {
+    await expect(createChoir('AB', { deviceId: 'd1' })).rejects.toThrow(
+      /corto/i,
+    );
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('avisa (y no crea) si ya existe uno con el mismo nombre', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(
+      snapshot({ [CHOIR_ID]: { name: 'Coro Consolación Castellón' } }),
+    );
+    await expect(
+      createChoir('coro  consolacion castellon', { deviceId: 'd1' }),
+    ).rejects.toThrow(/Ya existe/);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('crea el coro con nameKey, createdBy y sin claves undefined', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(snapshot(null));
+    const created = await createChoir('Coro Consolación Castellón', {
+      deviceId: 'd1',
+    });
+
+    expect(created.id).toMatch(/^coro-consolacion-castellon-/);
+    expect(created.nameKey).toBe('coro-consolacion-castellon');
+    expect(created.playlists).toEqual({});
+    const written = (set as jest.Mock).mock.calls[0][1];
+    expect(written.createdBy).toEqual({ deviceId: 'd1' });
+    expect(written.createdBy).not.toHaveProperty('name');
+  });
+});
+
+describe('índice de playlists', () => {
+  it('upsert escribe la entrada y refresca el updatedAt del coro', async () => {
+    const now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    await upsertChoirPlaylist(CHOIR_ID, {
+      code: '1234',
+      name: 'Domingo',
+      createdAt: 0,
+      updatedAt: 0,
+      songCount: 7,
+      ownerDeviceId: 'd1',
+    });
+
+    const payload = (update as jest.Mock).mock.calls[0][1];
+    expect(payload['playlists/1234']).toMatchObject({
+      name: 'Domingo',
+      songCount: 7,
+      updatedAt: now,
+      ownerDeviceId: 'd1',
+    });
+    // `createdAt: 0` significa "nueva", no "1 de enero de 1970".
+    expect(payload['playlists/1234'].createdAt).toBe(now);
+    expect(payload.updatedAt).toBe(now);
+  });
+
+  it('remove borra solo esa entrada (null), no el coro', async () => {
+    await removeChoirPlaylist(CHOIR_ID, '1234');
+    const payload = (update as jest.Mock).mock.calls[0][1];
+    expect(payload['playlists/1234']).toBeNull();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('deleteChoir sí borra el nodo entero', async () => {
+    await deleteChoir(CHOIR_ID);
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcm-app/__tests__/choirIds.test.ts
+++ b/mcm-app/__tests__/choirIds.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests de `utils/choirIds.ts` — la identidad de un coro.
+ *
+ * Lo crítico aquí es la invariante que sostiene todo el rediseño: un id de
+ * coro NUNCA se puede confundir con un código de playlist de 4 dígitos, porque
+ * ambos comparten el mismo nodo de sesiones (`/choirSessions/<clave>`) y las
+ * mismas URLs.
+ */
+import {
+  choirNameKey,
+  isChoirId,
+  makeChoirId,
+  normalizeChoirName,
+} from '@/utils/choirIds';
+import { isValidCode } from '@/utils/playlistCodes';
+
+describe('normalizeChoirName', () => {
+  it('colapsa espacios y recorta', () => {
+    expect(normalizeChoirName('  Coro   Consolación  ')).toBe(
+      'Coro Consolación',
+    );
+  });
+
+  it('recorta nombres kilométricos', () => {
+    expect(normalizeChoirName('x'.repeat(200))).toHaveLength(60);
+  });
+});
+
+describe('choirNameKey', () => {
+  it('ignora mayúsculas, acentos y separadores al comparar', () => {
+    const key = choirNameKey('Coro Consolación Castellón');
+    expect(choirNameKey('coro  consolacion castellon')).toBe(key);
+    expect(choirNameKey('CORO-CONSOLACION-CASTELLON')).toBe(key);
+  });
+
+  it('no confunde dos coros distintos', () => {
+    expect(choirNameKey('Coro de Madrid')).not.toBe(
+      choirNameKey('Coro de Málaga'),
+    );
+  });
+});
+
+describe('makeChoirId', () => {
+  it('produce un id legible con sufijo', () => {
+    expect(makeChoirId('Coro Consolación Castellón', 'ab12')).toBe(
+      'coro-consolacion-castellon-ab12',
+    );
+  });
+
+  it('sobrevive a un nombre sin letras latinas', () => {
+    expect(makeChoirId('🎵🎵🎵', 'ab12')).toBe('coro-ab12');
+  });
+
+  it('no deja guiones dobles al recortar nombres largos', () => {
+    const id = makeChoirId('a'.repeat(40), 'ab12');
+    expect(id).not.toMatch(/--/);
+    expect(isChoirId(id)).toBe(true);
+  });
+
+  it('todo id generado es válido y nunca parece un código de playlist', () => {
+    for (const name of [
+      'Coro A',
+      'Parroquia San Juan',
+      'jóvenes 2026',
+      '123',
+    ]) {
+      const id = makeChoirId(name, 'zz99');
+      expect(isChoirId(id)).toBe(true);
+      expect(isValidCode(id)).toBe(false);
+    }
+  });
+});
+
+describe('isChoirId', () => {
+  it.each(['1234', '0000', 'coro', '', 'Coro-Mayus', 'con espacio-1234'])(
+    'rechaza «%s»',
+    (value) => {
+      expect(isChoirId(value)).toBe(false);
+    },
+  );
+
+  it('acepta un id bien formado', () => {
+    expect(isChoirId('consolacion-castellon-4f2a')).toBe(true);
+  });
+});

--- a/mcm-app/__tests__/choirLiveSession.test.ts
+++ b/mcm-app/__tests__/choirLiveSession.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Reglas del "coro en vivo" tras el rediseño:
+ *
+ *  - la sesión cuelga del **coro** (la clave del nodo es el id del coro), pero
+ *    se siguen aceptando códigos sueltos de 4 dígitos;
+ *  - **caduca 24 h después de empezar** y no se estira publicando;
+ *  - **el mismo usuario puede tomar el mando desde otro dispositivo** sin
+ *    contraseña; cualquier otra persona sí la necesita.
+ */
+import {
+  CHOIR_SESSION_TTL_MS,
+  isSameLeader,
+  isSessionKey,
+  isSessionLive,
+  type ChoirSession,
+} from '@/services/choirSessionService';
+
+const baseSession = (over: Partial<ChoirSession> = {}): ChoirSession =>
+  ({
+    v: 1,
+    master: { deviceId: 'dev-1', name: 'David', lastSeen: 0 },
+    playlist: [],
+    current: null,
+    createdAt: 0,
+    startedAt: 0,
+    updatedAt: 0,
+    lastActivity: 0,
+    expiresAt: CHOIR_SESSION_TTL_MS,
+    ...over,
+  }) as ChoirSession;
+
+describe('isSessionKey', () => {
+  it('acepta códigos de 4 dígitos y ids de coro', () => {
+    expect(isSessionKey('1234')).toBe(true);
+    expect(isSessionKey('consolacion-castellon-4f2a')).toBe(true);
+  });
+
+  it('rechaza cualquier otra cosa', () => {
+    expect(isSessionKey('12')).toBe(false);
+    expect(isSessionKey('sinGuion')).toBe(false);
+    expect(isSessionKey('')).toBe(false);
+  });
+});
+
+describe('caducidad a las 24 h', () => {
+  it('viva justo antes de las 24 h', () => {
+    expect(isSessionLive(baseSession(), CHOIR_SESSION_TTL_MS - 1)).toBe(true);
+  });
+
+  it('muerta justo en las 24 h', () => {
+    expect(isSessionLive(baseSession(), CHOIR_SESSION_TTL_MS)).toBe(false);
+  });
+
+  it('una sesión antigua sin `expiresAt` se mide desde que empezó', () => {
+    const legacy = baseSession({
+      expiresAt: undefined as any,
+      startedAt: 1000,
+    });
+    expect(isSessionLive(legacy, 1000 + CHOIR_SESSION_TTL_MS - 1)).toBe(true);
+    expect(isSessionLive(legacy, 1000 + CHOIR_SESSION_TTL_MS + 1)).toBe(false);
+  });
+
+  it('no hay sesión → no está viva', () => {
+    expect(isSessionLive(null)).toBe(false);
+  });
+});
+
+describe('quién puede tomar el mando sin contraseña', () => {
+  it('el mismo dispositivo, siempre', () => {
+    expect(isSameLeader(baseSession(), { deviceId: 'dev-1' })).toBe(true);
+  });
+
+  it('el mismo usuario desde otro móvil (mismo nombre de perfil)', () => {
+    expect(
+      isSameLeader(baseSession(), { deviceId: 'otro', name: '  david  ' }),
+    ).toBe(true);
+  });
+
+  it('otra persona, no', () => {
+    expect(isSameLeader(baseSession(), { deviceId: 'otro', name: 'Ana' })).toBe(
+      false,
+    );
+  });
+
+  it('sin nombre en el perfil no basta con que el líder tampoco lo tenga', () => {
+    const anon = baseSession({
+      master: { deviceId: 'dev-1', lastSeen: 0 },
+    });
+    expect(isSameLeader(anon, { deviceId: 'otro' })).toBe(false);
+  });
+
+  it('si no hay sesión, no hay a quién quitarle el mando', () => {
+    expect(isSameLeader(null, { deviceId: 'quien-sea' })).toBe(true);
+  });
+});

--- a/mcm-app/__tests__/choirSessionService.test.ts
+++ b/mcm-app/__tests__/choirSessionService.test.ts
@@ -23,7 +23,7 @@ import {
 } from '@/services/choirSessionService';
 import type { SelectedSong } from '@/contexts/SelectedSongsContext';
 
-const TWO_WEEKS_MS = 1000 * 60 * 60 * 24 * 14;
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 const VALID = '1234';
 const OTHER = '5678';
 
@@ -46,7 +46,7 @@ describe('validación de código', () => {
     ['12', 'demasiado corto'],
     ['123456', 'demasiado largo'],
     ['', 'vacío'],
-  ])('rechaza el código "%s" (%s)', async (code) => {
+  ])('rechaza la clave "%s" (%s)', async (code) => {
     await expect(choirSessionExists(code)).rejects.toThrow(/inválido/i);
   });
 
@@ -57,7 +57,7 @@ describe('validación de código', () => {
 });
 
 describe('createChoirSession', () => {
-  it('construye el payload con expiración a 2 semanas y current nulo', async () => {
+  it('construye el payload con expiración a 24 h y current nulo', async () => {
     const now = 1_700_000_000_000;
     jest.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -72,7 +72,8 @@ describe('createChoirSession', () => {
     expect(result.master.deviceId).toBe('dev-1');
     expect(result.current).toBeNull();
     expect(result.createdAt).toBe(now);
-    expect(result.expiresAt).toBe(now + TWO_WEEKS_MS);
+    expect(result.startedAt).toBe(now);
+    expect(result.expiresAt).toBe(now + ONE_DAY_MS);
     expect(result.playlist).toHaveLength(2);
     expect(set).toHaveBeenCalledTimes(1);
   });
@@ -112,7 +113,9 @@ describe('publicaciones del maestro', () => {
     expect(payload.current.transpose).toBe(2);
     expect(payload.current.updatedAt).toBe(now);
     expect(payload['master/lastSeen']).toBe(now);
-    expect(payload.expiresAt).toBe(now + TWO_WEEKS_MS);
+    // La caducidad NO se estira al publicar: la sesión muere 24 h después de
+    // empezar, aunque el líder siga cantando.
+    expect(payload).not.toHaveProperty('expiresAt');
   });
 
   it('publishChoirPlaylist actualiza la playlist y la actividad', async () => {

--- a/mcm-app/__tests__/playlistSync.test.ts
+++ b/mcm-app/__tests__/playlistSync.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests de `utils/playlistSync.ts`: la firma que decide si la pantalla dice
+ * «guardada» o «cambios sin guardar», el orden del histórico de un coro y las
+ * fechas relativas.
+ *
+ * La firma es la pieza delicada: un falso «cambios sin guardar» nada más
+ * importar haría que la gente subiera copias de la misma lista sin parar.
+ */
+import {
+  formatRelativeDate,
+  latestChoirPlaylist,
+  playlistSignature,
+  sortChoirPlaylists,
+  type ChoirPlaylistEntry,
+} from '@/utils/playlistSync';
+import type { SelectedSong } from '@/contexts/SelectedSongsContext';
+
+const song = (
+  filename: string,
+  order: number,
+  extra: Partial<SelectedSong> = {},
+): SelectedSong => ({
+  filename,
+  transpose: 0,
+  order,
+  addedAt: 1000 + order,
+  ...extra,
+});
+
+describe('playlistSignature', () => {
+  it('no depende del orden del array, solo del campo `order`', () => {
+    const a = [song('a.cho', 0), song('b.cho', 1)];
+    const b = [song('b.cho', 1), song('a.cho', 0)];
+    expect(playlistSignature(a)).toBe(playlistSignature(b));
+  });
+
+  it('cambia si se reordena de verdad', () => {
+    const a = [song('a.cho', 0), song('b.cho', 1)];
+    const b = [song('a.cho', 1), song('b.cho', 0)];
+    expect(playlistSignature(a)).not.toBe(playlistSignature(b));
+  });
+
+  it('cambia al transportar una canción', () => {
+    const base = [song('a.cho', 0)];
+    const transposed = [song('a.cho', 0, { transpose: 2 })];
+    expect(playlistSignature(base)).not.toBe(playlistSignature(transposed));
+  });
+
+  it('cambia al poner una cejilla distinta', () => {
+    const base = [song('a.cho', 0)];
+    const capo = [song('a.cho', 0, { capoOverride: 3 })];
+    expect(playlistSignature(base)).not.toBe(playlistSignature(capo));
+  });
+
+  it('trata `capoOverride: null` y ausente como lo mismo', () => {
+    expect(playlistSignature([song('a.cho', 0, { capoOverride: null })])).toBe(
+      playlistSignature([song('a.cho', 0)]),
+    );
+  });
+
+  it('ignora duplicados, igual que hace la selección al guardarse', () => {
+    const conDuplicado = [song('a.cho', 0), song('a.cho', 1), song('b.cho', 2)];
+    const sinDuplicado = [song('a.cho', 0), song('b.cho', 1)];
+    expect(playlistSignature(conDuplicado)).toBe(
+      playlistSignature(sinDuplicado),
+    );
+  });
+
+  it('la lista vacía tiene firma estable', () => {
+    expect(playlistSignature([])).toBe(playlistSignature([]));
+    expect(playlistSignature([])).not.toBe(playlistSignature([song('a', 0)]));
+  });
+});
+
+describe('orden del histórico del coro', () => {
+  const entry = (
+    code: string,
+    updatedAt: number,
+    name = `Playlist ${code}`,
+  ): ChoirPlaylistEntry => ({
+    code,
+    name,
+    createdAt: 0,
+    updatedAt,
+    songCount: 3,
+  });
+
+  it('la más reciente va primero', () => {
+    const sorted = sortChoirPlaylists([
+      entry('1111', 100),
+      entry('2222', 300),
+      entry('3333', 200),
+    ]);
+    expect(sorted.map((e) => e.code)).toEqual(['2222', '3333', '1111']);
+  });
+
+  it('empate de fecha → por nombre, para que el orden no baile', () => {
+    const sorted = sortChoirPlaylists([
+      entry('1111', 100, 'Zeta'),
+      entry('2222', 100, 'Alfa'),
+    ]);
+    expect(sorted.map((e) => e.name)).toEqual(['Alfa', 'Zeta']);
+  });
+
+  it('«importar la última» coge la de fecha mayor', () => {
+    expect(
+      latestChoirPlaylist([entry('1111', 100), entry('2222', 300)])?.code,
+    ).toBe('2222');
+  });
+
+  it('un coro sin playlists no tiene última', () => {
+    expect(latestChoirPlaylist([])).toBeNull();
+  });
+});
+
+describe('formatRelativeDate', () => {
+  const now = new Date('2026-08-12T12:00:00Z').getTime();
+
+  it.each([
+    [now - 30_000, 'ahora mismo'],
+    [now - 12 * 60_000, 'hace 12 min'],
+    [now - 3 * 3_600_000, 'hace 3 h'],
+    [now - 30 * 3_600_000, 'ayer'],
+  ])('%s → %s', (ts, expected) => {
+    expect(formatRelativeDate(ts, now)).toBe(expected);
+  });
+
+  it('más de dos días → fecha corta', () => {
+    expect(
+      formatRelativeDate(new Date('2026-08-07T10:00:00Z').getTime(), now),
+    ).toBe('7 ago');
+  });
+
+  it('otro año → incluye el año', () => {
+    expect(
+      formatRelativeDate(new Date('2025-08-07T10:00:00Z').getTime(), now),
+    ).toBe('7 ago 2025');
+  });
+
+  it('sin fecha → cadena vacía (no «NaN»)', () => {
+    expect(formatRelativeDate(0, now)).toBe('');
+  });
+});

--- a/mcm-app/__tests__/qrScan.test.ts
+++ b/mcm-app/__tests__/qrScan.test.ts
@@ -55,6 +55,23 @@ describe('parseScannedQr', () => {
     expect(parseScannedQr('')).toBeNull();
   });
 
+  it('reconoce el enlace de un coro en los dos flujos', () => {
+    expect(
+      parseScannedQr('https://mcm.expo.app/playlist?coro=consolacion-4f2a'),
+    ).toEqual({
+      kind: 'choir',
+      target: 'playlist',
+      choirId: 'consolacion-4f2a',
+    });
+    expect(
+      parseScannedQr('https://mcm.expo.app/coro?coro=consolacion-4f2a'),
+    ).toEqual({ kind: 'choir', target: 'choir', choirId: 'consolacion-4f2a' });
+    // `?c=` con un id de coro (en vez de 4 dígitos) también es una sesión.
+    expect(
+      parseScannedQr('https://mcm.expo.app/coro?c=consolacion-4f2a'),
+    ).toEqual({ kind: 'choir', target: 'choir', choirId: 'consolacion-4f2a' });
+  });
+
   it('ignora códigos mal formados dentro de un enlace nuestro', () => {
     expect(parseScannedQr('https://mcm.expo.app/playlist?p=12')).toBeNull();
     expect(parseScannedQr('https://mcm.expo.app/coro?c=abcd')).toBeNull();
@@ -71,6 +88,16 @@ describe('describeMismatch', () => {
   const choirCode = { kind: 'code', target: 'choir', code: '1234' } as const;
   const loose = { kind: 'code', target: null, code: '1234' } as const;
   const offline = { kind: 'offline', payload: '1~D5' } as const;
+  const choirLink = {
+    kind: 'choir',
+    target: 'playlist',
+    choirId: 'consolacion-4f2a',
+  } as const;
+  const choirLive = {
+    kind: 'choir',
+    target: 'choir',
+    choirId: 'consolacion-4f2a',
+  } as const;
 
   it('deja pasar el QR del flujo correcto', () => {
     expect(describeMismatch(playlistCode, 'playlist')).toBeNull();
@@ -81,6 +108,13 @@ describe('describeMismatch', () => {
   it('un código suelto vale para cualquiera de los dos flujos', () => {
     expect(describeMismatch(loose, 'playlist')).toBeNull();
     expect(describeMismatch(loose, 'choir')).toBeNull();
+  });
+
+  it('distingue el QR "última playlist del coro" del de sesión en vivo', () => {
+    expect(describeMismatch(choirLink, 'playlist')).toBeNull();
+    expect(describeMismatch(choirLive, 'choir')).toBeNull();
+    expect(describeMismatch(choirLive, 'playlist')).toMatch(/en vivo/i);
+    expect(describeMismatch(choirLink, 'choir')).toMatch(/playlist/i);
   });
 
   it('avisa cuando el QR es del otro flujo', () => {

--- a/mcm-app/app/coro.tsx
+++ b/mcm-app/app/coro.tsx
@@ -1,7 +1,7 @@
 /**
  * Pantalla "puente" del deep link `https://mcm.expo.app/coro?c=1234`.
  *
- * Toma el código `?c=` de la URL, lo persiste en una mini-cola in-memory
+ * Toma el código `?c=` (o el coro `?coro=`) de la URL, lo persiste en una mini-cola in-memory
  * y redirige al stack del cancionero. Allí, `CategoriesScreen` detectará
  * el pending code y navegará automáticamente a "Seleccionadas" para
  * unirse al coro.
@@ -10,19 +10,27 @@ import { useEffect } from 'react';
 import { View, ActivityIndicator, StyleSheet, Platform } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { setPendingChoirCode } from '@/utils/pendingCloudPlaylist';
-import { isValidCode } from '@/utils/playlistCodes';
+import { isSessionKey } from '@/services/choirSessionService';
 
 export default function ChoirDeepLink() {
-  const params = useLocalSearchParams<{ c?: string; code?: string }>();
+  const params = useLocalSearchParams<{
+    c?: string;
+    code?: string;
+    coro?: string;
+  }>();
+  // `?coro=<id>` es la forma nueva (la sesión cuelga del coro); `?c=` sigue
+  // valiendo para los dos: id de coro o código suelto de 4 dígitos.
   const code =
-    typeof params.c === 'string'
-      ? params.c
-      : typeof params.code === 'string'
-        ? params.code
-        : undefined;
+    typeof params.coro === 'string'
+      ? params.coro
+      : typeof params.c === 'string'
+        ? params.c
+        : typeof params.code === 'string'
+          ? params.code
+          : undefined;
 
   useEffect(() => {
-    if (code && isValidCode(code)) {
+    if (code && isSessionKey(code)) {
       setPendingChoirCode(code);
     }
     // En web, también limpiamos el query string para que no se quede en la URL.

--- a/mcm-app/app/playlist.tsx
+++ b/mcm-app/app/playlist.tsx
@@ -3,6 +3,10 @@
  *
  *  - `https://mcm.expo.app/playlist?p=1234` → playlist "en la nube": persiste el
  *    código de 4 dígitos para que SelectedSongs lo descargue de Firebase.
+ *  - `https://mcm.expo.app/playlist?coro=<id>` → **la última playlist de ese
+ *    coro**. Es el enlace que se comparte una vez y sirve para siempre: quien
+ *    lo abra se trae la lista de hoy sin que nadie tenga que pasar un código
+ *    nuevo cada domingo.
  *  - `mcmapp://playlist?d=<payload>` → playlist **offline**: el payload lleva la
  *    playlist entera embebida (categoría + número + tono/cejilla). Se persiste
  *    tal cual y se resuelve sin conexión en SelectedSongs contra el catálogo
@@ -15,16 +19,19 @@ import { useEffect } from 'react';
 import { View, ActivityIndicator, StyleSheet, Platform } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
+  setPendingChoirImport,
   setPendingCloudPlaylistCode,
   setPendingOfflinePlaylist,
 } from '@/utils/pendingCloudPlaylist';
 import { isValidCode } from '@/utils/playlistCodes';
+import { isChoirId } from '@/utils/choirIds';
 
 export default function PlaylistDeepLink() {
   const params = useLocalSearchParams<{
     p?: string;
     code?: string;
     d?: string;
+    coro?: string;
   }>();
   const code =
     typeof params.p === 'string'
@@ -33,10 +40,13 @@ export default function PlaylistDeepLink() {
         ? params.code
         : undefined;
   const offline = typeof params.d === 'string' ? params.d : undefined;
+  const choirId = typeof params.coro === 'string' ? params.coro : undefined;
 
   useEffect(() => {
     if (offline) {
       setPendingOfflinePlaylist(offline);
+    } else if (choirId && isChoirId(choirId)) {
+      setPendingChoirImport(choirId);
     } else if (code && isValidCode(code)) {
       setPendingCloudPlaylistCode(code);
     }
@@ -49,7 +59,7 @@ export default function PlaylistDeepLink() {
       }
     }
     router.replace('/(tabs)/cancionero' as any);
-  }, [code, offline]);
+  }, [code, offline, choirId]);
 
   return (
     <View style={styles.container}>

--- a/mcm-app/app/screens/CategoriesScreen.tsx
+++ b/mcm-app/app/screens/CategoriesScreen.tsx
@@ -32,6 +32,7 @@ import {
   consumePendingCloudPlaylistCode,
   consumePendingChoirCode,
   consumePendingOfflinePlaylist,
+  consumePendingChoirImport,
 } from '@/utils/pendingCloudPlaylist';
 
 const ALL_SONGS_CATEGORY_ID = '__ALL__';
@@ -122,17 +123,20 @@ export default function CategoriesScreen({
     toast.show({ variant: 'success', label: '¡Sugerencia enviada!' });
   };
 
-  // Deep link: si llegamos con un código pendiente de la nube
-  // (proveniente de /playlist?p=1234 o /coro?c=1234), saltamos a la pantalla de
-  // seleccionadas con ese código para que dispare el autoimport o auto-join.
+  // Deep link: si llegamos con algo pendiente de la nube (de /playlist?p=1234,
+  // /playlist?coro=<id> o /coro?coro=<id>), saltamos a la pantalla de
+  // seleccionadas con ese parámetro para que dispare el autoimport o auto-join.
   useEffect(() => {
     const pendingPlaylist = consumePendingCloudPlaylistCode();
     const pendingChoir = consumePendingChoirCode();
     const pendingOffline = consumePendingOfflinePlaylist();
+    const pendingChoirImport = consumePendingChoirImport();
 
     if (pendingOffline) {
       // setParams no funciona para una nueva pantalla; usamos navigate.
       navigation.navigate('SelectedSongs', { d: pendingOffline } as any);
+    } else if (pendingChoirImport) {
+      navigation.navigate('SelectedSongs', { coro: pendingChoirImport } as any);
     } else if (pendingPlaylist) {
       navigation.navigate('SelectedSongs', { p: pendingPlaylist } as any);
     } else if (pendingChoir) {

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -1387,42 +1387,55 @@ const SelectedSongsScreen: React.FC = () => {
               onPress: () => setCodeDialog({ variant: 'choir-join' }),
             },
           ]
-        : [
-            {
-              id: 'show-qr-choir',
-              icon: 'qr-code-2',
-              label: 'Ver QR del coro',
-              description: 'Quien lo escanee se une al coro directamente',
-              onPress: () =>
-                setQrModal({
-                  title: `Coro · Código ${choir.code}`,
-                  url: `${WEB_BASE_URL}/coro?c=${choir.code}`,
-                  code: choir.code ?? '',
-                }),
-            },
-            {
-              id: 'choir-change-code',
-              icon: 'edit',
-              label: 'Cambiar código del coro',
-              description: `Actual: ${choir.code}${choir.mode === 'slave' ? ' (solo el líder puede cambiarlo)' : ''}`,
-              onPress: () =>
-                setCodeDialog({
-                  variant: 'change-code',
-                  initial: choir.code ?? undefined,
-                }),
-              disabled: choir.mode !== 'master',
-            },
-            {
+        : (() => {
+            // La sesión puede colgar de un coro (clave = id del coro) o ser
+            // suelta (clave = 4 dígitos). No es lo mismo: a una sesión de coro
+            // NO se le puede cambiar el código, porque la clave *es* el coro —
+            // hacerlo la desataría de él y nadie del coro la encontraría.
+            const key = choir.code ?? '';
+            const esCoro = isChoirId(key);
+            const nombre = choir.session?.choirName ?? sharing.myChoir?.name;
+            const acciones: PlaylistAction[] = [
+              {
+                id: 'show-qr-choir',
+                icon: 'qr-code-2',
+                label: 'Ver QR de la sesión',
+                description: 'Quien lo escanee entra directamente',
+                onPress: () =>
+                  setQrModal({
+                    title: esCoro
+                      ? `${nombre ?? 'Coro'} · en vivo`
+                      : `Coro · Código ${key}`,
+                    url: esCoro
+                      ? `${WEB_BASE_URL}/coro?coro=${key}`
+                      : `${WEB_BASE_URL}/coro?c=${key}`,
+                    code: esCoro ? undefined : key,
+                  }),
+              },
+            ];
+            if (!esCoro) {
+              acciones.push({
+                id: 'choir-change-code',
+                icon: 'edit',
+                label: 'Cambiar código de la sesión',
+                description: `Actual: ${key}${choir.mode === 'slave' ? ' (solo el líder puede cambiarlo)' : ''}`,
+                onPress: () =>
+                  setCodeDialog({ variant: 'change-code', initial: key }),
+                disabled: choir.mode !== 'master',
+              });
+            }
+            acciones.push({
               id: 'choir-leave',
               icon: 'logout',
               label:
                 choir.mode === 'master'
-                  ? 'Cerrar sesión de coro'
-                  : 'Salir del coro',
+                  ? 'Cerrar la sesión en vivo'
+                  : 'Salir del coro en vivo',
               variant: 'danger',
               onPress: () => choir.leave(),
-            },
-          ];
+            });
+            return acciones;
+          })();
 
     // Vaciar ya no pasa por un diálogo de confirmación: se vacía y el toast
     // deja 10 s para deshacerlo. Empezar una lista de cero es de las cosas que
@@ -1440,26 +1453,33 @@ const SelectedSongsScreen: React.FC = () => {
 
     // Sin canciones no se puede compartir, exportar, subir ni vaciar NADA: esas
     // opciones se quitan en vez de dejarse muertas (una lista llena de cosas
-    // que no hacen nada es peor que una lista corta). Se quedan las de IMPORTAR
-    // —que son justo las que tienen sentido con la playlist vacía— y el modo
-    // coro, donde las canciones las pone el maestro después.
+    // que no hacen nada es peor que una lista corta). Se quedan las que SÍ
+    // funcionan con la lista vacía: importar, el hub del coro, compartir el
+    // enlace del coro (que no depende de tu selección) y el modo coro en vivo,
+    // donde las canciones las pone el líder después.
+    const VIVAS_SIN_CANCIONES = new Set([
+      'download-cloud',
+      'choir-hub',
+      'share-choir-link',
+    ]);
     const soloImportar = <T extends PlaylistAction>(as: T[]) =>
       as.filter(
-        (a) =>
-          a.id.startsWith('import') ||
-          a.id === 'download-cloud' ||
-          a.id === 'choir-hub',
+        (a) => a.id.startsWith('import') || VIVAS_SIN_CANCIONES.has(a.id),
       );
 
+    // Orden por frecuencia de uso real: traer/guardar la del coro es lo que se
+    // hace cada semana; exportar el mensaje de WhatsApp o el PDF, casi igual de
+    // a menudo; el coro en vivo, los domingos; y los códigos, los QR y los
+    // archivos son la trastienda para casos raros.
     return [
       { title: 'Mi coro', actions: coroPlaylists },
       { title: 'Exportar y compartir', actions: hasSongs ? exportar : [] },
       { title: 'Coro en vivo', actions: coro },
-      { title: 'Archivo', actions: hasSongs ? archivo : soloImportar(archivo) },
       {
         title: 'Códigos y QR',
         actions: hasSongs ? nube : soloImportar(nube),
       },
+      { title: 'Archivo', actions: hasSongs ? archivo : soloImportar(archivo) },
       { actions: hasSongs ? peligro : [] },
     ];
   }, [

--- a/mcm-app/app/screens/SelectedSongsScreen.tsx
+++ b/mcm-app/app/screens/SelectedSongsScreen.tsx
@@ -23,7 +23,6 @@ import { PressableFeedback } from 'heroui-native';
 import AppTextField from '@/components/ui/AppTextField';
 import { useToast } from '@/contexts/AppToastContext';
 import { extractSongMedia } from '@/types/songMedia';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
@@ -76,18 +75,29 @@ import ConfirmChoiceModal from '@/components/playlist/ConfirmChoiceModal';
 import ShareQrModal from '@/components/playlist/ShareQrModal';
 import PasswordPromptModal from '@/components/playlist/PasswordPromptModal';
 import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
+import ChoirSheet from '@/components/playlist/ChoirSheet';
 
 import {
-  cloudPlaylistExists,
   fetchCloudPlaylist,
   uploadCloudPlaylist,
   changeCloudPlaylistCode,
   deleteCloudPlaylist,
 } from '@/services/cloudPlaylistService';
 import {
+  removeChoirPlaylist,
+  upsertChoirPlaylist,
+} from '@/services/choirDirectoryService';
+import {
   choirSessionExists,
   fetchChoirSession,
+  fetchLiveChoirSession,
 } from '@/services/choirSessionService';
+import {
+  usePlaylistSharing,
+  SHARED_PASSWORD,
+} from '@/hooks/usePlaylistSharing';
+import { playlistSignature } from '@/utils/playlistSync';
+import { isChoirId } from '@/utils/choirIds';
 import { transposeLabel, transposeKey } from '@/utils/transposeKey';
 import { convertChord } from '@/utils/chordNotation';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -128,19 +138,9 @@ const WEB_BASE_URL = 'https://mcm.expo.app';
 /** Esquema propio para deep links offline (playlist embebida en la URL). */
 const APP_SCHEME = 'mcmapp://';
 
-/** Contraseña para sobrescribir una playlist en la nube que ya existe. */
-const OVERWRITE_PASSWORD = 'coco';
-
 const SelectedSongsScreen: React.FC = () => {
-  const {
-    selectedSongs,
-    isHydrated,
-    clearSelection,
-    addSong,
-    removeSong,
-    moveSong,
-    replaceAll,
-  } = useSelectedSongs();
+  const { selectedSongs, isHydrated, addSong, removeSong, moveSong } =
+    useSelectedSongs();
   const choir = useChoirSession();
   const { settings } = useSettings();
 
@@ -207,40 +207,52 @@ const SelectedSongsScreen: React.FC = () => {
     name?: string;
   } | null>(null);
 
-  // Código de la última subida a la nube (para "cambiar código" / "borrar").
-  // Persistido para sobrevivir al cierre de la app.
-  const [lastUploadCode, setLastUploadCodeState] = useState<string | null>(
-    null,
-  );
-  const LAST_UPLOAD_CODE_KEY = '@mcm_last_upload_code';
-  useEffect(() => {
-    AsyncStorage.getItem(LAST_UPLOAD_CODE_KEY).then((v) => {
-      if (v) setLastUploadCodeState(v);
-    });
-  }, []);
-  const setLastUploadCode = useCallback((code: string | null) => {
-    setLastUploadCodeState(code);
-    if (code) {
-      AsyncStorage.setItem(LAST_UPLOAD_CODE_KEY, code).catch(() => {});
-    } else {
-      AsyncStorage.removeItem(LAST_UPLOAD_CODE_KEY).catch(() => {});
-    }
-  }, []);
+  // Estado de "compartir": coro elegido, enlace con la nube, deshacer,
+  // contraseña… todo vive en su propio hook (ver `usePlaylistSharing`).
+  const sharing = usePlaylistSharing({
+    onShowQr: (l) =>
+      setQrModal({
+        title: l.name ? `${l.name} · #${l.code}` : `Playlist · #${l.code}`,
+        url: `${WEB_BASE_URL}/playlist?p=${l.code}`,
+        code: l.code,
+      }),
+  });
+  const link = sharing.link;
 
-  // Auto-import / auto-join si llegamos con ?p=XXXX o ?c=YYYY en web (deep link).
+  // Auto-import / auto-join al llegar por un enlace:
+  //   ?p=1234    → playlist por código
+  //   ?coro=id   → la ÚLTIMA playlist de ese coro (siempre la de hoy)
+  //   ?c=1234|id → sesión de coro en vivo
+  // En los tres casos se reemplaza la selección directamente y el toast deja
+  // 10 s para deshacer: venir de un enlace y que te pregunten tres cosas antes
+  // de enseñarte nada era el peor momento posible para un diálogo.
   const autoImportAttempted = useRef(false);
   useEffect(() => {
     if (autoImportAttempted.current) return;
     const params: any = (route?.params as any) || {};
     const playlistCode = params.p ?? params.code;
-    const choirCode = params.c;
+    const choirParam = params.coro;
+    const liveKey = params.c;
 
     if (typeof playlistCode === 'string' && /^\d{4}$/.test(playlistCode)) {
       autoImportAttempted.current = true;
-      void handleDownloadFromCloud(playlistCode);
-    } else if (typeof choirCode === 'string' && /^\d{4}$/.test(choirCode)) {
+      void sharing.importByCode(playlistCode).catch((e: any) => {
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido importar',
+        });
+      });
+    } else if (typeof choirParam === 'string' && isChoirId(choirParam)) {
       autoImportAttempted.current = true;
-      void handleJoinChoir(choirCode);
+      void sharing.importLatestFromChoir(choirParam).catch((e: any) => {
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido importar',
+        });
+      });
+    } else if (typeof liveKey === 'string' && liveKey) {
+      autoImportAttempted.current = true;
+      void handleJoinChoir(liveKey);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -262,7 +274,7 @@ const SelectedSongsScreen: React.FC = () => {
         toast.show({ label: 'No se pudo leer la playlist del QR' });
         return;
       }
-      askMergeOrReplace(songs);
+      sharing.replaceWithUndo(songs, 'Playlist del QR importada', null);
       if (missing > 0) {
         toast.show({
           label: `${missing} canción(es) del QR no están en este dispositivo`,
@@ -731,14 +743,21 @@ const SelectedSongsScreen: React.FC = () => {
     }
   }, []);
 
-  /** Muestra el confirmador "reemplazar / añadir / cancelar" tras una importación. */
+  /**
+   * Importación desde ARCHIVO (.mcm). Es el único sitio donde seguimos
+   * preguntando "reemplazar o añadir": un archivo suele ser un trozo de
+   * repertorio que quieres juntar con lo tuyo, mientras que una playlist del
+   * coro o de un enlace es "la lista de hoy" y ahí reemplazar y ofrecer
+   * deshacer es más rápido y menos confuso.
+   */
   const askMergeOrReplace = useCallback(
     (imported: SelectedSong[]) => {
       if (selectedSongs.length === 0) {
-        replaceAll(imported);
-        toast.show({
-          label: `Playlist importada (${imported.length} canciones)`,
-        });
+        sharing.replaceWithUndo(
+          imported,
+          `Playlist importada (${imported.length} canciones)`,
+          null,
+        );
         return;
       }
       setConfirmDialog({
@@ -750,8 +769,7 @@ const SelectedSongsScreen: React.FC = () => {
             variant: 'primary',
             onPress: () => {
               setConfirmDialog(null);
-              replaceAll(imported);
-              toast.show({ label: 'Playlist reemplazada' });
+              sharing.replaceWithUndo(imported, 'Playlist reemplazada', null);
             },
           },
           {
@@ -779,7 +797,7 @@ const SelectedSongsScreen: React.FC = () => {
         ],
       });
     },
-    [selectedSongs, replaceAll, addSong, toast],
+    [selectedSongs, sharing, addSong, toast],
   );
 
   const handleImportFile = useCallback(async () => {
@@ -835,24 +853,53 @@ const SelectedSongsScreen: React.FC = () => {
 
   // --- Nube -----------------------------------------------------------------
 
+  /** Guarda el enlace local tras subir con código suelto (sin coro). */
+  const rememberUpload = useCallback(
+    (code: string, name?: string) => {
+      sharing.setLink({
+        code,
+        name,
+        choirId: link?.code === code ? link.choirId : undefined,
+        choirName: link?.code === code ? link.choirName : undefined,
+        signature: playlistSignature(selectedSongs),
+        syncedAt: Date.now(),
+        owned: true,
+      });
+    },
+    [sharing, link, selectedSongs],
+  );
+
+  /**
+   * Subida por CÓDIGO (opción secundaria; lo normal es subir al coro).
+   *
+   * Si el código está ocupado ya no es un callejón sin salida: cualquiera
+   * puede machacarlo escribiendo la contraseña, y si la playlist la subiste tú
+   * desde este mismo dispositivo ni siquiera se pide.
+   */
   const handleUploadToCloud = useCallback(
     async (code: string, name?: string) => {
-      const exists = await cloudPlaylistExists(code);
-      if (exists) {
-        // El código ya tiene contenido (tuyo o de otra persona). Para
-        // machacarlo pedimos la contraseña; también se puede elegir otro
-        // código. Cerramos el diálogo de código para no apilar modales.
+      const existing = await fetchCloudPlaylist(code);
+      const mine =
+        !!existing &&
+        ((!!existing.ownerDeviceId &&
+          existing.ownerDeviceId === sharing.identity.deviceId) ||
+          (link?.code === code && link.owned));
+      if (existing && !mine) {
+        // Ocupado por otra persona: se puede machacar con la contraseña o
+        // coger otro código. Cerramos el diálogo para no apilar modales.
         setCodeDialog(null);
         setConfirmDialog({
-          title: 'Código ocupado',
-          description: `Ya hay una playlist subida con el código ${code}. Para sobrescribirla necesitas la contraseña.`,
+          title: 'Ese código ya está ocupado',
+          description: `Hay una playlist${
+            existing.name ? ` («${existing.name}»)` : ''
+          } en el código ${code}. Puedes machacarla con la contraseña del coro o subir la tuya con otro código.`,
           actions: [
             {
-              label: 'Sobrescribir…',
+              label: 'Sobrescribirla…',
               variant: 'danger',
               onPress: () => {
                 setConfirmDialog(null);
-                setPendingOverwrite({ code, name });
+                setPendingOverwrite({ code, name: name ?? existing.name });
               },
             },
             {
@@ -860,7 +907,7 @@ const SelectedSongsScreen: React.FC = () => {
               variant: 'primary',
               onPress: () => {
                 setConfirmDialog(null);
-                setCodeDialog({ variant: 'cloud-upload', initial: undefined });
+                setCodeDialog({ variant: 'cloud-upload' });
               },
             },
             {
@@ -873,13 +920,20 @@ const SelectedSongsScreen: React.FC = () => {
         // Lanzamos error para que el diálogo no se cierre automáticamente.
         throw new Error('__handled__');
       }
-      await uploadCloudPlaylist(code, selectedSongs, { name });
-      setLastUploadCode(code);
+      await uploadCloudPlaylist(code, selectedSongs, {
+        name,
+        createdAt: existing?.createdAt,
+        choirId: existing?.choirId,
+        choirName: existing?.choirName,
+        by: sharing.identity.name,
+        ownerDeviceId: sharing.identity.deviceId,
+      });
+      rememberUpload(code, name);
       setCodeDialog(null);
       showUploadSuccess(code, name);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedSongs],
+    [selectedSongs, link, sharing.identity, rememberUpload],
   );
 
   /** Subida tras validar la contraseña de sobrescritura. */
@@ -888,16 +942,22 @@ const SelectedSongsScreen: React.FC = () => {
     setPendingOverwrite(null);
     if (!pending) return;
     try {
+      const existing = await fetchCloudPlaylist(pending.code);
       await uploadCloudPlaylist(pending.code, selectedSongs, {
         name: pending.name,
+        createdAt: existing?.createdAt,
+        choirId: existing?.choirId,
+        choirName: existing?.choirName,
+        by: sharing.identity.name,
+        ownerDeviceId: sharing.identity.deviceId,
       });
-      setLastUploadCode(pending.code);
+      rememberUpload(pending.code, pending.name);
       showUploadSuccess(pending.code, pending.name);
     } catch (e: any) {
       toast.show({ label: e?.message ?? 'Error al subir' });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingOverwrite, selectedSongs]);
+  }, [pendingOverwrite, selectedSongs, sharing.identity, rememberUpload]);
 
   const showUploadSuccess = useCallback(
     (code: string, name?: string) => {
@@ -929,14 +989,10 @@ const SelectedSongsScreen: React.FC = () => {
 
   const handleDownloadFromCloud = useCallback(
     async (code: string) => {
-      const data = await fetchCloudPlaylist(code);
-      if (!data) {
-        throw new Error('No existe ninguna playlist con ese código');
-      }
+      await sharing.importByCode(code);
       setCodeDialog(null);
-      askMergeOrReplace(data.songs);
     },
-    [askMergeOrReplace],
+    [sharing],
   );
 
   /**
@@ -955,32 +1011,65 @@ const SelectedSongsScreen: React.FC = () => {
         return;
       }
       setCodeDialog(null);
-      askMergeOrReplace(songs);
+      sharing.replaceWithUndo(songs, 'Playlist del QR importada', null);
       if (missing > 0) {
         toast.show({
           label: `${missing} canción(es) del QR no están en este dispositivo`,
         });
       }
     },
-    [askMergeOrReplace, offlineFilenameResolver, toast],
+    [sharing, offlineFilenameResolver, toast],
+  );
+
+  /** QR de coro escaneado desde "importar": traemos su última playlist. */
+  const handleScannedChoirQr = useCallback(
+    (choirId: string) => {
+      setCodeDialog(null);
+      void sharing.importLatestFromChoir(choirId).catch((e: any) => {
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido importar',
+        });
+      });
+    },
+    [sharing, toast],
   );
 
   const handleChangeCloudCode = useCallback(
     async (newCode: string) => {
-      if (!lastUploadCode) return;
-      await changeCloudPlaylistCode(lastUploadCode, newCode);
-      setLastUploadCode(newCode);
+      if (!link) return;
+      await changeCloudPlaylistCode(link.code, newCode);
+      // El índice del coro va por código, así que hay que rehacer la entrada.
+      if (link.choirId) {
+        try {
+          await removeChoirPlaylist(link.choirId, link.code);
+          await upsertChoirPlaylist(link.choirId, {
+            code: newCode,
+            name: link.name ?? `Playlist ${newCode}`,
+            createdAt: link.syncedAt,
+            updatedAt: Date.now(),
+            songCount: selectedSongs.length,
+            ownerDeviceId: sharing.identity.deviceId,
+          });
+        } catch (e) {
+          logger.error('reindex choir playlist error', e);
+        }
+      }
+      sharing.setLink({ ...link, code: newCode });
       setCodeDialog(null);
       toast.show({ label: `Código cambiado a ${newCode}` });
     },
-    [lastUploadCode, toast, setLastUploadCode],
+    [link, toast, sharing, selectedSongs.length],
   );
 
   const handleDeleteFromCloud = useCallback(async () => {
-    if (!lastUploadCode) return;
+    if (!link) return;
+    const { code, choirId, name } = link;
     setConfirmDialog({
-      title: `Borrar playlist ${lastUploadCode} de la nube`,
-      description: 'Cualquiera con el código dejará de poder importarla.',
+      title: `Borrar «${name ?? code}» de la nube`,
+      description: choirId
+        ? 'Desaparece del histórico del coro y nadie podrá importarla.'
+        : 'Cualquiera con el código dejará de poder importarla.',
       actions: [
         {
           label: 'Borrar de la nube',
@@ -988,8 +1077,9 @@ const SelectedSongsScreen: React.FC = () => {
           onPress: async () => {
             setConfirmDialog(null);
             try {
-              await deleteCloudPlaylist(lastUploadCode);
-              setLastUploadCode(null);
+              await deleteCloudPlaylist(code);
+              if (choirId) await removeChoirPlaylist(choirId, code);
+              sharing.setLink(null);
               toast.show({ label: 'Borrada de la nube' });
             } catch (e: any) {
               toast.show({ label: e?.message ?? 'Error al borrar' });
@@ -1003,7 +1093,7 @@ const SelectedSongsScreen: React.FC = () => {
         },
       ],
     });
-  }, [lastUploadCode, toast, setLastUploadCode]);
+  }, [link, toast, sharing]);
 
   // --- Coro -----------------------------------------------------------------
 
@@ -1025,7 +1115,9 @@ const SelectedSongsScreen: React.FC = () => {
               onPress: async () => {
                 setConfirmDialog(null);
                 try {
-                  await choir.startAsMaster(code, selectedSongs);
+                  await choir.startAsMaster(code, selectedSongs, {
+                    name: sharing.identity.name,
+                  });
                   showChoirSuccess(code);
                 } catch (e: any) {
                   toast.show({ label: e?.message ?? 'Error al iniciar' });
@@ -1049,26 +1141,36 @@ const SelectedSongsScreen: React.FC = () => {
         });
         throw new Error('__handled__');
       }
-      await choir.startAsMaster(code, selectedSongs);
+      await choir.startAsMaster(code, selectedSongs, {
+        name: sharing.identity.name,
+      });
       setCodeDialog(null);
       showChoirSuccess(code);
     },
-    [choir, selectedSongs, toast, showChoirSuccess],
+    [choir, selectedSongs, toast, showChoirSuccess, sharing.identity.name],
   );
 
   const handleJoinChoir = useCallback(
-    async (code: string) => {
-      const session = await fetchChoirSession(code);
+    async (key: string) => {
+      // `fetchLive…` ignora las caducadas (24 h): mejor decir "no hay sesión"
+      // que meter al usuario en una que va a expulsarle en el siguiente tic.
+      const session = await fetchLiveChoirSession(key);
       if (!session) {
-        throw new Error('No existe sesión con ese código');
+        throw new Error('No hay ninguna sesión de coro abierta ahí');
       }
-      // Importamos la playlist del maestro como nuestra selección base.
-      replaceAll(session.playlist || []);
-      await choir.joinAsSlave(code);
+      // La playlist del líder pasa a ser la nuestra — con 10 s para deshacer,
+      // que unirse al coro no debería costarte tu propia lista.
+      sharing.replaceWithUndo(
+        session.playlist || [],
+        `Sigues a ${session.master?.name || 'el líder'}${
+          session.choirName ? ` en ${session.choirName}` : ''
+        }`,
+        null,
+      );
+      await choir.joinAsSlave(key);
       setCodeDialog(null);
-      toast.show({ label: `Conectado al coro ${code}` });
     },
-    [choir, replaceAll, toast],
+    [choir, sharing],
   );
 
   const handleChangeChoirCode = useCallback(
@@ -1131,22 +1233,53 @@ const SelectedSongsScreen: React.FC = () => {
       },
     ];
 
+    // El coro es ahora la vía principal: nadie tiene que acordarse de códigos.
+    const coroPlaylists: PlaylistAction[] = [
+      {
+        id: 'choir-hub',
+        icon: 'groups',
+        label: sharing.myChoir
+          ? `Coro: ${sharing.myChoir.name}`
+          : 'Elegir mi coro',
+        description: sharing.myChoir
+          ? 'Importar la última, ver el histórico o dirigir en vivo'
+          : 'Las playlists cuelgan del coro. Elígelo una vez y listo.',
+        onPress: () => sharing.openSheet(sharing.myChoir ? 'home' : 'choose'),
+      },
+    ];
+    if (hasSongs) {
+      coroPlaylists.push({
+        id: 'choir-save',
+        icon: 'cloud-upload',
+        label: link
+          ? 'Guardar cambios en el coro'
+          : 'Subir esta playlist al coro',
+        description: link
+          ? sharing.isSynced
+            ? `«${link.name ?? link.code}» ya está al día`
+            : `Actualizar «${link.name ?? link.code}» o subir una nueva`
+          : `${flatSelectedSongs.length} canciones para todo el coro`,
+        onPress: () => sharing.openSheet(sharing.myChoir ? 'save' : 'choose'),
+      });
+    }
+
+    // Códigos y QR: se mantienen, pero como opción secundaria.
     const nube: PlaylistAction[] = [
+      {
+        id: 'download-cloud',
+        icon: 'pin',
+        label: 'Importar con un código',
+        description: 'Los 4 dígitos que te han pasado (o escanear un QR)',
+        onPress: () => setCodeDialog({ variant: 'cloud-download' }),
+      },
       {
         id: 'upload-cloud',
         icon: 'cloud-upload',
-        label: 'Subir playlist (compartir código)',
-        description: lastUploadCode
-          ? `Código actual: ${lastUploadCode}`
-          : 'Cualquiera con el código podrá importarla',
+        label: 'Subir con un código suelto',
+        description: link
+          ? `Sin coro. Código actual: ${link.code}`
+          : 'Sin coro: solo quien tenga el código podrá importarla',
         onPress: () => setCodeDialog({ variant: 'cloud-upload' }),
-      },
-      {
-        id: 'download-cloud',
-        icon: 'cloud-download',
-        label: 'Importar playlist con código',
-        description: 'Introduce el código de 4 dígitos que te han pasado',
-        onPress: () => setCodeDialog({ variant: 'cloud-download' }),
       },
     ];
     if (offlineUrl) {
@@ -1160,29 +1293,43 @@ const SelectedSongsScreen: React.FC = () => {
         description: 'Dos pestañas: con código (internet) o sin conexión',
         onPress: () =>
           setQrModal({
-            title: lastUploadCode
-              ? `Playlist · Código ${lastUploadCode}`
+            title: link
+              ? `${link.name ?? 'Playlist'} · #${link.code}`
               : 'Compartir playlist',
-            url: lastUploadCode
-              ? `${WEB_BASE_URL}/playlist?p=${lastUploadCode}`
-              : undefined,
-            code: lastUploadCode ?? undefined,
+            url: link ? `${WEB_BASE_URL}/playlist?p=${link.code}` : undefined,
+            code: link?.code,
             offlineUrl,
-            defaultMode: lastUploadCode ? 'online' : 'offline',
+            defaultMode: link ? 'online' : 'offline',
           }),
       });
     }
-    if (lastUploadCode) {
+    if (sharing.myChoir) {
+      nube.push({
+        id: 'share-choir-link',
+        icon: 'link',
+        label: 'Enlace del coro (siempre la última)',
+        description: `Quien lo abra importa la última playlist de ${sharing.myChoir.name}`,
+        onPress: () =>
+          setQrModal({
+            title: `${sharing.myChoir!.name} · última playlist`,
+            url: `${WEB_BASE_URL}/playlist?coro=${sharing.myChoir!.id}`,
+          }),
+      });
+    }
+    // Cambiar el código o borrar de la nube solo tiene sentido sobre una
+    // playlist que subiste tú: sobre la de otra persona sería un destrozo
+    // silencioso (para eso está "actualizar", que sí pide la contraseña).
+    if (link?.owned) {
       nube.push(
         {
           id: 'change-cloud-code',
           icon: 'edit',
           label: 'Cambiar código de la playlist',
-          description: `Actual: ${lastUploadCode}`,
+          description: `Actual: ${link.code}`,
           onPress: () =>
             setCodeDialog({
               variant: 'change-code',
-              initial: lastUploadCode,
+              initial: link.code,
             }),
         },
         {
@@ -1215,17 +1362,26 @@ const SelectedSongsScreen: React.FC = () => {
       choir.mode === 'off'
         ? [
             {
-              id: 'choir-start',
+              id: 'choir-live-hub',
               icon: 'campaign',
-              label: 'Iniciar sesión de coro (ser líder)',
-              description:
-                'Otros dispositivos te siguen con un código de 4 dígitos',
+              label: 'Dirigir o seguir a mi coro',
+              description: sharing.myChoir
+                ? `Sin códigos: se entra por ${sharing.myChoir.name}`
+                : 'Elige tu coro y dirige (o síguele) en vivo',
+              onPress: () =>
+                sharing.openSheet(sharing.myChoir ? 'home' : 'choose'),
+            },
+            {
+              id: 'choir-start',
+              icon: 'pin',
+              label: 'Sesión suelta con código',
+              description: 'Para un ensayo puntual fuera de tu coro',
               onPress: () => setCodeDialog({ variant: 'choir-start' }),
             },
             {
               id: 'choir-join',
               icon: 'headphones',
-              label: 'Unirse a sesión de coro',
+              label: 'Unirse con un código',
               description:
                 'Introduces un código y sigues las canciones del líder',
               onPress: () => setCodeDialog({ variant: 'choir-join' }),
@@ -1268,33 +1424,17 @@ const SelectedSongsScreen: React.FC = () => {
             },
           ];
 
+    // Vaciar ya no pasa por un diálogo de confirmación: se vacía y el toast
+    // deja 10 s para deshacerlo. Empezar una lista de cero es de las cosas que
+    // más se hacen y era de las más pesadas (menú → confirmar → aceptar).
     const peligro: PlaylistAction[] = [
       {
         id: 'clear',
         icon: 'delete-outline',
-        label: 'Vaciar playlist',
+        label: 'Vaciar playlist y empezar de cero',
+        description: 'Se puede deshacer justo después',
         variant: 'danger',
-        onPress: () => {
-          setConfirmDialog({
-            title: '¿Vaciar la playlist?',
-            description: 'Se quitarán todas las canciones seleccionadas.',
-            actions: [
-              {
-                label: 'Vaciar',
-                variant: 'danger',
-                onPress: () => {
-                  clearSelection();
-                  setConfirmDialog(null);
-                },
-              },
-              {
-                label: 'Cancelar',
-                variant: 'secondary',
-                onPress: () => setConfirmDialog(null),
-              },
-            ],
-          });
-        },
+        onPress: sharing.clearWithUndo,
       },
     ];
 
@@ -1304,16 +1444,22 @@ const SelectedSongsScreen: React.FC = () => {
     // —que son justo las que tienen sentido con la playlist vacía— y el modo
     // coro, donde las canciones las pone el maestro después.
     const soloImportar = <T extends PlaylistAction>(as: T[]) =>
-      as.filter((a) => a.id.startsWith('import') || a.id === 'download-cloud');
+      as.filter(
+        (a) =>
+          a.id.startsWith('import') ||
+          a.id === 'download-cloud' ||
+          a.id === 'choir-hub',
+      );
 
     return [
+      { title: 'Mi coro', actions: coroPlaylists },
       { title: 'Exportar y compartir', actions: hasSongs ? exportar : [] },
+      { title: 'Coro en vivo', actions: coro },
+      { title: 'Archivo', actions: hasSongs ? archivo : soloImportar(archivo) },
       {
-        title: 'Playlist en la nube',
+        title: 'Códigos y QR',
         actions: hasSongs ? nube : soloImportar(nube),
       },
-      { title: 'Archivo', actions: hasSongs ? archivo : soloImportar(archivo) },
-      { title: 'Modo coro', actions: coro },
       { actions: hasSongs ? peligro : [] },
     ];
   }, [
@@ -1322,14 +1468,22 @@ const SelectedSongsScreen: React.FC = () => {
     handleStartExportFile,
     handleStartExportPdf,
     handleImportFile,
-    lastUploadCode,
+    link,
+    sharing,
+    flatSelectedSongs.length,
     offlineUrl,
     choir,
     handleDeleteFromCloud,
-    clearSelection,
   ]);
 
   // --- Header ---------------------------------------------------------------
+
+  /** Abre la hoja del coro por el paso que toque según si ya hay coro elegido. */
+  const openChoirSheet = useCallback(
+    (step: 'home' | 'save' = 'home') =>
+      sharing.openSheet(sharing.myChoir ? step : 'choose'),
+    [sharing],
+  );
 
   const headerIconColor =
     Platform.OS === 'ios' || Platform.OS === 'web'
@@ -1342,6 +1496,16 @@ const SelectedSongsScreen: React.FC = () => {
     navigation.setOptions({
       headerRight: () => (
         <View style={styles.headerActions}>
+          {/* El coro a un toque: es el camino principal para traer y dejar
+              playlists, así que no puede vivir escondido en el menú. */}
+          <TouchableOpacity
+            onPress={() => openChoirSheet()}
+            style={styles.headerIconBtn}
+            hitSlop={6}
+            accessibilityLabel="Playlists del coro"
+          >
+            <MaterialIcons name="groups" size={24} color={headerIconColor} />
+          </TouchableOpacity>
           <TouchableOpacity
             onPress={() => setShowActions(true)}
             style={styles.headerIconBtn}
@@ -1357,12 +1521,13 @@ const SelectedSongsScreen: React.FC = () => {
         </View>
       ),
     });
-  }, [navigation, headerIconColor, styles]);
+  }, [navigation, headerIconColor, styles, openChoirSheet]);
 
   // --- Render ---------------------------------------------------------------
 
   const submitForVariant = (
     variant: CodeDialogVariant,
+    initial?: string,
   ): ((code: string, name?: string) => Promise<void>) => {
     switch (variant) {
       case 'cloud-upload':
@@ -1374,10 +1539,13 @@ const SelectedSongsScreen: React.FC = () => {
       case 'choir-join':
         return handleJoinChoir;
       case 'change-code':
-        return lastUploadCode
-          ? handleChangeCloudCode
-          : choir.mode === 'master'
-            ? handleChangeChoirCode
+        // El mismo diálogo sirve para renombrar el código de la playlist y el
+        // de la sesión de coro. Lo desambigua el código con el que se abrió:
+        // si es el de la sesión en curso, estamos cambiando el del coro.
+        return initial && initial === choir.code && choir.mode === 'master'
+          ? handleChangeChoirCode
+          : link
+            ? handleChangeCloudCode
             : async () => {};
     }
   };
@@ -1399,31 +1567,35 @@ const SelectedSongsScreen: React.FC = () => {
         </Text>
       </View>
       <View style={{ gap: 10, marginBottom: Platform.OS === 'ios' ? 100 : 20 }}>
+        {/* Con la lista vacía, lo primero que quiere casi todo el mundo es
+            traerse la del coro: va la primera y sin pedir ningún código. */}
+        <PressableFeedback
+          onPress={() => openChoirSheet()}
+          style={styles.importButton}
+        >
+          <PressableFeedback.Highlight />
+          <MaterialIcons
+            name="groups"
+            size={20}
+            color={isDark ? '#7AB3FF' : '#253883'}
+          />
+          <Text style={styles.importButtonText}>
+            {sharing.myChoir
+              ? `Traer la playlist de ${sharing.myChoir.name}`
+              : 'Elegir mi coro e importar'}
+          </Text>
+        </PressableFeedback>
         <PressableFeedback
           onPress={() => setCodeDialog({ variant: 'cloud-download' })}
           style={styles.importButton}
         >
           <PressableFeedback.Highlight />
           <MaterialIcons
-            name="cloud-download"
+            name="pin"
             size={20}
             color={isDark ? '#7AB3FF' : '#253883'}
           />
-          <Text style={styles.importButtonText}>
-            Importar playlist con código
-          </Text>
-        </PressableFeedback>
-        <PressableFeedback
-          onPress={() => setCodeDialog({ variant: 'choir-join' })}
-          style={styles.importButton}
-        >
-          <PressableFeedback.Highlight />
-          <MaterialIcons
-            name="headphones"
-            size={20}
-            color={isDark ? '#7AB3FF' : '#253883'}
-          />
-          <Text style={styles.importButtonText}>Unirme a un coro</Text>
+          <Text style={styles.importButtonText}>Tengo un código o un QR</Text>
         </PressableFeedback>
         <PressableFeedback
           onPress={handleImportFile}
@@ -1445,13 +1617,25 @@ const SelectedSongsScreen: React.FC = () => {
     () => (
       <PlaylistHeaderBar
         visibleCount={visibleCount}
-        lastUploadCode={lastUploadCode}
+        link={link}
+        isSynced={sharing.isSynced}
+        onPressStatus={() => openChoirSheet('save')}
+        onClear={sharing.clearWithUndo}
         viewMode={viewMode}
         setViewMode={setViewMode}
         styles={styles}
       />
     ),
-    [visibleCount, lastUploadCode, viewMode, setViewMode, styles],
+    [
+      visibleCount,
+      link,
+      sharing.isSynced,
+      sharing.clearWithUndo,
+      openChoirSheet,
+      viewMode,
+      setViewMode,
+      styles,
+    ],
   );
 
   const renderCategoryGroup = ({ item }: { item: CategorizedSongs }) => (
@@ -1632,8 +1816,13 @@ const SelectedSongsScreen: React.FC = () => {
               ? handleScannedOfflinePlaylist
               : undefined
           }
+          onScanChoir={
+            codeDialog.variant === 'cloud-download'
+              ? handleScannedChoirQr
+              : undefined
+          }
           onSubmit={async (code, name) => {
-            const fn = submitForVariant(codeDialog.variant);
+            const fn = submitForVariant(codeDialog.variant, codeDialog.initial);
             try {
               await fn(code, name);
             } catch (e: any) {
@@ -1667,12 +1856,48 @@ const SelectedSongsScreen: React.FC = () => {
         />
       ) : null}
 
+      {/* Hoja del coro: elegir coro, importar la última, histórico, guardar y
+          dirigir/seguir en vivo. Es el camino principal; los códigos quedan
+          como opción secundaria dentro del menú de acciones. */}
+      <ChoirSheet
+        visible={sharing.sheetStep !== null}
+        initialStep={sharing.sheetStep ?? 'home'}
+        myChoir={sharing.myChoir}
+        onChooseChoir={sharing.setMyChoir}
+        songCount={flatSelectedSongs.length}
+        link={link}
+        identity={sharing.identity}
+        liveMode={choir.mode}
+        liveKey={choir.code}
+        onImport={(entry, c) => void sharing.importEntry(entry, c)}
+        onSaveNew={(name, c) => void sharing.saveNew(name, c)}
+        onSaveUpdate={sharing.saveUpdate}
+        onLead={sharing.lead}
+        onJoinLive={(c, session) => void sharing.joinLive(c, session)}
+        onLeaveLive={sharing.leaveLive}
+        onClose={sharing.closeSheet}
+      />
+
+      {/* Contraseña compartida ('coco'): machacar la playlist de otra persona
+          o quitarle el mando al líder de un coro. */}
+      {sharing.passwordRequest ? (
+        <PasswordPromptModal
+          visible
+          title={sharing.passwordRequest.title}
+          description={sharing.passwordRequest.description}
+          expectedPassword={SHARED_PASSWORD}
+          confirmLabel={sharing.passwordRequest.confirmLabel}
+          onSuccess={sharing.passwordRequest.onSuccess}
+          onClose={sharing.dismissPassword}
+        />
+      ) : null}
+
       {pendingOverwrite ? (
         <PasswordPromptModal
           visible
           title="Sobrescribir playlist"
-          description={`Vas a machacar la playlist con código ${pendingOverwrite.code}. Escribe la contraseña para confirmar.`}
-          expectedPassword={OVERWRITE_PASSWORD}
+          description={`Ya hay una playlist en el código ${pendingOverwrite.code}. Cualquiera puede machacarla con la contraseña del coro.`}
+          expectedPassword={SHARED_PASSWORD}
           confirmLabel="Sobrescribir"
           onSuccess={() => void handleConfirmOverwrite()}
           onClose={() => setPendingOverwrite(null)}

--- a/mcm-app/components/playlist/ChoirSheet.tsx
+++ b/mcm-app/components/playlist/ChoirSheet.tsx
@@ -1,0 +1,652 @@
+/**
+ * Hoja del **coro**: el sitio único desde el que se hace todo lo de compartir
+ * playlists, sin códigos de por medio.
+ *
+ * Pasos (el mismo BottomSheet cambia de contenido, no se apilan modales):
+ *
+ *   choose  → elegir mi coro de la lista, o crear uno nuevo
+ *   create  → nombre del coro nuevo
+ *   home    → «importar la última» (acción destacada), ver todas, guardar,
+ *             y el estado del coro en vivo
+ *   browse  → histórico de playlists del coro (nombre, fecha, y el código
+ *             pequeñito al final, que ya no es el protagonista)
+ *   save    → actualizar la que ya subí vs. subir una nueva
+ *
+ * La hoja NO toca la selección local ni pide contraseñas: cuando el usuario
+ * decide algo, se cierra y llama al callback correspondiente. Quien ejecuta
+ * (y quien pide la contraseña si hace falta) es `SelectedSongsScreen`.
+ */
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import BottomSheet from '@/components/BottomSheet';
+import AppTextField from '@/components/ui/AppTextField';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { h } from '@/utils/haptics';
+import { logger } from '@/utils/logger';
+import type { MyChoir } from '@/hooks/useMyChoir';
+import type { PlaylistLink } from '@/hooks/usePlaylistLink';
+import {
+  choirLatestPlaylist,
+  choirPlaylists,
+  createChoir,
+  fetchChoir,
+  listChoirs,
+  type Choir,
+  type ChoirPlaylistEntry,
+} from '@/services/choirDirectoryService';
+import {
+  fetchLiveChoirSession,
+  isSameLeader,
+  type ChoirSession,
+} from '@/services/choirSessionService';
+import { defaultPlaylistName } from '@/utils/playlistCodes';
+import { formatRelativeDate } from '@/utils/playlistSync';
+import { accent, createStyles } from './choirSheetStyles';
+
+export type ChoirSheetStep = 'choose' | 'create' | 'home' | 'browse' | 'save';
+
+interface Props {
+  visible: boolean;
+  initialStep: ChoirSheetStep;
+  myChoir: MyChoir | null;
+  onChooseChoir: (choir: MyChoir) => void;
+  /** Selección actual: 0 canciones desactiva "guardar". */
+  songCount: number;
+  link: PlaylistLink | null;
+  identity: { deviceId: string; name?: string };
+  /** 'off' | 'master' | 'slave' de la sesión en vivo actual. */
+  liveMode: 'off' | 'master' | 'slave';
+  /** Clave de la sesión en vivo en curso (id de coro o código). */
+  liveKey: string | null;
+
+  onImport: (entry: ChoirPlaylistEntry, choir: MyChoir) => void;
+  onSaveNew: (name: string, choir: MyChoir) => void;
+  onSaveUpdate: (entry: ChoirPlaylistEntry, choir: MyChoir) => void;
+  onLead: (choir: MyChoir, existing: ChoirSession | null) => void;
+  onJoinLive: (choir: MyChoir, session: ChoirSession) => void;
+  onLeaveLive: () => void;
+  onClose: () => void;
+}
+
+const ChoirSheet: React.FC<Props> = ({
+  visible,
+  initialStep,
+  myChoir,
+  onChooseChoir,
+  songCount,
+  link,
+  identity,
+  liveMode,
+  liveKey,
+  onImport,
+  onSaveNew,
+  onSaveUpdate,
+  onLead,
+  onJoinLive,
+  onLeaveLive,
+  onClose,
+}) => {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+
+  const [step, setStep] = useState<ChoirSheetStep>(initialStep);
+  const [choirs, setChoirs] = useState<Choir[] | null>(null);
+  const [choir, setChoir] = useState<Choir | null>(null);
+  const [live, setLive] = useState<ChoirSession | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newChoirName, setNewChoirName] = useState('');
+  const [newPlaylistName, setNewPlaylistName] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  // Al abrir, la hoja arranca siempre en el paso que pide la pantalla. Se
+  // ajusta durante el render (patrón documentado de React para "resetear
+  // estado cuando cambia una prop") para no pintar un fotograma con el paso
+  // de la vez anterior.
+  const [lastOpen, setLastOpen] = useState({ visible, initialStep });
+  if (lastOpen.visible !== visible || lastOpen.initialStep !== initialStep) {
+    setLastOpen({ visible, initialStep });
+    if (visible) {
+      setStep(myChoir ? initialStep : 'choose');
+      setError(null);
+      setBusy(false);
+      setNewChoirName('');
+      setNewPlaylistName(link?.name || defaultPlaylistName());
+      // Cada apertura recarga el coro: entre una vez y otra puede haber subido
+      // otra persona (o tú mismo desde el ordenador). Enseñar el histórico
+      // cacheado sería justo lo contrario de lo que se viene a hacer aquí.
+      setChoir(null);
+      setLive(null);
+    }
+  }
+
+  /** Carga el coro elegido + su sesión en vivo. */
+  const loadChoir = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [data, session] = await Promise.all([
+        fetchChoir(id),
+        fetchLiveChoirSession(id).catch(() => null),
+      ]);
+      setChoir(data);
+      setLive(session);
+      if (!data) setError('Este coro ya no existe. Elige otro.');
+    } catch (e: any) {
+      logger.error('choir load error', e);
+      setError('No se ha podido conectar. ¿Tienes internet?');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadChoirs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setChoirs(await listChoirs());
+    } catch (e: any) {
+      logger.error('choir list error', e);
+      setError('No se ha podido cargar la lista de coros');
+      setChoirs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (step === 'choose') void loadChoirs();
+    else if (myChoir && choir?.id !== myChoir.id) void loadChoir(myChoir.id);
+    // `choir?.id` a propósito: si ya está cargado el coro correcto, no se
+    // vuelve a pedir cada vez que se cambia de paso dentro de la hoja.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, step, myChoir?.id]);
+
+  const entries = useMemo(() => (choir ? choirPlaylists(choir) : []), [choir]);
+  const latest = useMemo(
+    () => (choir ? choirLatestPlaylist(choir) : null),
+    [choir],
+  );
+  /** La playlist del coro que este dispositivo tiene enlazada (si sigue ahí). */
+  const linkedEntry = useMemo(() => {
+    if (!link || !choir || link.choirId !== choir.id) return null;
+    return entries.find((e) => e.code === link.code) ?? null;
+  }, [link, choir, entries]);
+
+  /**
+   * Cierra la hoja y ejecuta la acción DESPUÉS de que el Modal se haya
+   * desmontado del todo: iOS no presenta un segundo Modal (la contraseña, el
+   * QR) mientras el primero sigue montado. Mismo patrón que
+   * `PlaylistActionsBottomSheet`.
+   */
+  const pendingActionRef = useRef<(() => void) | null>(null);
+  const close = (fn?: () => void) => {
+    pendingActionRef.current = fn ?? null;
+    onClose();
+  };
+  const handleCloseComplete = useCallback(() => {
+    const fn = pendingActionRef.current;
+    pendingActionRef.current = null;
+    fn?.();
+  }, []);
+
+  const pickChoir = (c: Choir) => {
+    h.tap();
+    onChooseChoir({ id: c.id, name: c.name });
+    setChoir(c);
+    setStep('home');
+  };
+
+  const handleCreate = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await createChoir(newChoirName, identity);
+      onChooseChoir({ id: created.id, name: created.name });
+      setChoir(created);
+      setLive(null);
+      setStep('home');
+    } catch (e: any) {
+      setError(e?.message ?? 'No se ha podido crear el coro');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /* ------------------------------------------------------------------ */
+
+  const renderBack = (to: ChoirSheetStep, label: string) => (
+    <TouchableOpacity style={styles.backRow} onPress={() => setStep(to)}>
+      <MaterialIcons name="chevron-left" size={20} color={accent(isDark)} />
+      <Text style={styles.backText}>{label}</Text>
+    </TouchableOpacity>
+  );
+
+  const renderChoirHeader = () => (
+    <View style={styles.choirRow}>
+      <View style={styles.choirIcon}>
+        <MaterialIcons name="groups" size={20} color={accent(isDark)} />
+      </View>
+      <View style={styles.choirTextBlock}>
+        <Text style={styles.choirLabel}>Mi coro</Text>
+        <Text style={styles.choirName} numberOfLines={1}>
+          {choir?.name ?? myChoir?.name}
+        </Text>
+      </View>
+      <TouchableOpacity
+        style={styles.linkBtn}
+        onPress={() => setStep('choose')}
+      >
+        <Text style={styles.linkBtnText}>Cambiar</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  const renderRow = (
+    icon: keyof typeof MaterialIcons.glyphMap,
+    label: string,
+    description: string | undefined,
+    onPress: () => void,
+    opts?: { disabled?: boolean; live?: boolean },
+  ) => (
+    <TouchableOpacity
+      style={[styles.row, opts?.disabled && styles.rowDisabled]}
+      onPress={() => {
+        if (opts?.disabled) return;
+        h.tap();
+        onPress();
+      }}
+      disabled={opts?.disabled}
+    >
+      <View style={[styles.rowIcon, opts?.live && styles.rowIconLive]}>
+        <MaterialIcons
+          name={icon}
+          size={20}
+          color={opts?.live ? '#28A76A' : accent(isDark)}
+        />
+      </View>
+      <View style={styles.rowTextBlock}>
+        <Text style={styles.rowLabel}>{label}</Text>
+        {description ? (
+          <Text style={styles.rowDescription}>{description}</Text>
+        ) : null}
+      </View>
+      <MaterialIcons name="chevron-right" size={20} color="#8E8E93" />
+    </TouchableOpacity>
+  );
+
+  const entryMeta = (e: ChoirPlaylistEntry) =>
+    `${formatRelativeDate(e.updatedAt)} · ${e.songCount} ${
+      e.songCount === 1 ? 'canción' : 'canciones'
+    }${e.by ? ` · ${e.by}` : ''}`;
+
+  /* --- Paso: elegir coro -------------------------------------------- */
+  const renderChoose = () => (
+    <>
+      <Text style={styles.description}>
+        Las playlists cuelgan del coro. Elige el tuyo una vez y luego importar
+        la del domingo es un toque.
+      </Text>
+      {loading ? (
+        <ActivityIndicator style={styles.loading} color={accent(isDark)} />
+      ) : (
+        <ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
+          {(choirs ?? []).map((c) => (
+            <TouchableOpacity
+              key={c.id}
+              style={[
+                styles.listItem,
+                myChoir?.id === c.id && styles.listItemActive,
+              ]}
+              onPress={() => pickChoir(c)}
+            >
+              <View style={styles.choirIcon}>
+                <MaterialIcons name="groups" size={18} color={accent(isDark)} />
+              </View>
+              <View style={styles.rowTextBlock}>
+                <Text style={styles.listTitle}>{c.name}</Text>
+                <Text style={styles.listMeta}>
+                  {Object.keys(c.playlists).length} playlist
+                  {Object.keys(c.playlists).length === 1 ? '' : 's'}
+                </Text>
+              </View>
+              {myChoir?.id === c.id ? (
+                <MaterialIcons name="check" size={20} color={accent(isDark)} />
+              ) : null}
+            </TouchableOpacity>
+          ))}
+          {choirs && choirs.length === 0 ? (
+            <Text style={styles.empty}>
+              Todavía no hay ningún coro. Crea el primero.
+            </Text>
+          ) : null}
+        </ScrollView>
+      )}
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {renderRow(
+        'add-circle-outline',
+        'Crear un coro nuevo',
+        'Por ejemplo «Coro Consolación Castellón»',
+        () => {
+          setError(null);
+          setStep('create');
+        },
+      )}
+    </>
+  );
+
+  /* --- Paso: crear coro --------------------------------------------- */
+  const renderCreate = () => (
+    <>
+      {renderBack('choose', 'Volver a la lista')}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Nombre del coro</Text>
+        <AppTextField
+          value={newChoirName}
+          onChangeText={setNewChoirName}
+          placeholder="Coro Consolación Castellón"
+          autoFocus
+          editable={!busy}
+          accentColor={accent(isDark)}
+          accentWhenFilled
+        />
+      </View>
+      <Text style={styles.description}>
+        Cualquiera podrá elegirlo y subirle playlists, así que ponle el nombre
+        por el que lo conoce la gente.
+      </Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <View style={styles.buttons}>
+        <TouchableOpacity
+          style={[styles.btn, styles.btnSecondary]}
+          onPress={() => setStep('choose')}
+          disabled={busy}
+        >
+          <Text style={styles.btnSecondaryText}>Cancelar</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.btn,
+            styles.btnPrimary,
+            (busy || newChoirName.trim().length < 3) && styles.btnDisabled,
+          ]}
+          onPress={() => void handleCreate()}
+          disabled={busy || newChoirName.trim().length < 3}
+        >
+          {busy ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.btnPrimaryText}>Crear coro</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+
+  /* --- Paso: home del coro ------------------------------------------ */
+  const renderHome = () => {
+    const leadingHere = liveMode === 'master' && liveKey === choir?.id;
+    const followingHere = liveMode === 'slave' && liveKey === choir?.id;
+    const leaderName = live?.master?.name?.trim();
+    const iAmLeader = isSameLeader(live, identity);
+
+    return (
+      <>
+        {renderChoirHeader()}
+
+        <TouchableOpacity
+          style={[styles.hero, !latest && styles.heroDisabled]}
+          disabled={!latest || !myChoir}
+          onPress={() => {
+            if (!latest || !myChoir) return;
+            h.tap();
+            close(() => onImport(latest, myChoir));
+          }}
+        >
+          <View style={styles.heroIcon}>
+            <MaterialIcons name="bolt" size={22} color="#fff" />
+          </View>
+          <View style={styles.heroTextBlock}>
+            <Text style={styles.heroTitle}>Importar la última</Text>
+            <Text style={styles.heroSubtitle}>
+              {latest
+                ? `${latest.name} · ${entryMeta(latest)}`
+                : loading
+                  ? 'Cargando…'
+                  : 'Este coro aún no tiene playlists'}
+            </Text>
+          </View>
+        </TouchableOpacity>
+
+        {renderRow(
+          'history',
+          'Ver todas las playlists',
+          entries.length
+            ? `${entries.length} en el histórico`
+            : 'Aún no hay ninguna',
+          () => setStep('browse'),
+          { disabled: entries.length === 0 },
+        )}
+
+        <View style={styles.separator} />
+
+        {renderRow(
+          'cloud-upload',
+          linkedEntry
+            ? `Guardar en ${choir?.name ?? 'el coro'}`
+            : 'Subir esta playlist',
+          linkedEntry
+            ? `Actualizar «${linkedEntry.name}» o subir una nueva`
+            : songCount > 0
+              ? `${songCount} ${songCount === 1 ? 'canción' : 'canciones'} · queda para todo el coro`
+              : 'Tu selección está vacía',
+          () => {
+            setNewPlaylistName(link?.name || defaultPlaylistName());
+            setStep('save');
+          },
+          { disabled: songCount === 0 },
+        )}
+
+        <View style={styles.separator} />
+        <Text style={styles.sectionTitle}>Coro en vivo</Text>
+
+        {leadingHere ? (
+          renderRow(
+            'campaign',
+            'Estás dirigiendo',
+            'Los demás ven la canción que abras. Toca para cerrar la sesión.',
+            () => close(onLeaveLive),
+            { live: true },
+          )
+        ) : followingHere ? (
+          renderRow(
+            'headphones',
+            `Siguiendo a ${leaderName || 'el líder'}`,
+            'Toca para salir del coro en vivo',
+            () => close(onLeaveLive),
+            { live: true },
+          )
+        ) : live ? (
+          <>
+            {renderRow(
+              'headphones',
+              `Unirme · dirige ${leaderName || 'alguien'}`,
+              'Verás su canción y su tono en tiempo real',
+              () => {
+                if (!myChoir) return;
+                close(() => onJoinLive(myChoir, live));
+              },
+              { live: true },
+            )}
+            {renderRow(
+              'campaign',
+              'Tomar el mando',
+              iAmLeader
+                ? 'Eres tú desde otro dispositivo: pasa sin contraseña'
+                : 'Hace falta la contraseña del coro',
+              () => {
+                if (!myChoir) return;
+                close(() => onLead(myChoir, live));
+              },
+            )}
+          </>
+        ) : (
+          renderRow(
+            'campaign',
+            'Dirigir yo',
+            'Quien se una a este coro seguirá tus canciones (24 h)',
+            () => {
+              if (!myChoir) return;
+              close(() => onLead(myChoir, null));
+            },
+            { disabled: !myChoir },
+          )
+        )}
+
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+      </>
+    );
+  };
+
+  /* --- Paso: histórico ---------------------------------------------- */
+  const renderBrowse = () => (
+    <>
+      {renderBack('home', choir?.name ?? 'Volver')}
+      {loading ? (
+        <ActivityIndicator style={styles.loading} color={accent(isDark)} />
+      ) : (
+        <ScrollView style={styles.list}>
+          {entries.map((e) => (
+            <TouchableOpacity
+              key={e.code}
+              style={[
+                styles.listItem,
+                link?.code === e.code && styles.listItemActive,
+              ]}
+              onPress={() => {
+                if (!myChoir) return;
+                h.tap();
+                close(() => onImport(e, myChoir));
+              }}
+            >
+              <View style={styles.rowTextBlock}>
+                <Text style={styles.listTitle} numberOfLines={1}>
+                  {e.name}
+                </Text>
+                <Text style={styles.listMeta}>{entryMeta(e)}</Text>
+              </View>
+              <Text style={styles.codeChip}>#{e.code}</Text>
+            </TouchableOpacity>
+          ))}
+          {entries.length === 0 ? (
+            <Text style={styles.empty}>Este coro aún no tiene playlists.</Text>
+          ) : null}
+        </ScrollView>
+      )}
+    </>
+  );
+
+  /* --- Paso: guardar ------------------------------------------------ */
+  const renderSave = () => (
+    <>
+      {renderBack('home', choir?.name ?? 'Volver')}
+      {linkedEntry ? (
+        <>
+          {renderRow(
+            'sync',
+            `Actualizar «${linkedEntry.name}»`,
+            `Machaca la del coro · ${formatRelativeDate(linkedEntry.updatedAt)} · #${linkedEntry.code}`,
+            () => {
+              if (!myChoir) return;
+              close(() => onSaveUpdate(linkedEntry, myChoir));
+            },
+          )}
+          <View style={styles.separator} />
+          <Text style={styles.sectionTitle}>O empezar una nueva</Text>
+        </>
+      ) : null}
+
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Nombre de la playlist</Text>
+        <AppTextField
+          value={newPlaylistName}
+          onChangeText={setNewPlaylistName}
+          placeholder="Eucaristía domingo 7 ago"
+          editable={!busy}
+          accentColor={accent(isDark)}
+          accentWhenFilled
+        />
+      </View>
+      <Text style={styles.description}>
+        Se sube a {choir?.name ?? 'tu coro'} con {songCount}{' '}
+        {songCount === 1 ? 'canción' : 'canciones'}. El código para compartirla
+        suelta se genera solo.
+      </Text>
+      <View style={styles.buttons}>
+        <TouchableOpacity
+          style={[
+            styles.btn,
+            styles.btnPrimary,
+            !newPlaylistName.trim() && styles.btnDisabled,
+          ]}
+          onPress={() => {
+            if (!myChoir || !newPlaylistName.trim()) return;
+            close(() => onSaveNew(newPlaylistName.trim(), myChoir));
+          }}
+          disabled={!newPlaylistName.trim()}
+        >
+          <Text style={styles.btnPrimaryText}>
+            {linkedEntry ? 'Subir como nueva' : 'Subir al coro'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+
+  const titles: Record<ChoirSheetStep, string> = {
+    choose: 'Elige tu coro',
+    create: 'Nuevo coro',
+    home: 'Coro',
+    browse: 'Playlists del coro',
+    save: 'Guardar en el coro',
+  };
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      onCloseComplete={handleCloseComplete}
+      title={titles[step]}
+    >
+      <View style={styles.container}>
+        {step === 'choose'
+          ? renderChoose()
+          : step === 'create'
+            ? renderCreate()
+            : step === 'browse'
+              ? renderBrowse()
+              : step === 'save'
+                ? renderSave()
+                : renderHome()}
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default ChoirSheet;

--- a/mcm-app/components/playlist/ChoirSheet.tsx
+++ b/mcm-app/components/playlist/ChoirSheet.tsx
@@ -205,11 +205,19 @@ const ChoirSheet: React.FC<Props> = ({
     fn?.();
   }, []);
 
+  /**
+   * Paso al que ir después de elegir/crear coro. Si la hoja se abrió para
+   * guardar y no había coro elegido, se pasa por la lista y se VUELVE a
+   * guardar: obligar a empezar otra vez desde el menú era un toque tonto.
+   */
+  const stepAfterChoosing = (): ChoirSheetStep =>
+    initialStep === 'choose' || initialStep === 'create' ? 'home' : initialStep;
+
   const pickChoir = (c: Choir) => {
     h.tap();
     onChooseChoir({ id: c.id, name: c.name });
     setChoir(c);
-    setStep('home');
+    setStep(stepAfterChoosing());
   };
 
   const handleCreate = async () => {
@@ -221,7 +229,7 @@ const ChoirSheet: React.FC<Props> = ({
       onChooseChoir({ id: created.id, name: created.name });
       setChoir(created);
       setLive(null);
-      setStep('home');
+      setStep(stepAfterChoosing());
     } catch (e: any) {
       setError(e?.message ?? 'No se ha podido crear el coro');
     } finally {
@@ -448,14 +456,12 @@ const ChoirSheet: React.FC<Props> = ({
 
         {renderRow(
           'cloud-upload',
-          linkedEntry
-            ? `Guardar en ${choir?.name ?? 'el coro'}`
-            : 'Subir esta playlist',
-          linkedEntry
-            ? `Actualizar «${linkedEntry.name}» o subir una nueva`
-            : songCount > 0
-              ? `${songCount} ${songCount === 1 ? 'canción' : 'canciones'} · queda para todo el coro`
-              : 'Tu selección está vacía',
+          linkedEntry ? `Guardar «${linkedEntry.name}»` : 'Subir mi playlist',
+          songCount === 0
+            ? 'Tu selección está vacía'
+            : linkedEntry
+              ? 'Actualizar la del coro o subir una nueva'
+              : `${songCount} ${songCount === 1 ? 'canción' : 'canciones'} para todo el coro`,
           () => {
             setNewPlaylistName(link?.name || defaultPlaylistName());
             setStep('save');

--- a/mcm-app/components/playlist/CodeInputModal.tsx
+++ b/mcm-app/components/playlist/CodeInputModal.tsx
@@ -63,6 +63,11 @@ interface Props {
    * resuelve la pantalla. Si no se pasa, esos QR se rechazan con un aviso.
    */
   onScanOffline?: (payload: string) => void;
+  /**
+   * Se llama cuando el QR escaneado era el de un CORO (`?coro=<id>`): no hay
+   * código que descargar, hay que traerse la última playlist de ese coro.
+   */
+  onScanChoir?: (choirId: string) => void;
 }
 
 interface VariantCopy {
@@ -158,6 +163,7 @@ const CodeInputModal: React.FC<Props> = ({
   onClose,
   onSubmit,
   onScanOffline,
+  onScanChoir,
 }) => {
   const scheme = useColorScheme();
   const isDark = scheme === 'dark';
@@ -228,6 +234,11 @@ const CodeInputModal: React.FC<Props> = ({
   const handleScannedOffline = (payload: string) => {
     setScan('closing');
     onScanOffline?.(payload);
+  };
+
+  const handleScannedChoir = (choirId: string) => {
+    setScan('closing');
+    onScanChoir?.(choirId);
   };
 
   const handleChangeText = (txt: string) => {
@@ -395,6 +406,7 @@ const CodeInputModal: React.FC<Props> = ({
           onDismissed={() => setScan('idle')}
           onCode={handleScannedCode}
           onOffline={onScanOffline ? handleScannedOffline : undefined}
+          onChoir={onScanChoir ? handleScannedChoir : undefined}
         />
       ) : null}
     </>

--- a/mcm-app/components/playlist/PlaylistHeaderBar.tsx
+++ b/mcm-app/components/playlist/PlaylistHeaderBar.tsx
@@ -1,21 +1,34 @@
 /**
- * Cabecera del resumen de la playlist: banner de Modo Coro, cuenta de canciones,
- * código de la copia en la nube y el conmutador «Por categoría / Orden ajustado».
+ * Cabecera del resumen de la playlist: banner de Modo Coro, cuenta de
+ * canciones, **estado de sincronización con el coro** y el conmutador
+ * «Por categoría / Orden ajustado».
  *
- * Extraída de `SelectedSongsScreen` sin tocar el marcado. Va memoizada porque la
- * pantalla se re-renderiza en cada cambio de la selección y esta cabecera solo
- * depende de cuatro props.
+ * El estado es la parte nueva y la que más preguntas quita de encima: dice si
+ * lo que ves es lo que hay subido («guardada en X») o si has tocado algo desde
+ * entonces («cambios sin guardar»), y al tocarlo lleva directo a guardar. Antes
+ * solo se veía un código de 4 dígitos, que no contaba ninguna de las dos cosas.
+ *
+ * Va memoizada porque la pantalla se re-renderiza en cada cambio de la
+ * selección y esta cabecera solo depende de sus props.
  */
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import ChoirSessionBanner from '@/components/playlist/ChoirSessionBanner';
 import type { SelectedSongsStyles } from '@/components/playlist/selectedSongsStyles';
+import type { PlaylistLink } from '@/hooks/usePlaylistLink';
+import { formatRelativeDate } from '@/utils/playlistSync';
 
 export type ViewMode = 'category' | 'manual';
 
 export interface PlaylistHeaderBarProps {
   visibleCount: number;
-  lastUploadCode: string | null;
+  /** Enlace con la copia en la nube, si la playlist viene de/ha ido a un coro. */
+  link: PlaylistLink | null;
+  /** ¿Coincide lo que ves con lo subido? */
+  isSynced: boolean;
+  onPressStatus: () => void;
+  onClear: () => void;
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
   styles: SelectedSongsStyles;
@@ -23,25 +36,52 @@ export interface PlaylistHeaderBarProps {
 
 export const PlaylistHeaderBar = React.memo(function PlaylistHeaderBar({
   visibleCount,
-  lastUploadCode,
+  link,
+  isSynced,
+  onPressStatus,
+  onClear,
   viewMode,
   setViewMode,
   styles,
 }: PlaylistHeaderBarProps) {
+  const statusLabel = link
+    ? isSynced
+      ? `☁️ ${link.choirName ? `Guardada en ${link.choirName}` : 'Guardada'}${
+          link.syncedAt ? ` · ${formatRelativeDate(link.syncedAt)}` : ''
+        }`
+      : `✏️ Cambios sin guardar en «${link.name ?? link.code}»`
+    : null;
+
   return (
     <View>
       <ChoirSessionBanner />
       <View style={styles.summaryRow}>
-        <View>
+        <View style={{ flex: 1 }}>
           <Text style={styles.selectionCount}>
             {visibleCount} {visibleCount === 1 ? 'canción' : 'canciones'}
           </Text>
-          {lastUploadCode ? (
-            <Text style={styles.subInfo}>
-              ☁️ Guardada con código {lastUploadCode}
-            </Text>
+          {statusLabel ? (
+            <TouchableOpacity onPress={onPressStatus} hitSlop={6}>
+              <Text
+                style={[styles.subInfo, !isSynced && styles.subInfoDirty]}
+                numberOfLines={1}
+              >
+                {statusLabel}
+              </Text>
+            </TouchableOpacity>
           ) : null}
         </View>
+        {visibleCount > 0 ? (
+          <TouchableOpacity
+            onPress={onClear}
+            style={styles.clearBtn}
+            hitSlop={6}
+            accessibilityLabel="Vaciar la playlist"
+          >
+            <MaterialIcons name="delete-sweep" size={18} color="#8E8E93" />
+            <Text style={styles.clearBtnText}>Vaciar</Text>
+          </TouchableOpacity>
+        ) : null}
         {visibleCount > 1 ? (
           <View style={styles.viewToggle}>
             <TouchableOpacity

--- a/mcm-app/components/playlist/QrScannerModal.tsx
+++ b/mcm-app/components/playlist/QrScannerModal.tsx
@@ -92,6 +92,12 @@ interface Props {
    * se presenta en el mismo ciclo de render en que otro se cierra.
    */
   onDismissed?: () => void;
+  /**
+   * QR de coro (`?coro=<id>`) leído desde el flujo de playlists: no hay nada
+   * que descargar por código, hay que traerse la ÚLTIMA playlist de ese coro.
+   * Si no se pasa, esos QR se rechazan con un aviso.
+   */
+  onChoir?: (choirId: string) => void;
 }
 
 const QrScannerModal: React.FC<Props> = ({
@@ -101,6 +107,7 @@ const QrScannerModal: React.FC<Props> = ({
   onCode,
   onOffline,
   onDismissed,
+  onChoir,
 }) => {
   const insets = useSafeAreaInsets();
   const camera = getCamera();
@@ -179,7 +186,12 @@ const QrScannerModal: React.FC<Props> = ({
       celebrationRef.current = setTimeout(() => {
         celebrationRef.current = null;
         if (result.kind === 'offline') onOffline?.(result.payload);
-        else onCode(result.code);
+        else if (result.kind === 'choir') {
+          // Para unirse en vivo, el id del coro ES la clave de la sesión, así
+          // que va por el mismo camino que un código de 4 dígitos.
+          if (result.target === 'choir') onCode(result.choirId);
+          else onChoir?.(result.choirId);
+        } else onCode(result.code);
       }, CELEBRATION_MS);
     },
     [onCode, onOffline],
@@ -216,9 +228,13 @@ const QrScannerModal: React.FC<Props> = ({
         showHint('Ese QR lleva la playlist entera; ábrelo con la cámara');
         return;
       }
+      if (result.kind === 'choir' && result.target === 'playlist' && !onChoir) {
+        showHint('Ese QR es de un coro; ábrelo desde «Mi coro»');
+        return;
+      }
       resolve(result);
     },
-    [expected, onOffline, resolve, showHint],
+    [expected, onOffline, onChoir, resolve, showHint],
   );
 
   if (!camera) return null;

--- a/mcm-app/components/playlist/choirSheetStyles.ts
+++ b/mcm-app/components/playlist/choirSheetStyles.ts
@@ -1,0 +1,239 @@
+/**
+ * Estilos de `ChoirSheet`. En módulo aparte para que el componente se quede en
+ * lógica de flujos (la convención del proyecto: nada de componentes de 400+
+ * líneas con la hoja de estilos dentro).
+ */
+import { StyleSheet } from 'react-native';
+import { radii } from '@/constants/uiStyles';
+
+export const accent = (isDark: boolean) => (isDark ? '#7AB3FF' : '#253883');
+
+export const createStyles = (isDark: boolean) =>
+  StyleSheet.create({
+    container: {
+      paddingBottom: 24,
+      gap: 12,
+    },
+    /* --- Cabecera con el coro elegido --- */
+    choirRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      borderRadius: radii.md,
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    choirIcon: {
+      width: 34,
+      height: 34,
+      borderRadius: 17,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: isDark ? '#2B3E68' : '#DCE7FF',
+    },
+    choirTextBlock: { flex: 1 },
+    choirLabel: {
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 0.6,
+      textTransform: 'uppercase',
+      color: isDark ? '#8E8E93' : '#6B6B70',
+    },
+    choirName: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    linkBtn: {
+      paddingVertical: 6,
+      paddingHorizontal: 10,
+      borderRadius: radii.sm,
+    },
+    linkBtnText: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: accent(isDark),
+    },
+
+    /* --- Acción destacada («Importar la última») --- */
+    hero: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      paddingVertical: 14,
+      paddingHorizontal: 14,
+      borderRadius: radii.lg,
+      backgroundColor: accent(isDark),
+    },
+    heroIcon: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255,255,255,0.2)',
+    },
+    heroTextBlock: { flex: 1 },
+    heroTitle: {
+      fontSize: 16,
+      fontWeight: '800',
+      color: '#fff',
+    },
+    heroSubtitle: {
+      fontSize: 13,
+      color: 'rgba(255,255,255,0.85)',
+      marginTop: 2,
+    },
+    heroDisabled: { opacity: 0.5 },
+
+    /* --- Filas de acción normales --- */
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 14,
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: radii.md,
+    },
+    rowIcon: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    rowIconLive: {
+      backgroundColor: isDark ? '#123A2A' : '#DFF5E9',
+    },
+    rowTextBlock: { flex: 1 },
+    rowLabel: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    rowDescription: {
+      fontSize: 13,
+      color: '#8E8E93',
+      marginTop: 2,
+    },
+    rowDisabled: { opacity: 0.4 },
+
+    /* --- Listas --- */
+    list: { maxHeight: 340 },
+    listItem: {
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: radii.md,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+    },
+    listItemActive: {
+      backgroundColor: isDark ? '#1A2744' : '#EEF4FF',
+    },
+    listTitle: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+    },
+    listMeta: {
+      fontSize: 12,
+      color: '#8E8E93',
+      marginTop: 2,
+    },
+    /* El código pasa a ser un detalle pequeñito, no el protagonista. */
+    codeChip: {
+      fontSize: 11,
+      fontWeight: '700',
+      color: isDark ? '#8E8E93' : '#8A8A8E',
+      fontVariant: ['tabular-nums'],
+    },
+
+    /* --- Varios --- */
+    sectionTitle: {
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 0.6,
+      textTransform: 'uppercase',
+      color: isDark ? '#8E8E93' : '#6B6B70',
+      paddingHorizontal: 12,
+      paddingTop: 6,
+    },
+    separator: {
+      height: StyleSheet.hairlineWidth,
+      backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+      marginVertical: 2,
+      marginHorizontal: 12,
+    },
+    description: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      paddingHorizontal: 12,
+    },
+    error: {
+      fontSize: 13,
+      color: '#FF453A',
+      paddingHorizontal: 12,
+      fontWeight: '600',
+    },
+    empty: {
+      fontSize: 14,
+      color: '#8E8E93',
+      textAlign: 'center',
+      paddingVertical: 22,
+      paddingHorizontal: 12,
+    },
+    loading: {
+      paddingVertical: 26,
+    },
+    field: {
+      paddingHorizontal: 12,
+      gap: 6,
+    },
+    fieldLabel: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: isDark ? '#A0A0A8' : '#6B6B70',
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    buttons: {
+      flexDirection: 'row',
+      gap: 10,
+      paddingHorizontal: 12,
+      paddingTop: 4,
+    },
+    btn: {
+      flex: 1,
+      paddingVertical: 13,
+      borderRadius: radii.md,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    btnPrimary: { backgroundColor: accent(isDark) },
+    btnSecondary: { backgroundColor: isDark ? '#2C2C2E' : '#E5E5EA' },
+    btnDisabled: { opacity: 0.45 },
+    btnPrimaryText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+    btnSecondaryText: {
+      color: isDark ? '#F5F5F7' : '#1C1C1E',
+      fontSize: 15,
+      fontWeight: '600',
+    },
+    backRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingHorizontal: 12,
+      paddingBottom: 2,
+    },
+    backText: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: accent(isDark),
+    },
+  });
+
+export type ChoirSheetStyles = ReturnType<typeof createStyles>;

--- a/mcm-app/components/playlist/selectedSongsStyles.ts
+++ b/mcm-app/components/playlist/selectedSongsStyles.ts
@@ -58,6 +58,24 @@ export const createStyles = (
       marginTop: 3,
       fontWeight: '600',
     },
+    /** Mismo sitio, color de aviso: hay cambios que no están subidos. */
+    subInfoDirty: {
+      color: isDark ? '#F0B429' : '#B26B00',
+    },
+    clearBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      paddingVertical: 5,
+      paddingHorizontal: 8,
+      borderRadius: 8,
+      backgroundColor: isDark ? '#2C2C2E' : '#EFEFF4',
+    },
+    clearBtnText: {
+      fontSize: 12,
+      fontWeight: '700',
+      color: '#8E8E93',
+    },
     viewToggle: {
       flexDirection: 'row',
       backgroundColor: isDark ? '#2C2C2E' : '#E5E5EA',

--- a/mcm-app/contexts/ChoirSessionContext.tsx
+++ b/mcm-app/contexts/ChoirSessionContext.tsx
@@ -47,7 +47,7 @@ interface ChoirSessionContextValue {
   startAsMaster: (
     code: string,
     playlist: SelectedSong[],
-    opts?: { name?: string },
+    opts?: { name?: string; choirId?: string; choirName?: string },
   ) => Promise<void>;
   joinAsSlave: (code: string) => Promise<void>;
   leave: () => Promise<void>;
@@ -194,6 +194,7 @@ export const ChoirSessionProvider: React.FC<{ children: ReactNode }> = ({
         newCode,
         { deviceId, name: opts?.name },
         playlist,
+        { choirId: opts?.choirId, choirName: opts?.choirName },
       );
       setMode('master');
       setCode(newCode);

--- a/mcm-app/database.rules.json
+++ b/mcm-app/database.rules.json
@@ -245,8 +245,11 @@
     },
 
     /* ------------------------------------------------------------------ *
-     *  SESIONES DE CORO EN VIVO  (/choirSessions/<code>)
+     *  SESIONES DE CORO EN VIVO  (/choirSessions/<clave>)
      *  Misma lógica que playlistShares (sincronización en tiempo real).
+     *  La <clave> es el id de un coro (`consolacion-castellon-4f2a`) o, en las
+     *  sesiones sueltas, un código de 4 dígitos. La sesión caduca sola a las
+     *  24 h (`expiresAt`); el cliente ignora las caducadas.
      * ------------------------------------------------------------------ */
     "choirSessions": {
       ".read": false,
@@ -255,6 +258,29 @@
         ".read": true,
         ".write": true,
         ".validate": "newData.hasChild('expiresAt') && newData.child('expiresAt').isNumber()"
+      }
+    },
+
+    /* ------------------------------------------------------------------ *
+     *  COROS  (/choirs/<choirId>)
+     *  La "entidad" de la que cuelgan las playlists históricas. Se espera un
+     *  puñado (5-10), así que la lista SÍ es enumerable: la app la lee entera
+     *  para que cada uno elija el suyo.
+     *
+     *  Cualquiera puede crear un coro y subirle playlists (misma confianza que
+     *  `playlistShares`); guardamos `createdBy` para que el panel sepa quién lo
+     *  creó y pueda borrarlo. La raíz no se puede machacar de una sentada:
+     *  solo se escribe coro a coro.
+     *
+     *  El CONTENIDO de las playlists sigue en `/playlistShares/<code>`: aquí
+     *  solo vive el índice (nombre, fechas, nº de canciones, código).
+     * ------------------------------------------------------------------ */
+    "choirs": {
+      ".read": true,
+      ".write": false,
+      "$choirId": {
+        ".write": true,
+        ".validate": "newData.hasChildren(['name'])"
       }
     },
 

--- a/mcm-app/hooks/useMyChoir.ts
+++ b/mcm-app/hooks/useMyChoir.ts
@@ -1,0 +1,54 @@
+/**
+ * "Mi coro": el coro que este dispositivo tiene elegido. Se guarda en
+ * AsyncStorage para que solo haya que elegirlo una vez en la vida — a partir
+ * de ahí, importar la playlist del domingo es un toque.
+ *
+ * Guardamos también el nombre para poder pintarlo sin esperar a Firebase
+ * (arranque en frío, sin cobertura en el sótano de la parroquia…).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logger } from '@/utils/logger';
+import { isChoirId } from '@/utils/choirIds';
+
+const STORAGE_KEY = '@mcm_my_choir_v1';
+
+export interface MyChoir {
+  id: string;
+  name: string;
+}
+
+export function useMyChoir() {
+  const [choir, setChoirState] = useState<MyChoir | null>(null);
+  const [isHydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        const parsed = JSON.parse(raw) as MyChoir;
+        if (parsed?.id && isChoirId(parsed.id)) {
+          setChoirState({ id: parsed.id, name: parsed.name || parsed.id });
+        }
+      })
+      .catch((e) => logger.error('my choir restore error', e))
+      .finally(() => {
+        if (!cancelled) setHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setChoir = useCallback((next: MyChoir | null) => {
+    setChoirState(next);
+    if (next) {
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+    } else {
+      AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
+    }
+  }, []);
+
+  return { choir, setChoir, isHydrated };
+}

--- a/mcm-app/hooks/usePlaylistLink.ts
+++ b/mcm-app/hooks/usePlaylistLink.ts
@@ -1,0 +1,91 @@
+/**
+ * El **enlace** entre la playlist que tienes en el móvil y su copia en la nube.
+ *
+ * Es lo que permite responder a la pregunta que antes no tenía respuesta:
+ * «he tocado 3 canciones, ¿esto que veo es lo que está subido o no?». Con el
+ * enlace guardado (código + coro + firma de la lista en el momento de
+ * subir/importar) la pantalla puede decir «guardada» o «cambios sin guardar»,
+ * y ofrecer **actualizar** en vez de obligar a inventarse otro código.
+ *
+ * Se persiste en AsyncStorage: sobrevive a cerrar la app, que es justo cuando
+ * antes se perdía el hilo (subo desde el ordenador, importo en el móvil, y al
+ * día siguiente ya no hay forma de sobrescribir "la mía").
+ */
+import { useCallback, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logger } from '@/utils/logger';
+import { isValidCode } from '@/utils/playlistCodes';
+
+const STORAGE_KEY = '@mcm_playlist_link_v1';
+/** Clave antigua: solo guardaba el código de la última subida. */
+const LEGACY_CODE_KEY = '@mcm_last_upload_code';
+
+export interface PlaylistLink {
+  /** Código de 4 dígitos bajo el que vive en `/playlistShares`. */
+  code: string;
+  /** Nombre con el que se subió («Eucaristía 7 ago»). */
+  name?: string;
+  choirId?: string;
+  choirName?: string;
+  /**
+   * Firma (`playlistSignature`) de la selección en el momento de subirla o
+   * importarla. Si la firma actual difiere, hay cambios sin guardar.
+   */
+  signature: string;
+  /** Cuándo se sincronizó por última vez. */
+  syncedAt: number;
+  /** ¿La subimos desde este dispositivo? Entonces actualizarla no pide contraseña. */
+  owned: boolean;
+}
+
+export function usePlaylistLink() {
+  const [link, setLinkState] = useState<PlaylistLink | null>(null);
+  const [isHydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as PlaylistLink;
+          if (parsed?.code && isValidCode(parsed.code) && !cancelled) {
+            setLinkState(parsed);
+          }
+        } else {
+          // Migración desde la versión que solo recordaba el código: se asume
+          // que era nuestra (es lo que había subido este dispositivo) y que la
+          // lista puede haber cambiado desde entonces (firma vacía).
+          const legacy = await AsyncStorage.getItem(LEGACY_CODE_KEY);
+          if (legacy && isValidCode(legacy) && !cancelled) {
+            setLinkState({
+              code: legacy,
+              signature: '',
+              syncedAt: 0,
+              owned: true,
+            });
+          }
+          if (legacy) await AsyncStorage.removeItem(LEGACY_CODE_KEY);
+        }
+      } catch (e) {
+        logger.error('playlist link restore error', e);
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setLink = useCallback((next: PlaylistLink | null) => {
+    setLinkState(next);
+    if (next) {
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+    } else {
+      AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
+    }
+  }, []);
+
+  return { link, setLink, isHydrated };
+}

--- a/mcm-app/hooks/usePlaylistSharing.ts
+++ b/mcm-app/hooks/usePlaylistSharing.ts
@@ -1,0 +1,474 @@
+/**
+ * Todos los flujos de "compartir la playlist" en un solo sitio: coro,
+ * playlists en la nube, sesión en vivo, deshacer y contraseña.
+ *
+ * Vive fuera de `SelectedSongsScreen` porque la pantalla ya era el fichero más
+ * grande del proyecto y porque estos flujos tienen reglas propias que conviene
+ * poder leer (y testear) de corrido:
+ *
+ *  1. **Importar SIEMPRE reemplaza**, y siempre deja 10 s de "Deshacer". Antes
+ *     cada importación abría un diálogo de tres botones aunque vinieras de un
+ *     enlace: ahora la lista se pone sola y, si no era lo que querías, un toque
+ *     lo devuelve todo (canciones y enlace con la nube).
+ *  2. **Cualquiera puede machacar una playlist si sabe la contraseña.** Si la
+ *     subiste tú desde este dispositivo, ni eso: actualizar es directo.
+ *  3. **El enlace con la nube se recuerda** (`usePlaylistLink`), así que
+ *     "actualizar la que subí" existe como opción de primera clase en vez de
+ *     obligarte a recordar un código de 4 dígitos.
+ */
+import { useCallback, useMemo, useState } from 'react';
+import { logger } from '@/utils/logger';
+import { trackEvent } from '@/utils/analytics';
+import { tramoTamano } from '@/constants/analyticsEvents';
+import { useToast } from '@/contexts/AppToastContext';
+import {
+  useSelectedSongs,
+  type SelectedSong,
+} from '@/contexts/SelectedSongsContext';
+import { useChoirSession } from '@/contexts/ChoirSessionContext';
+import { useUserProfile } from '@/contexts/UserProfileContext';
+import { useMyChoir, type MyChoir } from '@/hooks/useMyChoir';
+import { usePlaylistLink, type PlaylistLink } from '@/hooks/usePlaylistLink';
+import {
+  allocateFreeCode,
+  fetchCloudPlaylist,
+  uploadCloudPlaylist,
+} from '@/services/cloudPlaylistService';
+import {
+  fetchChoir,
+  choirLatestPlaylist,
+  upsertChoirPlaylist,
+  type ChoirPlaylistEntry,
+} from '@/services/choirDirectoryService';
+import {
+  isSameLeader,
+  type ChoirSession,
+} from '@/services/choirSessionService';
+import { playlistSignature } from '@/utils/playlistSync';
+import type { ChoirSheetStep } from '@/components/playlist/ChoirSheet';
+
+/** Contraseña única para machacar cosas ajenas (playlists y liderazgo). */
+export const SHARED_PASSWORD = 'coco';
+
+/** Ventana para arrepentirse de una importación. Larga a propósito. */
+const UNDO_MS = 10_000;
+
+export interface PasswordRequest {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onSuccess: () => void;
+}
+
+export function usePlaylistSharing(opts: {
+  onShowQr: (link: PlaylistLink) => void;
+}) {
+  const { selectedSongs, replaceAll, clearSelection } = useSelectedSongs();
+  const { profile } = useUserProfile();
+  const choirSession = useChoirSession();
+  const { toast } = useToast();
+  const { choir: myChoir, setChoir: setMyChoir } = useMyChoir();
+  const { link, setLink } = usePlaylistLink();
+
+  const [sheetStep, setSheetStep] = useState<ChoirSheetStep | null>(null);
+  const [passwordRequest, setPasswordRequest] =
+    useState<PasswordRequest | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const identity = useMemo(
+    () => ({
+      deviceId: choirSession.deviceId,
+      name: profile.name?.trim() || undefined,
+    }),
+    [choirSession.deviceId, profile.name],
+  );
+
+  const signature = useMemo(
+    () => playlistSignature(selectedSongs),
+    [selectedSongs],
+  );
+  /** ¿Lo que veo es exactamente lo que hay subido? */
+  const isSynced = !!link && link.signature === signature;
+
+  const openSheet = useCallback(
+    (step: ChoirSheetStep) => setSheetStep(step),
+    [],
+  );
+  const closeSheet = useCallback(() => setSheetStep(null), []);
+
+  /* --------------------------------------------------------------- */
+  /*  Reemplazar con deshacer                                         */
+  /* --------------------------------------------------------------- */
+
+  /**
+   * Sustituye la selección entera dejando 10 s para volver atrás. Restaura
+   * también el enlace con la nube: deshacer una importación tiene que dejarte
+   * exactamente donde estabas, no a medias.
+   */
+  const replaceWithUndo = useCallback(
+    (songs: SelectedSong[], label: string, nextLink: PlaylistLink | null) => {
+      const prevSongs = selectedSongs;
+      const prevLink = link;
+      replaceAll(songs);
+      setLink(nextLink);
+      toast.show({
+        label,
+        variant: 'success',
+        duration: UNDO_MS,
+        actionLabel: 'Deshacer',
+        onActionPress: ({ hide }) => {
+          replaceAll(prevSongs);
+          setLink(prevLink);
+          hide();
+          toast.show({ label: 'Restaurada tu playlist anterior' });
+        },
+      });
+    },
+    [selectedSongs, link, replaceAll, setLink, toast],
+  );
+
+  /** Vaciar la lista sin ceremonias: un toque y 10 s para arrepentirse. */
+  const clearWithUndo = useCallback(() => {
+    if (selectedSongs.length === 0) return;
+    const prevSongs = selectedSongs;
+    clearSelection();
+    toast.show({
+      label: 'Playlist vaciada',
+      duration: UNDO_MS,
+      actionLabel: 'Deshacer',
+      onActionPress: ({ hide }) => {
+        replaceAll(prevSongs);
+        hide();
+      },
+    });
+  }, [selectedSongs, clearSelection, replaceAll, toast]);
+
+  /* --------------------------------------------------------------- */
+  /*  Importar                                                        */
+  /* --------------------------------------------------------------- */
+
+  /** Descarga un código y lo deja puesto (reemplazando, con deshacer). */
+  const importByCode = useCallback(
+    async (code: string, hint?: { name?: string; choir?: MyChoir }) => {
+      const data = await fetchCloudPlaylist(code);
+      if (!data) {
+        throw new Error('No existe ninguna playlist con ese código');
+      }
+      const songs = data.songs ?? [];
+      const name = hint?.name ?? data.name;
+      const choirId = hint?.choir?.id ?? data.choirId;
+      const choirName = hint?.choir?.name ?? data.choirName;
+      trackEvent('playlist_usada', {
+        accion: 'importada',
+        tamano: tramoTamano(songs.length),
+      });
+      replaceWithUndo(
+        songs,
+        name ? `«${name}» importada` : `Playlist ${code} importada`,
+        {
+          code,
+          name,
+          choirId,
+          choirName,
+          signature: playlistSignature(songs),
+          syncedAt: Date.now(),
+          owned:
+            !!data.ownerDeviceId && data.ownerDeviceId === identity.deviceId,
+        },
+      );
+      // Si la playlist declara coro y todavía no tenías uno elegido, te lo
+      // dejamos puesto: has entrado por el enlace de ese coro, es el tuyo.
+      if (choirId && choirName && !myChoir) {
+        setMyChoir({ id: choirId, name: choirName });
+      }
+    },
+    [replaceWithUndo, identity.deviceId, myChoir, setMyChoir],
+  );
+
+  /** Importa una entrada concreta del histórico de un coro. */
+  const importEntry = useCallback(
+    async (entry: ChoirPlaylistEntry, choir: MyChoir) => {
+      try {
+        await importByCode(entry.code, { name: entry.name, choir });
+      } catch (e: any) {
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido importar',
+        });
+      }
+    },
+    [importByCode, toast],
+  );
+
+  /** «Importar la última» desde un enlace `?coro=<id>` sin abrir nada. */
+  const importLatestFromChoir = useCallback(
+    async (choirId: string) => {
+      const choir = await fetchChoir(choirId);
+      if (!choir) throw new Error('Ese coro ya no existe');
+      const latest = choirLatestPlaylist(choir);
+      if (!latest) throw new Error(`«${choir.name}» aún no tiene playlists`);
+      await importByCode(latest.code, {
+        name: latest.name,
+        choir: { id: choir.id, name: choir.name },
+      });
+    },
+    [importByCode],
+  );
+
+  /* --------------------------------------------------------------- */
+  /*  Guardar                                                         */
+  /* --------------------------------------------------------------- */
+
+  const publish = useCallback(
+    async (args: {
+      code: string;
+      name: string;
+      choir: MyChoir;
+      createdAt?: number;
+    }) => {
+      const now = Date.now();
+      await uploadCloudPlaylist(args.code, selectedSongs, {
+        name: args.name,
+        createdAt: args.createdAt,
+        choirId: args.choir.id,
+        choirName: args.choir.name,
+        by: identity.name,
+        ownerDeviceId: identity.deviceId,
+      });
+      await upsertChoirPlaylist(args.choir.id, {
+        code: args.code,
+        name: args.name,
+        createdAt: args.createdAt ?? now,
+        updatedAt: now,
+        songCount: selectedSongs.length,
+        ...(identity.name ? { by: identity.name } : {}),
+        ownerDeviceId: identity.deviceId,
+      });
+      const nextLink: PlaylistLink = {
+        code: args.code,
+        name: args.name,
+        choirId: args.choir.id,
+        choirName: args.choir.name,
+        signature: playlistSignature(selectedSongs),
+        syncedAt: now,
+        owned: true,
+      };
+      setLink(nextLink);
+      trackEvent('playlist_usada', {
+        accion: 'compartida',
+        tamano: tramoTamano(selectedSongs.length),
+      });
+      toast.show({
+        variant: 'success',
+        label: `«${args.name}» guardada en ${args.choir.name}`,
+        duration: 6000,
+        actionLabel: 'Ver QR',
+        onActionPress: ({ hide }) => {
+          hide();
+          opts.onShowQr(nextLink);
+        },
+      });
+    },
+    [selectedSongs, identity, setLink, toast, opts],
+  );
+
+  /** Sube la selección como playlist NUEVA del coro (código automático). */
+  const saveNew = useCallback(
+    async (name: string, choir: MyChoir) => {
+      if (busy) return;
+      setBusy(true);
+      try {
+        const code = await allocateFreeCode();
+        await publish({ code, name, choir });
+      } catch (e: any) {
+        logger.error('saveNew error', e);
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido subir',
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, publish, toast],
+  );
+
+  /**
+   * Machaca una playlist que ya existe. Sin contraseña si la subiste tú desde
+   * este dispositivo; con contraseña en cualquier otro caso (que es justo lo
+   * que faltaba: antes, la playlist que te habías hecho en el ordenador no
+   * había forma de actualizarla desde el móvil).
+   */
+  const saveUpdate = useCallback(
+    (entry: ChoirPlaylistEntry, choir: MyChoir) => {
+      const run = async () => {
+        setBusy(true);
+        try {
+          await publish({
+            code: entry.code,
+            name: entry.name,
+            choir,
+            createdAt: entry.createdAt,
+          });
+        } catch (e: any) {
+          logger.error('saveUpdate error', e);
+          toast.show({
+            variant: 'danger',
+            label: e?.message ?? 'No se ha podido actualizar',
+          });
+        } finally {
+          setBusy(false);
+        }
+      };
+
+      const mine =
+        (link?.code === entry.code && link.owned) ||
+        (!!entry.ownerDeviceId && entry.ownerDeviceId === identity.deviceId);
+      if (mine) {
+        void run();
+        return;
+      }
+      setPasswordRequest({
+        title: `Actualizar «${entry.name}»`,
+        description: `La subió otra persona (o desde otro dispositivo). Escribe la contraseña del coro para machacarla con tus ${selectedSongs.length} canciones.`,
+        confirmLabel: 'Actualizar',
+        onSuccess: () => {
+          setPasswordRequest(null);
+          void run();
+        },
+      });
+    },
+    [publish, link, identity.deviceId, selectedSongs.length, toast],
+  );
+
+  /* --------------------------------------------------------------- */
+  /*  Coro en vivo                                                    */
+  /* --------------------------------------------------------------- */
+
+  /** Ponerse al frente del coro. Si ya dirige otra persona, pide contraseña. */
+  const lead = useCallback(
+    (choir: MyChoir, existing: ChoirSession | null) => {
+      const run = async () => {
+        try {
+          await choirSession.startAsMaster(choir.id, selectedSongs, {
+            name: identity.name,
+            choirId: choir.id,
+            choirName: choir.name,
+          });
+          toast.show({
+            variant: 'success',
+            label: `Diriges ${choir.name}. La sesión se cierra sola en 24 h.`,
+          });
+        } catch (e: any) {
+          logger.error('lead error', e);
+          toast.show({
+            variant: 'danger',
+            label: e?.message ?? 'No se ha podido iniciar',
+          });
+        }
+      };
+
+      if (!existing || isSameLeader(existing, identity)) {
+        void run();
+        return;
+      }
+      setPasswordRequest({
+        title: 'Tomar el mando',
+        description: `Ahora mismo dirige ${existing.master?.name || 'otra persona'}. Con la contraseña del coro pasas tú a dirigir y los demás te seguirán a ti.`,
+        confirmLabel: 'Dirigir yo',
+        onSuccess: () => {
+          setPasswordRequest(null);
+          void run();
+        },
+      });
+    },
+    [choirSession, selectedSongs, identity, toast],
+  );
+
+  /** Unirse como oyente: la playlist del líder pasa a ser la tuya (con deshacer). */
+  const joinLive = useCallback(
+    async (choir: MyChoir, session: ChoirSession) => {
+      try {
+        replaceWithUndo(
+          session.playlist ?? [],
+          `Sigues a ${session.master?.name || 'el líder'} en ${choir.name}`,
+          null,
+        );
+        await choirSession.joinAsSlave(choir.id);
+      } catch (e: any) {
+        logger.error('joinLive error', e);
+        toast.show({
+          variant: 'danger',
+          label: e?.message ?? 'No se ha podido entrar',
+        });
+      }
+    },
+    [choirSession, replaceWithUndo, toast],
+  );
+
+  const leaveLive = useCallback(() => {
+    void choirSession.leave();
+  }, [choirSession]);
+
+  const dismissPassword = useCallback(() => setPasswordRequest(null), []);
+
+  // El objeto se memoiza porque lo consume la pantalla de la playlist: si
+  // cambiara en cada render, la cabecera memoizada y el menú de acciones se
+  // recalcularían con cada pulsación de la lista.
+  return useMemo(
+    () => ({
+      // estado
+      myChoir,
+      setMyChoir,
+      link,
+      signature,
+      isSynced,
+      identity,
+      busy,
+      // hoja del coro
+      sheetStep,
+      openSheet,
+      closeSheet,
+      // contraseña
+      passwordRequest,
+      dismissPassword,
+      // acciones
+      replaceWithUndo,
+      clearWithUndo,
+      importByCode,
+      importEntry,
+      importLatestFromChoir,
+      saveNew,
+      saveUpdate,
+      lead,
+      joinLive,
+      leaveLive,
+      setLink,
+    }),
+    [
+      myChoir,
+      setMyChoir,
+      link,
+      signature,
+      isSynced,
+      identity,
+      busy,
+      sheetStep,
+      openSheet,
+      closeSheet,
+      passwordRequest,
+      dismissPassword,
+      replaceWithUndo,
+      clearWithUndo,
+      importByCode,
+      importEntry,
+      importLatestFromChoir,
+      saveNew,
+      saveUpdate,
+      lead,
+      joinLive,
+      leaveLive,
+      setLink,
+    ],
+  );
+}

--- a/mcm-app/services/choirDirectoryService.ts
+++ b/mcm-app/services/choirDirectoryService.ts
@@ -1,0 +1,216 @@
+/**
+ * Directorio de **coros** en Firebase Realtime Database.
+ *
+ * Un coro es la entidad de la que cuelga todo lo demás: sus playlists
+ * históricas y su sesión en vivo. La idea es que nadie tenga que acordarse de
+ * códigos: eliges tu coro una vez y a partir de ahí importas «la última» o
+ * subes la de hoy.
+ *
+ *   /choirs/{choirId} = {
+ *     v: 1,
+ *     name: "Coro Consolación Castellón",
+ *     nameKey: "coro-consolacion-castellon",     ← para detectar duplicados
+ *     createdAt, updatedAt,
+ *     createdBy: { deviceId, name? },            ← quién lo creó (para el panel)
+ *     playlists: {
+ *       "1234": { name, createdAt, updatedAt, songCount, by?, ownerDeviceId? }
+ *     }
+ *   }
+ *
+ * El **contenido** de cada playlist NO se duplica aquí: sigue viviendo en
+ * `/playlistShares/{code}` (ver `cloudPlaylistService`). Este nodo es solo el
+ * índice, para poder pintar la lista de un coro con una sola lectura ligera.
+ *
+ * Sin permisos: cualquiera puede crear un coro y subirle playlists. Borrar un
+ * coro se hace desde el panel de admin (por eso guardamos `createdBy`).
+ */
+import { getDatabase, ref, get, set, update, remove } from 'firebase/database';
+import { getFirebaseApp } from '@/utils/firebaseApp';
+import {
+  choirNameKey,
+  isChoirId,
+  makeChoirId,
+  normalizeChoirName,
+} from '@/utils/choirIds';
+import {
+  latestChoirPlaylist,
+  sortChoirPlaylists,
+  type ChoirPlaylistEntry,
+} from '@/utils/playlistSync';
+
+const ROOT = 'choirs';
+
+export type { ChoirPlaylistEntry };
+
+export interface ChoirAuthor {
+  deviceId: string;
+  name?: string;
+}
+
+export interface Choir {
+  id: string;
+  v: 1;
+  name: string;
+  nameKey: string;
+  createdAt: number;
+  updatedAt: number;
+  createdBy?: ChoirAuthor;
+  /** Índice de playlists, indexado por código de 4 dígitos. */
+  playlists: Record<string, ChoirPlaylistEntry>;
+}
+
+function choirRef(choirId: string) {
+  if (!isChoirId(choirId)) {
+    throw new Error('Identificador de coro inválido');
+  }
+  return ref(getDatabase(getFirebaseApp()), `${ROOT}/${choirId}`);
+}
+
+/** Normaliza lo que viene de Firebase (puede faltar `playlists`, venir sin id…). */
+function hydrate(id: string, raw: any): Choir {
+  const playlists: Record<string, ChoirPlaylistEntry> = {};
+  for (const [code, entry] of Object.entries(raw?.playlists ?? {})) {
+    const e = entry as Partial<ChoirPlaylistEntry>;
+    playlists[code] = {
+      code,
+      name: e?.name || `Playlist ${code}`,
+      createdAt: e?.createdAt ?? 0,
+      updatedAt: e?.updatedAt ?? e?.createdAt ?? 0,
+      songCount: e?.songCount ?? 0,
+      ...(e?.by ? { by: e.by } : {}),
+      ...(e?.ownerDeviceId ? { ownerDeviceId: e.ownerDeviceId } : {}),
+    };
+  }
+  return {
+    id,
+    v: 1,
+    name: raw?.name || id,
+    nameKey: raw?.nameKey || choirNameKey(raw?.name || id),
+    createdAt: raw?.createdAt ?? 0,
+    updatedAt: raw?.updatedAt ?? raw?.createdAt ?? 0,
+    ...(raw?.createdBy ? { createdBy: raw.createdBy as ChoirAuthor } : {}),
+    playlists,
+  };
+}
+
+/**
+ * Todos los coros, ordenados por nombre. Se espera un puñado (5-10), así que
+ * traerlos de golpe es más barato que cualquier paginación.
+ */
+export async function listChoirs(): Promise<Choir[]> {
+  const snap = await get(ref(getDatabase(getFirebaseApp()), ROOT));
+  if (!snap.exists()) return [];
+  const raw = snap.val() as Record<string, unknown>;
+  return Object.entries(raw)
+    .map(([id, value]) => hydrate(id, value))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Un coro concreto, o null si ya no existe (lo borró el panel). */
+export async function fetchChoir(choirId: string): Promise<Choir | null> {
+  const snap = await get(choirRef(choirId));
+  if (!snap.exists()) return null;
+  return hydrate(choirId, snap.val());
+}
+
+/**
+ * Crea un coro nuevo. Si ya hay uno con el mismo nombre (ignorando mayúsculas
+ * y acentos) lanza error con el nombre existente: es casi siempre lo que el
+ * usuario quería usar, no uno nuevo.
+ */
+export async function createChoir(
+  rawName: string,
+  createdBy: ChoirAuthor,
+): Promise<Choir> {
+  const name = normalizeChoirName(rawName);
+  if (name.length < 3) {
+    throw new Error('El nombre del coro es demasiado corto');
+  }
+  const nameKey = choirNameKey(name);
+  const existing = await listChoirs();
+  const clash = existing.find((c) => c.nameKey === nameKey);
+  if (clash) {
+    throw new Error(`Ya existe «${clash.name}». Elígelo en la lista.`);
+  }
+
+  const now = Date.now();
+  const id = makeChoirId(name);
+  const payload = {
+    v: 1 as const,
+    name,
+    nameKey,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: {
+      deviceId: createdBy.deviceId,
+      ...(createdBy.name ? { name: createdBy.name } : {}),
+    },
+  };
+  await set(choirRef(id), payload);
+  return { ...payload, id, playlists: {} };
+}
+
+/** Renombra un coro (lo usa sobre todo el panel; la app lo deja a mano). */
+export async function renameChoir(
+  choirId: string,
+  rawName: string,
+): Promise<void> {
+  const name = normalizeChoirName(rawName);
+  if (name.length < 3) throw new Error('El nombre del coro es demasiado corto');
+  await update(choirRef(choirId), {
+    name,
+    nameKey: choirNameKey(name),
+    updatedAt: Date.now(),
+  });
+}
+
+/** Borra el coro entero (panel de admin). No toca `/playlistShares`. */
+export async function deleteChoir(choirId: string): Promise<void> {
+  await remove(choirRef(choirId));
+}
+
+/**
+ * Da de alta (o actualiza) una playlist en el índice del coro. Se llama justo
+ * después de subir el contenido a `/playlistShares/{code}`.
+ */
+export async function upsertChoirPlaylist(
+  choirId: string,
+  entry: ChoirPlaylistEntry,
+): Promise<void> {
+  const now = Date.now();
+  const value = {
+    name: entry.name,
+    createdAt: entry.createdAt || now,
+    updatedAt: entry.updatedAt || now,
+    songCount: entry.songCount,
+    ...(entry.by ? { by: entry.by } : {}),
+    ...(entry.ownerDeviceId ? { ownerDeviceId: entry.ownerDeviceId } : {}),
+  };
+  // Una sola escritura multi-path: la entrada y el `updatedAt` del coro (que
+  // es lo que ordena la lista de coros por actividad en el panel).
+  await update(choirRef(choirId), {
+    [`playlists/${entry.code}`]: value,
+    updatedAt: now,
+  });
+}
+
+/** Quita una playlist del índice del coro (no borra el contenido compartido). */
+export async function removeChoirPlaylist(
+  choirId: string,
+  code: string,
+): Promise<void> {
+  await update(choirRef(choirId), {
+    [`playlists/${code}`]: null,
+    updatedAt: Date.now(),
+  });
+}
+
+/** Las playlists de un coro, ya ordenadas (la más reciente primero). */
+export function choirPlaylists(choir: Choir): ChoirPlaylistEntry[] {
+  return sortChoirPlaylists(Object.values(choir.playlists));
+}
+
+/** La playlist más reciente de un coro — lo que importa «importar la última». */
+export function choirLatestPlaylist(choir: Choir): ChoirPlaylistEntry | null {
+  return latestChoirPlaylist(Object.values(choir.playlists));
+}

--- a/mcm-app/services/choirSessionService.ts
+++ b/mcm-app/services/choirSessionService.ts
@@ -1,19 +1,30 @@
 /**
- * "Modo Coro": un dispositivo maestro publica la canción que está mirando
- * (y su tono) y N dispositivos esclavos la siguen en tiempo real.
+ * "Modo Coro": un dispositivo líder publica la canción que está mirando
+ * (y su tono) y N dispositivos oyentes la siguen en tiempo real.
+ *
+ * Desde el rediseño de coros, la sesión **cuelga del coro**: la clave del nodo
+ * es el id del coro (`consolacion-castellon-4f2a`), así que unirse es "elijo mi
+ * coro y ya" en vez de "que alguien me dicte 4 dígitos". Se siguen aceptando
+ * claves de 4 dígitos para las sesiones sueltas por código (opción secundaria,
+ * y los enlaces `/coro?c=1234` antiguos siguen funcionando).
  *
  * Estructura en Firebase Realtime Database:
  *
- *   /choirSessions/{code} = {
+ *   /choirSessions/{choirId | code} = {
  *     v: 1,
  *     master: { deviceId, name?, lastSeen },
+ *     choirId?, choirName?,
  *     playlist: SelectedSong[],
  *     current: { filename, transpose, screen?, updatedAt } | null,
- *     createdAt, updatedAt, lastActivity, expiresAt
+ *     createdAt, startedAt, updatedAt, lastActivity, expiresAt
  *   }
  *
- * Sin permisos: cualquiera con el código puede leer y escribir. Se asume
- * un grupo de confianza pequeño (20 dispositivos máx.) y baja frecuencia.
+ * **La sesión caduca 24 h después de empezar** (`expiresAt = startedAt + 24h`)
+ * y ese límite NO se estira al publicar: es un ensayo/celebración, no un canal
+ * permanente. Quien quiera seguir, vuelve a tomar el mando y empieza otras 24 h.
+ *
+ * Sin permisos: cualquiera con la clave puede leer y escribir. Se asume un
+ * grupo de confianza pequeño (20 dispositivos máx.) y baja frecuencia.
  */
 import {
   getDatabase,
@@ -27,20 +38,22 @@ import {
 import { getFirebaseApp } from '@/utils/firebaseApp';
 import type { SelectedSong } from '@/contexts/SelectedSongsContext';
 import { CODE_LENGTH, isValidCode } from '@/utils/playlistCodes';
+import { isChoirId } from '@/utils/choirIds';
 
 const ROOT = 'choirSessions';
-const TWO_WEEKS_MS = 1000 * 60 * 60 * 24 * 14;
+/** Una sesión de coro dura como mucho un día desde que arranca. */
+export const CHOIR_SESSION_TTL_MS = 1000 * 60 * 60 * 24;
 
 export interface ChoirCurrentSong {
   filename: string;
   /** Semitonos sobre el tono original. */
   transpose: number;
-  /** Override de cejilla publicado por el maestro para esta canción. */
+  /** Override de cejilla publicado por el líder para esta canción. */
   capoOverride?: number | null;
   /** Marcador opcional: 'detail' (por defecto) o 'fullscreen'. */
   screen?: 'detail' | 'fullscreen';
   updatedAt: number;
-  // Metadatos para que el esclavo pueda renderizar la canción sin tener
+  // Metadatos para que el oyente pueda renderizar la canción sin tener
   // que buscarla en su cantoral local (puede ser una canción que ni
   // siquiera está en su selección).
   title?: string;
@@ -63,42 +76,98 @@ export interface ChoirSession {
   playlist: SelectedSong[];
   current: ChoirCurrentSong | null;
   createdAt: number;
+  /** Momento en que el líder actual tomó el mando (base de la caducidad). */
+  startedAt: number;
   updatedAt: number;
   lastActivity: number;
   expiresAt: number;
+  /** Coro del que cuelga la sesión (ausente en las sesiones sueltas por código). */
+  choirId?: string;
+  choirName?: string;
 }
 
-function getRef(code: string) {
-  if (!isValidCode(code)) {
-    throw new Error(`Código inválido (deben ser ${CODE_LENGTH} dígitos)`);
+/** ¿Es una clave válida de sesión? Un id de coro o un código de 4 dígitos. */
+export function isSessionKey(key: string): boolean {
+  return isValidCode(key) || isChoirId(key);
+}
+
+function getRef(key: string) {
+  if (!isSessionKey(key)) {
+    throw new Error(
+      `Código inválido (deben ser ${CODE_LENGTH} dígitos o un id de coro)`,
+    );
   }
   const db = getDatabase(getFirebaseApp());
-  return ref(db, `${ROOT}/${code}`);
+  return ref(db, `${ROOT}/${key}`);
 }
 
-/** ¿Existe ya una sesión de coro con ese código? */
-export async function choirSessionExists(code: string): Promise<boolean> {
-  const snap = await get(getRef(code));
+/**
+ * ¿Sigue viva esta sesión? Una sesión caducada se queda en Firebase hasta que
+ * pasa la purga, así que el cliente tiene que ignorarla por su cuenta.
+ */
+export function isSessionLive(
+  session: ChoirSession | null | undefined,
+  now = Date.now(),
+): boolean {
+  if (!session) return false;
+  const expires =
+    session.expiresAt ??
+    (session.startedAt ?? session.createdAt ?? 0) + CHOIR_SESSION_TTL_MS;
+  return expires > now;
+}
+
+/**
+ * ¿Es `deviceId`/`name` la misma persona que lidera la sesión?
+ *
+ * El mismo dispositivo siempre lo es. Y si el usuario tiene nombre en su
+ * perfil, también cuenta como "el mismo" desde otro móvil: es justo el caso de
+ * "quiero dirigir desde la tablet", que no debería pedir contraseña.
+ */
+export function isSameLeader(
+  session: ChoirSession | null | undefined,
+  who: { deviceId: string; name?: string },
+): boolean {
+  if (!session) return true;
+  if (session.master?.deviceId && session.master.deviceId === who.deviceId) {
+    return true;
+  }
+  const leaderName = (session.master?.name ?? '').trim().toLowerCase();
+  const myName = (who.name ?? '').trim().toLowerCase();
+  return !!leaderName && leaderName === myName;
+}
+
+/** ¿Existe ya una sesión de coro con esa clave? */
+export async function choirSessionExists(key: string): Promise<boolean> {
+  const snap = await get(getRef(key));
   return snap.exists();
 }
 
-/** Lee la sesión asociada a `code` o devuelve null si no existe. */
+/** Lee la sesión asociada a `key` o devuelve null si no existe. */
 export async function fetchChoirSession(
-  code: string,
+  key: string,
 ): Promise<ChoirSession | null> {
-  const snap = await get(getRef(code));
+  const snap = await get(getRef(key));
   if (!snap.exists()) return null;
   return snap.val() as ChoirSession;
 }
 
+/** Lee la sesión solo si sigue viva (caducadas → null). */
+export async function fetchLiveChoirSession(
+  key: string,
+): Promise<ChoirSession | null> {
+  const session = await fetchChoirSession(key);
+  return isSessionLive(session) ? session : null;
+}
+
 /**
- * Crea o reemplaza la sesión de coro `code` con la playlist y maestro dados.
- * Si ya existe, se sobrescribe (caller debe haber confirmado).
+ * Crea o reemplaza la sesión `key` con la playlist y líder dados. Tomar el
+ * mando reinicia el contador de 24 h: `startedAt` vuelve a ser ahora.
  */
 export async function createChoirSession(
-  code: string,
+  key: string,
   master: { deviceId: string; name?: string },
   playlist: SelectedSong[],
+  opts?: { choirId?: string; choirName?: string; createdAt?: number },
 ): Promise<ChoirSession> {
   const now = Date.now();
   const payload: ChoirSession = {
@@ -110,19 +179,22 @@ export async function createChoirSession(
     },
     playlist,
     current: null,
-    createdAt: now,
+    createdAt: opts?.createdAt ?? now,
+    startedAt: now,
     updatedAt: now,
     lastActivity: now,
-    expiresAt: now + TWO_WEEKS_MS,
+    expiresAt: now + CHOIR_SESSION_TTL_MS,
+    choirId: opts?.choirId,
+    choirName: opts?.choirName,
   };
   const cleanPayload = JSON.parse(JSON.stringify(payload));
-  await set(getRef(code), cleanPayload);
+  await set(getRef(key), cleanPayload);
   return payload;
 }
 
-/** Cambia la playlist publicada por el maestro. */
+/** Cambia la playlist publicada por el líder. */
 export async function publishChoirPlaylist(
-  code: string,
+  key: string,
   playlist: SelectedSong[],
 ): Promise<void> {
   const now = Date.now();
@@ -130,15 +202,14 @@ export async function publishChoirPlaylist(
     playlist,
     updatedAt: now,
     lastActivity: now,
-    expiresAt: now + TWO_WEEKS_MS,
     'master/lastSeen': now,
   };
-  await update(getRef(code), JSON.parse(JSON.stringify(updatePayload)));
+  await update(getRef(key), JSON.parse(JSON.stringify(updatePayload)));
 }
 
-/** Cambia la "canción actual" que el maestro está mostrando. */
+/** Cambia la "canción actual" que el líder está mostrando. */
 export async function publishChoirCurrent(
-  code: string,
+  key: string,
   current: Omit<ChoirCurrentSong, 'updatedAt'>,
 ): Promise<void> {
   const now = Date.now();
@@ -146,53 +217,55 @@ export async function publishChoirCurrent(
     current: { ...current, updatedAt: now },
     updatedAt: now,
     lastActivity: now,
-    expiresAt: now + TWO_WEEKS_MS,
     'master/lastSeen': now,
   };
-  await update(getRef(code), JSON.parse(JSON.stringify(updatePayload)));
+  await update(getRef(key), JSON.parse(JSON.stringify(updatePayload)));
 }
 
 /** Suscripción en tiempo real. Devuelve la función `unsubscribe`. */
 export function subscribeChoirSession(
-  code: string,
+  key: string,
   onChange: (session: ChoirSession | null) => void,
   onError?: (err: Error) => void,
 ): () => void {
-  const r = getRef(code);
+  const r = getRef(key);
   const unsubscribe = onValue(
     r,
     (snap) => {
-      onChange(snap.exists() ? (snap.val() as ChoirSession) : null);
+      const session = snap.exists() ? (snap.val() as ChoirSession) : null;
+      // Una sesión caducada equivale a que no la haya: así el oyente sale solo
+      // cuando pasan las 24 h, sin que nadie tenga que cerrarla a mano.
+      onChange(isSessionLive(session) ? session : null);
     },
     (err) => onError?.(err),
   );
   return unsubscribe;
 }
 
-/** Borra la sesión (cierre manual por el maestro). */
-export async function closeChoirSession(code: string): Promise<void> {
-  await remove(getRef(code));
+/** Borra la sesión (cierre manual por el líder). */
+export async function closeChoirSession(key: string): Promise<void> {
+  await remove(getRef(key));
 }
 
 /**
- * Mueve la sesión de `oldCode` a `newCode`. Falla si `newCode` está ocupado.
+ * Mueve la sesión de `oldKey` a `newKey`. Falla si `newKey` está ocupada.
  */
 export async function changeChoirSessionCode(
-  oldCode: string,
-  newCode: string,
+  oldKey: string,
+  newKey: string,
 ): Promise<ChoirSession> {
-  if (oldCode === newCode) {
-    const cur = await fetchChoirSession(oldCode);
+  if (oldKey === newKey) {
+    const cur = await fetchChoirSession(oldKey);
     if (!cur) throw new Error('La sesión ya no existe');
     return cur;
   }
-  if (await choirSessionExists(newCode)) {
+  if (await choirSessionExists(newKey)) {
     throw new Error('El nuevo código ya está en uso');
   }
-  const cur = await fetchChoirSession(oldCode);
+  const cur = await fetchChoirSession(oldKey);
   if (!cur) throw new Error('La sesión original ya no existe');
   const moved: ChoirSession = { ...cur, updatedAt: Date.now() };
-  await set(getRef(newCode), JSON.parse(JSON.stringify(moved)));
-  await remove(getRef(oldCode));
+  await set(getRef(newKey), JSON.parse(JSON.stringify(moved)));
+  await remove(getRef(oldKey));
   return moved;
 }

--- a/mcm-app/services/cloudPlaylistService.ts
+++ b/mcm-app/services/cloudPlaylistService.ts
@@ -9,7 +9,11 @@
 import { getDatabase, ref, get, set, remove, update } from 'firebase/database';
 import { getFirebaseApp } from '@/utils/firebaseApp';
 import type { SelectedSong } from '@/contexts/SelectedSongsContext';
-import { CODE_LENGTH, isValidCode } from '@/utils/playlistCodes';
+import {
+  CODE_LENGTH,
+  generateRandomCode,
+  isValidCode,
+} from '@/utils/playlistCodes';
 
 const ROOT = 'playlistShares';
 const SIX_MONTHS_MS = 1000 * 60 * 60 * 24 * 30 * 6;
@@ -21,6 +25,17 @@ export interface CloudPlaylist {
   createdAt: number;
   updatedAt: number;
   expiresAt: number;
+  /** Coro del que cuelga, si se subió desde un coro. */
+  choirId?: string;
+  /** Nombre del coro en el momento de subirla (para poder enseñarlo sin otra lectura). */
+  choirName?: string;
+  /** Nombre de quien la subió por última vez, si lo tenía puesto en su perfil. */
+  by?: string;
+  /**
+   * Dispositivo que la subió. Sirve para que "la tuya" no te pida contraseña
+   * al volver a subirla; para los demás la contraseña sigue haciendo falta.
+   */
+  ownerDeviceId?: string;
 }
 
 function getRef(code: string) {
@@ -63,7 +78,14 @@ export async function fetchCloudPlaylist(
 export async function uploadCloudPlaylist(
   code: string,
   songs: SelectedSong[],
-  opts?: { name?: string; createdAt?: number },
+  opts?: {
+    name?: string;
+    createdAt?: number;
+    choirId?: string;
+    choirName?: string;
+    by?: string;
+    ownerDeviceId?: string;
+  },
 ): Promise<CloudPlaylist> {
   const now = Date.now();
   const payload: CloudPlaylist = {
@@ -73,10 +95,32 @@ export async function uploadCloudPlaylist(
     createdAt: opts?.createdAt ?? now,
     updatedAt: now,
     expiresAt: now + SIX_MONTHS_MS,
+    choirId: opts?.choirId,
+    choirName: opts?.choirName,
+    by: opts?.by,
+    ownerDeviceId: opts?.ownerDeviceId,
   };
   const cleanPayload = JSON.parse(JSON.stringify(payload));
   await set(getRef(code), cleanPayload);
   return payload;
+}
+
+/**
+ * Busca un código libre. Se usa al subir una playlist **a un coro**, donde el
+ * código es un detalle secundario (se enseña pequeñito) y nadie quiere
+ * elegirlo a mano ni chocar con el de otro.
+ *
+ * Con 10.000 códigos y unas pocas decenas en uso, el primer intento acierta
+ * casi siempre; aun así probamos varias veces antes de rendirnos.
+ */
+export async function allocateFreeCode(attempts = 12): Promise<string> {
+  for (let i = 0; i < attempts; i++) {
+    const candidate = generateRandomCode();
+    if (!(await cloudPlaylistExists(candidate))) return candidate;
+  }
+  throw new Error(
+    'No se ha podido reservar un código libre, inténtalo otra vez',
+  );
 }
 
 /** Borra la playlist asociada a `code`. */
@@ -108,6 +152,7 @@ export async function changeCloudPlaylistCode(
   // copias vivas ni un estado intermedio.
   const now = Date.now();
   const moved: CloudPlaylist = {
+    ...cur,
     v: 2,
     songs: cur.songs,
     name: cur.name,

--- a/mcm-app/utils/choirIds.ts
+++ b/mcm-app/utils/choirIds.ts
@@ -1,0 +1,83 @@
+/**
+ * Identidad de un **coro** (la "entidad" de la que cuelgan las playlists y la
+ * sesión en vivo).
+ *
+ * Un coro se identifica con una clave legible derivada de su nombre más un
+ * sufijo aleatorio: `consolacion-castellon-4f2a`. Eso da tres cosas a la vez:
+ *
+ *  1. Es una clave válida de Realtime Database (sin `. $ # [ ] /`).
+ *  2. Se puede leer en una URL (`/playlist?coro=consolacion-castellon-4f2a`)
+ *     sin que parezca un identificador opaco.
+ *  3. Nunca colisiona con un **código de playlist** de 4 dígitos: todos los
+ *     ids de coro llevan al menos un guion, y los códigos son solo dígitos.
+ *     Gracias a eso, `/choirSessions/<clave>` puede almacenar indistintamente
+ *     sesiones de coro (clave = id del coro) y sesiones sueltas por código
+ *     (clave = 4 dígitos) sin ambigüedad.
+ *
+ * Todo aquí es lógica pura y sin dependencias, para poder testearla.
+ */
+
+/** Longitud máxima de la parte "slug" del id (sin contar el sufijo). */
+const MAX_SLUG_LENGTH = 32;
+
+/** Nombre de coro más largo que aceptamos al crear. */
+export const MAX_CHOIR_NAME_LENGTH = 60;
+
+/**
+ * Limpia el nombre tal cual lo escribe el usuario: sin espacios sobrantes ni
+ * saltos de línea, y recortado a `MAX_CHOIR_NAME_LENGTH`.
+ */
+export function normalizeChoirName(raw: string): string {
+  return (raw ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_CHOIR_NAME_LENGTH);
+}
+
+/** Quita acentos/diacríticos: «Castellón» → «Castellon». */
+function stripDiacritics(text: string): string {
+  return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/**
+ * Clave de comparación de nombres, para detectar duplicados: «Coro Consolación
+ * Castellón», «coro consolacion castellon» y «CORO  CONSOLACION-CASTELLON»
+ * comparten `nameKey`. Se guarda junto al coro para poder avisar de que ya
+ * existe en vez de crear un tercer «Coro de Madrid».
+ */
+export function choirNameKey(name: string): string {
+  return stripDiacritics(normalizeChoirName(name))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+/** Sufijo aleatorio de 4 caracteres (base 36) que hace único al id. */
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 6).padEnd(4, '0');
+}
+
+/**
+ * Construye el id de un coro a partir de su nombre. `randomPart` se puede
+ * inyectar en los tests para tener ids deterministas.
+ */
+export function makeChoirId(name: string, randomPart?: string): string {
+  const slug = choirNameKey(name)
+    .slice(0, MAX_SLUG_LENGTH)
+    // Un guion final (por el recorte) daría un id feo tipo `coro-de-`.
+    .replace(/-+$/, '');
+  const base = slug || 'coro';
+  return `${base}-${randomPart ?? randomSuffix()}`;
+}
+
+/**
+ * ¿Es `key` un id de coro bien formado? Exigimos el guion a propósito: es lo
+ * que garantiza que jamás se confunda con un código de 4 dígitos.
+ */
+export function isChoirId(key: string): boolean {
+  if (typeof key !== 'string') return false;
+  if (key.length < 3 || key.length > 48) return false;
+  if (!key.includes('-')) return false;
+  return /^[a-z0-9]+(-[a-z0-9]+)+$/.test(key);
+}

--- a/mcm-app/utils/pendingCloudPlaylist.ts
+++ b/mcm-app/utils/pendingCloudPlaylist.ts
@@ -10,6 +10,8 @@ let pendingPlaylist: string | null = null;
 let pendingChoir: string | null = null;
 /** Payload compacto de una playlist offline (mcmapp://playlist?d=...). */
 let pendingOffline: string | null = null;
+/** Id de coro del que hay que importar la ÚLTIMA playlist (`/playlist?coro=…`). */
+let pendingChoirImport: string | null = null;
 
 export function setPendingCloudPlaylistCode(code: string | null) {
   pendingPlaylist = code;
@@ -47,4 +49,14 @@ export function consumePendingOfflinePlaylist(): string | null {
   const payload = pendingOffline;
   pendingOffline = null;
   return payload;
+}
+
+export function setPendingChoirImport(choirId: string | null) {
+  pendingChoirImport = choirId;
+}
+
+export function consumePendingChoirImport(): string | null {
+  const id = pendingChoirImport;
+  pendingChoirImport = null;
+  return id;
 }

--- a/mcm-app/utils/playlistSync.ts
+++ b/mcm-app/utils/playlistSync.ts
@@ -1,0 +1,127 @@
+/**
+ * Utilidades puras del "estado de sincronización" de la playlist: saber si lo
+ * que tienes en el móvil es exactamente lo que hay subido, ordenar las
+ * playlists de un coro y escribir fechas que se lean de un vistazo.
+ *
+ * Vive aparte de la pantalla porque es lógica sin UI (y con tests).
+ */
+import type { SelectedSong } from '@/contexts/SelectedSongsContext';
+
+/**
+ * Huella de una playlist: cambia si cambian las canciones, su orden, su
+ * transporte o su cejilla. Sirve para decidir si mostrar «guardada» o
+ * «cambios sin guardar» sin tener que guardar una copia entera de la lista.
+ *
+ * No es criptográfica ni pretende serlo: solo tiene que ser estable y barata.
+ */
+export function playlistSignature(songs: SelectedSong[]): string {
+  // Se deduplica por `filename` igual que hace `SelectedSongsContext` al
+  // guardar: si no, una lista importada con un duplicado daría una firma
+  // distinta a la que acaba en el móvil y la pantalla diría "cambios sin
+  // guardar" nada más importarla.
+  const seen = new Set<string>();
+  const unique = [...songs]
+    .sort((a, b) => a.order - b.order)
+    .filter((s) => {
+      if (seen.has(s.filename)) return false;
+      seen.add(s.filename);
+      return true;
+    });
+  const canonical = unique
+    .map(
+      (s) =>
+        `${s.filename}:${s.transpose ?? 0}:${
+          s.capoOverride === null || s.capoOverride === undefined
+            ? '-'
+            : s.capoOverride
+        }`,
+    )
+    .join('|');
+
+  // Hash djb2 → base36. Añadimos la longitud para que dos listas distintas con
+  // el mismo hash (improbable) sigan distinguiéndose por tamaño.
+  let hash = 5381;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) + hash + canonical.charCodeAt(i)) | 0;
+  }
+  return `${unique.length}-${(hash >>> 0).toString(36)}`;
+}
+
+/** Entrada del índice de playlists de un coro (lo mínimo para pintar la lista). */
+export interface ChoirPlaylistEntry {
+  /** Código de 4 dígitos con el que se puede importar/compartir suelta. */
+  code: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  songCount: number;
+  /** Nombre de quien la subió por última vez, si lo tenía puesto. */
+  by?: string;
+  /** Dispositivo que la subió: "la mía" se actualiza sin contraseña. */
+  ownerDeviceId?: string;
+}
+
+/**
+ * Orden en el que se enseñan las playlists de un coro: la más recientemente
+ * modificada arriba. El panel puede retocar `updatedAt` justamente para
+ * reordenarlas a mano.
+ */
+export function sortChoirPlaylists(
+  entries: ChoirPlaylistEntry[],
+): ChoirPlaylistEntry[] {
+  return [...entries].sort(
+    (a, b) =>
+      (b.updatedAt ?? 0) - (a.updatedAt ?? 0) || a.name.localeCompare(b.name),
+  );
+}
+
+/** La más reciente de un coro, o null si el coro aún no tiene ninguna. */
+export function latestChoirPlaylist(
+  entries: ChoirPlaylistEntry[],
+): ChoirPlaylistEntry | null {
+  return sortChoirPlaylists(entries)[0] ?? null;
+}
+
+const MONTHS = [
+  'ene',
+  'feb',
+  'mar',
+  'abr',
+  'may',
+  'jun',
+  'jul',
+  'ago',
+  'sep',
+  'oct',
+  'nov',
+  'dic',
+];
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+/**
+ * Fecha corta y humana: «ahora mismo», «hace 12 min», «hace 3 h», «ayer»,
+ * «7 ago», «7 ago 2025». Pensada para caber en una línea pequeña bajo el
+ * nombre de la playlist.
+ */
+export function formatRelativeDate(ts: number, now = Date.now()): string {
+  if (!ts || !Number.isFinite(ts)) return '';
+  const diff = now - ts;
+  if (diff < 0) return formatAbsolute(ts, now);
+  if (diff < 2 * MINUTE) return 'ahora mismo';
+  if (diff < HOUR) return `hace ${Math.round(diff / MINUTE)} min`;
+  if (diff < 24 * HOUR) {
+    const hours = Math.floor(diff / HOUR);
+    return `hace ${hours} h`;
+  }
+  if (diff < 48 * HOUR) return 'ayer';
+  return formatAbsolute(ts, now);
+}
+
+function formatAbsolute(ts: number, now: number): string {
+  const d = new Date(ts);
+  const sameYear = d.getFullYear() === new Date(now).getFullYear();
+  const base = `${d.getDate()} ${MONTHS[d.getMonth()]}`;
+  return sameYear ? base : `${base} ${d.getFullYear()}`;
+}

--- a/mcm-app/utils/qrScan.ts
+++ b/mcm-app/utils/qrScan.ts
@@ -6,6 +6,10 @@
  *   1. Playlist en la nube  → https://mcm.expo.app/playlist?p=1234
  *   2. Sesión de coro       → https://mcm.expo.app/coro?c=1234
  *   3. Playlist sin conexión → mcmapp://playlist?d=<payload>
+ *   4. Coro (rediseño)      → https://mcm.expo.app/playlist?coro=<id> (importa
+ *      SIEMPRE la última playlist del coro) y https://mcm.expo.app/coro?coro=<id>
+ *      (se une a su sesión en vivo). Estos no caducan: el mismo QR pegado en la
+ *      carpeta del coro sirve todos los domingos.
  *
  * Además aceptamos que alguien escriba/pegue un QR con solo los 4 dígitos.
  *
@@ -14,11 +18,14 @@
  * Todo esto es lógica pura y sin dependencias para poder testearla.
  */
 import { isValidCode } from '@/utils/playlistCodes';
+import { isChoirId } from '@/utils/choirIds';
 
 /** A qué flujo apunta un QR escaneado. */
 export type QrTarget = 'playlist' | 'choir';
 
 export type QrScanResult =
+  /** QR de coro: `choirId` identifica al coro; el flujo depende del path. */
+  | { kind: 'choir'; target: QrTarget; choirId: string }
   /**
    * QR con código corto: hay que descargar de Firebase. `target` es `null`
    * cuando el QR traía solo los 4 dígitos, sin decir de qué flujo son: en ese
@@ -75,7 +82,19 @@ export function parseScannedQr(raw: string): QrScanResult | null {
   // 2. Playlist offline: el payload manda sobre el código.
   if (isPlaylist && params.d) return { kind: 'offline', payload: params.d };
 
-  // 3. Código corto. `code` es el alias que aceptan las dos pantallas puente.
+  // 3. Coro: `?coro=<id>` vale en los dos paths (importar la última / unirse).
+  if (params.coro && isChoirId(params.coro)) {
+    return {
+      kind: 'choir',
+      target: isChoir ? 'choir' : 'playlist',
+      choirId: params.coro,
+    };
+  }
+  if (isChoir && params.c && isChoirId(params.c)) {
+    return { kind: 'choir', target: 'choir', choirId: params.c };
+  }
+
+  // 4. Código corto. `code` es el alias que aceptan las dos pantallas puente.
   const code = isChoir ? (params.c ?? params.code) : (params.p ?? params.code);
   if (code && isValidCode(code)) {
     return { kind: 'code', target: isChoir ? 'choir' : 'playlist', code };
@@ -99,6 +118,12 @@ export function describeMismatch(
     return expected === 'playlist'
       ? null
       : 'Ese QR es una playlist, no una sesión de coro';
+  }
+  if (result.kind === 'choir') {
+    if (result.target === expected) return null;
+    return result.target === 'choir'
+      ? 'Ese QR es de una sesión de coro en vivo, no de una playlist'
+      : 'Ese QR trae la última playlist de un coro, no una sesión en vivo';
   }
   if (result.target === null || result.target === expected) return null;
   return result.target === 'choir'


### PR DESCRIPTION
## Qué cambia

Cambio de concepto: **el coro es la entidad de la que cuelgan las playlists** y la sesión en vivo. Se elige el coro una vez («Coro Consolación Castellón») y a partir de ahí importar la lista del domingo es un toque. Los códigos de 4 dígitos y los QR se quedan como opción secundaria, y **todos los antiguos siguen funcionando**: el contenido sigue viviendo en `/playlistShares/<code>`, `/choirs` es solo el índice.

## Modelo de datos

```
/choirs/{choirId}          ← nuevo. name, nameKey, createdBy, playlists{code: {name, updatedAt, songCount, by}}
/playlistShares/{code}     ← sin cambios de forma; +choirId, choirName, by, ownerDeviceId
/choirSessions/{choirId|code}  ← la clave puede ser un coro; expiresAt = startedAt + 24 h
```

El `choirId` (`consolacion-castellon-4f2a`) siempre lleva un guion, así que nunca se confunde con un código de 4 dígitos — eso es lo que permite que el nodo de sesiones acepte las dos cosas sin ambigüedad.

## Flujos arreglados

- **Actualizar una playlist ya subida**, que antes era imposible: la app recuerda el enlace con la nube (código + coro + firma de la lista) y ofrece «Actualizar «X»» o «Subir como nueva». La cabecera dice «guardada» o «cambios sin guardar».
- **Contraseña `coco` para machacar lo de otra persona**; si la subiste tú desde ese dispositivo, directo.
- **Importar deja de interrogar**: enlace, QR o coro reemplazan la selección y dejan 10 s de «Deshacer» (canciones y enlace). El diálogo «reemplazar / añadir» se queda solo para archivos `.mcm`.
- **Vaciar** pasa a la cabecera, sin confirmación y con deshacer.
- **Coro en vivo por coro**, no por código, con cierre automático a las 24 h desde que empezó (antes 2 semanas y se estiraba sola) y traspaso del mando — sin contraseña si eres el mismo usuario desde otro dispositivo.
- **Menú reorganizado** por frecuencia de uso, ocultando lo que no se puede hacer con la lista vacía.

## Enlaces nuevos

| URL | Qué hace |
| --- | --- |
| `/playlist?coro=<id>` | Importa **siempre la última** del coro. No caduca: el mismo QR sirve todos los domingos |
| `/coro?coro=<id>` | Se une a la sesión en vivo del coro |

## Antes de mergear a `production`

Hay que **desplegar las reglas** de `database.rules.json` (nodo `/choirs` nuevo): sin eso la app no puede crear coros. La gestión desde el panel va en mcmespana/mcmpanel#(PR de coros).

## Comprobado

- `npx tsc --noEmit` limpio
- `npm test`: 651 tests, 69 suites en verde (4 ficheros de test nuevos: ids de coro, firma/orden de playlists, directorio de coros, reglas de la sesión en vivo)
- `npm run lint`: 0 errores
- Sin paquetes nativos nuevos → no necesita build de tienda

Documentación: `docs/funcionalidades/COROS.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuWk4eSfzaNcW6VSn43mtF)_