### PR TITLE
Anota el CI parado desde abril y la regla del test-guardarraíl

### DIFF
--- a/docs/planes/BACKLOG.md
+++ b/docs/planes/BACKLOG.md
@@ -38,6 +38,7 @@
 | **Ahora mismo** | **Build de tienda 2.1 — agosto de 2026.** Falta: crear las cuentas de Sentry y Aptabase y meter las claves (§2 del doc de build), validar en dispositivo (§5), publicar (§6) |
 | **Bloqueado por ti** | Integración D2 (modelo de auth del panel) · desplegar las reglas de Firebase (escritas y listas, ver `docs/SEGURIDAD.md`) |
 | **Bloqueado fuera** | Política de privacidad y fichas de las tiendas (obligatorio antes de publicar, ver §6 del doc de build) · probar los channels en un Android real |
+| **⚠️ Roto y sin dueño** | **El CI no ejecuta nada desde el 2026-04-10.** Ningún PR se verifica de verdad; hasta arreglarlo, pasa los 4 pasos de `verify.yml` en local antes de mergear. Detalle en `mcm-app/TODO.md` §0 |
 | **Después de la build** | UI Nativa Fase 2 → Integración D → Carismochito |
 | **Oportunista** | Integraciones resto. **Ya NO**: Calidad Fase 1 (descartada, ver §2.A) ni Etiquetas (§2.C-ter, cerrado) |
 | **Futuro lejano, sin prisa** | Widget de Contigo · Panel Pañuelo (§1 notas) |

--- a/mcm-app/CHANGELOG.md
+++ b/mcm-app/CHANGELOG.md
@@ -18,6 +18,21 @@
 
 ---
 
+## 2026-08-15 21:30 — Aviso: el CI lleva parado desde abril
+
+Al arreglar los 4 errores de `typecheck:tests` de la #334 salió a la luz que
+**GitHub Actions no ejecuta nada en este repo desde el 2026-04-10**: por eso
+llevaban meses en `main` sin que saltara nadie. Ningún PR se está verificando de
+verdad, aunque el workflow siga en el repo.
+
+Anotado como tarea de prioridad máxima en `TODO.md` §0 y en el puntero rápido de
+`docs/planes/BACKLOG.md`. Mientras siga roto, los cuatro pasos de `verify.yml`
+(`typecheck`, `typecheck:tests`, `lint`, `test -- --ci`) hay que pasarlos en
+local antes de mergear.
+
+También en `CLAUDE.md`: una regla que se puede romper sin enterarse va en un
+test-guardarraíl, no en un documento (el modelo es `tabsLayoutWebSafety.test.ts`).
+
 ## 2026-08-15 20:15 — Repaso de warnings (111 → 51) y reordenación de los planes
 
 **Warnings del compilador de React, sin silenciar ninguno:**

--- a/mcm-app/CLAUDE.md
+++ b/mcm-app/CLAUDE.md
@@ -311,6 +311,7 @@ danger: '#9D1E74'; // Morado LC
 - **Plataforma**: usar `Platform.OS` para diferencias, archivos `.ios.tsx` para componentes iOS-only
 - **Tamaño de archivo**: el techo son **1.000 líneas** (ESLint avisa con `max-lines`); a partir de **1.500** hay que trocear de verdad — extraer subcomponentes a `components/<área>/` y la lógica a un hook `use<Pantalla>.ts` **ANTES** de añadir la feature. Umbrales subidos desde 400/600 el 2026-08-08: con agentes de IA leyendo el código, un archivo largo pero coherente cuesta menos que la misma lógica repartida en seis ficheros que hay que reconstruir mentalmente. Los gigantes que ya hay **se quedan**: no hace falta trocearlos por tamaño.
 - **Logging**: nunca `console.*` (ESLint lo bloquea como error). Usar el logger central `@/utils/logger` (`logger.debug/info/warn/error`).
+- **Una regla que se puede romper sin enterarse va en un test, no en un documento.** Este código lo edita siempre una IA, y una IA puede no leer un párrafo — pero no puede ignorar un test en rojo. El modelo es `__tests__/tabsLayoutWebSafety.test.ts`: no comprueba una función, comprueba que **nadie vuelva a importar** el módulo nativo de tabs en el grafo de web (el fallo real solo se veía al desplegar). Cuando algo se rompa por no saber una regla, el arreglo correcto no es ampliar este archivo: es un test-guardarraíl que falle solo. Razonamiento completo en `docs/planes/PLAN_CALIDAD.md` §0.
 
 ## Patrones comunes
 

--- a/mcm-app/TODO.md
+++ b/mcm-app/TODO.md
@@ -14,9 +14,32 @@
 
 ## Prioridad alta
 
-> Orden propuesto (repriorízalo si no lo ves). Los 1-3 están atados entre sí:
-> la rama de la barra de tabs no se mergea hasta validarla, y hay cosas que
-> sólo se pueden hacer con la build nativa delante.
+> Orden propuesto (repriorízalo si no lo ves).
+
+### 0. ⚠️ El CI no ejecuta nada desde abril de 2026
+
+- [ ] **Averiguar por qué GitHub Actions está parado y volver a encenderlo.**
+      El último run de `ci.yml` es del **2026-04-10**; desde entonces
+      **ningún PR se ha verificado de verdad**, aunque el workflow siga en el
+      repo y la PR parezca "clean" al mergear.
+
+Cómo se descubrió: el 2026-08-15, `npm run typecheck:tests` —que es uno de los
+cuatro pasos de `verify.yml`— llevaba fallando con 4 errores de tipos en `main`
+sin que saltara nadie. Se arreglaron en la #334, pero el problema de fondo es
+que **el guardarraíl está desenchufado**: mientras siga así, lo único que
+verifica el repo es lo que ejecute a mano quien esté trabajando.
+
+Sitios donde mirar: pestaña Actions del repo (¿deshabilitadas?), si la cuenta se
+quedó sin minutos, y si algún ajuste de la organización bloquea los workflows en
+PRs de ramas `claude/*`.
+
+Mientras tanto, **antes de mergear cualquier cosa hay que pasar los cuatro pasos
+en local**:
+
+```bash
+cd mcm-app
+npm run typecheck && npm run typecheck:tests && npm run lint && npm test -- --ci
+```
 
 ### 1. Sacar la build de tienda de agosto
 
@@ -133,11 +156,11 @@ quede pegado a la barra de estado ni le falte respiro arriba.
       Grupos migrados de sus versiones a mano).
 
       **Los `TextInput` que quedan NO se migran, y está decidido**: los
-                      buscadores del cantoral y de Grupos son otro patrón (icono dentro, botón
-                      de limpiar); el de `CodeInputModal` es un input INVISIBLE detrás de las
-                      celdas del código; y los de Revisión quedaron, tras el refactor del examen
-                      del día, como campos SIN borde dentro de una fila que sí lo tiene —
-                      `AppTextField` les metería un borde dentro de otro.
+                          buscadores del cantoral y de Grupos son otro patrón (icono dentro, botón
+                          de limpiar); el de `CodeInputModal` es un input INVISIBLE detrás de las
+                          celdas del código; y los de Revisión quedaron, tras el refactor del examen
+                          del día, como campos SIN borde dentro de una fila que sí lo tiene —
+                          `AppTextField` les metería un borde dentro de otro.
 
 ## Modo Carismochito (ver `docs/planes/PLAN_CARISMOCHITO.md`)
 
@@ -190,22 +213,22 @@ quede pegado a la barra de estado ni le falte respiro arriba.
       cada render) lo habría cazado un render test.
 
       Por dónde empezar, en orden de rentabilidad:
-                                              1. **Render tests de las pantallas de tab** (Home, Cantoral, Contigo,
-                                                 Más): que monten sin reventar con datos vacíos, con datos y offline.
-                                              2. `useResolvedProfileConfig` (el resolver puro ya está cubierto, falta el
-                                                 hook con sus contextos).
-                                              3. El flujo de subrayado de punta a punta: seleccionar → color → guardar →
-                                                 releer del bookmark.
-                                              4. `useReadingHighlights` y `useTabScroll`, que son hooks con estado.
+                                                  1. **Render tests de las pantallas de tab** (Home, Cantoral, Contigo,
+                                                     Más): que monten sin reventar con datos vacíos, con datos y offline.
+                                                  2. `useResolvedProfileConfig` (el resolver puro ya está cubierto, falta el
+                                                     hook con sus contextos).
+                                                  3. El flujo de subrayado de punta a punta: seleccionar → color → guardar →
+                                                     releer del bookmark.
+                                                  4. `useReadingHighlights` y `useTabScroll`, que son hooks con estado.
 
-                                              Nota: tener muchos tests **no** encarece las features nuevas. Un agente no
-                                              lee la suite entera para tocar código: lee los tests del área que toca. Lo
-                                              que sí ahorra es tiempo de depuración —los fallos salen en segundos en vez
-                                              de en una build de 20 minutos— y evita iteraciones enteras como la del
-                                              tamaño de los iconos. El coste real de una suite grande es de
-                                              MANTENIMIENTO: tests frágiles (snapshots enormes, aserciones sobre
-                                              detalles internos) que hay que reescribir en cada refactor. Por eso la
-                                              lista de arriba pide tests de COMPORTAMIENTO, no snapshots.
+                                                  Nota: tener muchos tests **no** encarece las features nuevas. Un agente no
+                                                  lee la suite entera para tocar código: lee los tests del área que toca. Lo
+                                                  que sí ahorra es tiempo de depuración —los fallos salen en segundos en vez
+                                                  de en una build de 20 minutos— y evita iteraciones enteras como la del
+                                                  tamaño de los iconos. El coste real de una suite grande es de
+                                                  MANTENIMIENTO: tests frágiles (snapshots enormes, aserciones sobre
+                                                  detalles internos) que hay que reescribir en cada refactor. Por eso la
+                                                  lista de arriba pide tests de COMPORTAMIENTO, no snapshots.
 
 - [ ] **Accesibilidad — completar cobertura restante**: ya cubren `accessibilityLabel` Home, Notificaciones, Cantoral (Categories/SongList/Detail/Fullscreen/Selected), Calendario (parcial vía Contigo), Contactos, Visitas, Grupos, Apps, EventHome, Profundiza, varios bottom sheets y modales, y (jun-2026) Fotos (`AlbumListScreen`/`AlbumCard`), Materiales, Comida, MasHome y `EventItem`. Horario es de solo lectura (sin interactivos). Pendiente: validar en dispositivo con VoiceOver/TalkBack y revisar pantallas/flujos secundarios.
 


### PR DESCRIPTION
Dos reflexiones que salieron trabajando en la #334 y que solo estaban en la conversación. Solo documentación.

## 1. ⚠️ El CI no ejecuta nada desde el 2026-04-10

Salió a la luz al arreglar los 4 errores de `typecheck:tests` de la #334: llevaban meses en `main` sin que saltara nadie. El último run de `ci.yml` es del **10 de abril**.

Ningún PR se está verificando de verdad, aunque el workflow siga en el repo y la PR parezca "clean" al mergear. El guardarraíl está desenchufado.

Queda anotado en dos sitios, con el detalle en uno solo:

- **`mcm-app/TODO.md` §0** — prioridad máxima, cómo se descubrió y dónde mirar (Actions deshabilitadas, minutos de la cuenta, ajustes de la organización sobre ramas `claude/*`).
- **`docs/planes/BACKLOG.md`**, puntero rápido — fila nueva "Roto y sin dueño", que apunta al TODO.

Mientras siga roto, los cuatro pasos de `verify.yml` se pasan en local antes de mergear:

```bash
cd mcm-app
npm run typecheck && npm run typecheck:tests && npm run lint && npm test -- --ci
```

## 2. Una regla que se puede romper sin enterarse va en un test, no en un documento

Va a **`mcm-app/CLAUDE.md`**, junto a las convenciones de código, porque es donde se mira antes de escribir (el razonamiento largo ya estaba en `PLAN_CALIDAD.md` §0, que entró en la #334).

El modelo es `__tests__/tabsLayoutWebSafety.test.ts`: no comprueba una función, comprueba que **nadie vuelva a importar** el módulo nativo de tabs en el grafo de web — un fallo que solo se veía al desplegar. La idea: este código lo edita siempre una IA, y una IA puede no leer un párrafo, pero no puede ignorar un test en rojo. Cuando algo se rompa por no saber una regla, el arreglo correcto no es ampliar `CLAUDE.md`, es un test que falle solo.

## Verificación

Los cuatro pasos de `verify.yml`, en local:

- `npm run typecheck` → limpio
- `npm run typecheck:tests` → limpio
- `npm run lint` → 0 errores, 51 warnings
- `npm test -- --ci` → 860 tests, 72 suites, en verde

## OTA

Seguro para OTA: solo documentación, sin cambios de código.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AKuVrR584Dn1SwrjUiRVD)_